### PR TITLE
Directly output a Map; helper methods can be defined externally; output an object.

### DIFF
--- a/lib/src/agent/stateful_agent.dart
+++ b/lib/src/agent/stateful_agent.dart
@@ -1447,7 +1447,15 @@ class StatefulAgent {
         }
 
         final result = runZoned(
-          () => Function.apply(tool.executable!, positionalArgs, namedArgs),
+          () {
+            if (tool.parameterMode == ToolParameterMode.object) {
+              // 对象参数模式
+              // 直接传递 decodedArgs Map
+              return tool.executable!(decodedArgs);
+            }
+            // 函数参数模式：使用 Function.apply 分解位置参数和命名参数
+            return Function.apply(tool.executable!, positionalArgs, namedArgs);
+          },
           zoneValues: {
             AgentCallToolContext.ZoneKey: AgentCallToolContext(
               state: state,

--- a/lib/src/core/tool.dart
+++ b/lib/src/core/tool.dart
@@ -1,3 +1,14 @@
+/// 工具参数模式枚举
+enum ToolParameterMode {
+  /// 对象参数模式
+  /// 直接传递 decodedArgs Map 给 executable
+  object,
+
+  /// 函数参数模式
+  /// 使用 Function.apply 分解位置参数和命名参数
+  function,
+}
+
 /// Defines a tool that can be executed by an agent.
 ///
 /// A tool consists of a name, description, and a JSON Schema for its parameters.
@@ -9,6 +20,7 @@ class Tool {
   final Map<String, dynamic> parameters; // JSON Schema
   final Function? executable;
   final List<String> namedParameters;
+  final ToolParameterMode parameterMode;
 
   Tool({
     required this.name,
@@ -16,6 +28,7 @@ class Tool {
     required this.parameters,
     this.executable,
     this.namedParameters = const [],
+    this.parameterMode = ToolParameterMode.function,
   });
   Map<String, dynamic> toJson() {
     return {
@@ -23,6 +36,7 @@ class Tool {
       'description': description,
       'parameters': parameters,
       'namedParameters': namedParameters,
+      'parameterMode': parameterMode.name,
     };
   }
 }


### PR DESCRIPTION
/// 创建Tool，自动处理参数映射
  ///
  /// [name] 工具名称
  /// [description] 工具描述
  /// [execute] 执行函数，接收DTO参数
  /// [formJson] JSON解析函数，将Map转换为DTO
  ///
  /// 返回Tool实例
  static Tool createTool<T extends AgentToolMixin>({
    required String name,
    required String description,
    required Future<String> Function(T input) execute,
    required T Function(Map<String, dynamic>) formJson,
  }) {
    return Tool(
      name: name,
      description: description,
      parameters: formJson({}).getJsonSchema(),
      parameterMode: ToolParameterMode.object,
      executable: (arguments) async {
        // 将arguments转换为DTO
        final dto = formJson(arguments);
        // 执行业务方法
        return await execute(dto);
      },
    );
  }