### PR TITLE
Feat/dart records to object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.9
+
+- **BREAKING**: Replace `SystemCallback` return type from Dart Record `(SystemMessage?, List<Tool>, List<LLMMessage>)` to `SystemCallbackResult` class for broader SDK compatibility and clearer semantics. Callers using `systemCallback` must update to access `.systemMessage`, `.tools`, `.requestMessages` properties instead of positional destructuring.
+
 ## 1.0.8
 
 - Lower Dart SDK minimum constraint from `^3.10.4` to `^3.9.2` to support Flutter 3.35 and HarmonyOS ecosystem.

--- a/lib/src/agent/stateful_agent.dart
+++ b/lib/src/agent/stateful_agent.dart
@@ -243,15 +243,28 @@ class CallLLMParams {
   });
 }
 
+/// Result of [SystemCallback], containing the potentially modified system message,
+/// tools, and request messages.
+class SystemCallbackResult {
+  final SystemMessage? systemMessage;
+  final List<Tool> tools;
+  final List<LLMMessage> requestMessages;
+
+  SystemCallbackResult({
+    required this.systemMessage,
+    required this.tools,
+    required this.requestMessages,
+  });
+}
+
 /// Callback type for intercepting and modifying system_message, tools, and request_messages
 /// before each LLM call. Receives the StatefulAgent instance as the first argument.
-typedef SystemCallback =
-    Future<(SystemMessage?, List<Tool>, List<LLMMessage>)> Function(
-      StatefulAgent agent,
-      SystemMessage? systemMessage,
-      List<Tool> tools,
-      List<LLMMessage> requestMessages,
-    );
+typedef SystemCallback = Future<SystemCallbackResult> Function(
+  StatefulAgent agent,
+  SystemMessage? systemMessage,
+  List<Tool> tools,
+  List<LLMMessage> requestMessages,
+);
 
 /// A stateful AI agent that orchestrates LLM calls, tool execution,
 /// skill management, and context compression.
@@ -774,19 +787,15 @@ class StatefulAgent {
         // System callback interception point
         if (systemCallback != null) {
           try {
-            final (
-              newSystemMessage,
-              newTools,
-              newRequestMessages,
-            ) = await systemCallback!(
+            final result = await systemCallback!(
               this,
               systemMessage,
               toolsCopy,
               requestMessages,
             );
-            systemMessage = newSystemMessage;
-            toolsCopy = newTools;
-            requestMessages = newRequestMessages;
+            systemMessage = result.systemMessage;
+            toolsCopy = result.tools;
+            requestMessages = result.requestMessages;
           } catch (e) {
             _logger.warning(
               '[$name] system_callback execution error: $e. Using original values.',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_agent_core
 description: A mobile-first, local-first Dart library for building stateful, tool-using AI agents with multi-provider LLM support (OpenAI, Gemini, AWS Bedrock).
-version: 1.0.8
+version: 1.0.9
 repository: https://github.com/memex-lab/dart_agent_core
 homepage: https://github.com/memex-lab/dart_agent_core
 topics:


### PR DESCRIPTION
Records是Dart 3.0引入的特性，SDK小于3.0的版本无法使用Records特性，固将方法返回Records替换成类，使其兼容范围更广，语义更清晰。此次为破坏性改动，需要调用者修改此方法数据返回类型。