### PR TITLE
修复 ClaudeClient 对 Anthropic content blocks 的回传

### DIFF
--- a/lib/src/agent/stateful_agent.dart
+++ b/lib/src/agent/stateful_agent.dart
@@ -885,6 +885,7 @@ class StatefulAgent {
 
         final StringBuffer aggregatedText = StringBuffer();
         final StringBuffer aggregatedThought = StringBuffer();
+        final List<Map<String, dynamic>> aggregatedContentBlocks = [];
         final List<FunctionCall> aggregatedTools = [];
         final List<ModelImagePart> imageOutputs = [];
         final List<ModelVideoPart> videoOutputs = [];
@@ -920,6 +921,9 @@ class StatefulAgent {
               }
               if (chunk.functionCalls.isNotEmpty) {
                 aggregatedTools.addAll(chunk.functionCalls);
+              }
+              if (chunk.contentBlocks.isNotEmpty) {
+                aggregatedContentBlocks.addAll(chunk.contentBlocks);
               }
               if (chunk.imageOutputs.isNotEmpty) {
                 imageOutputs.addAll(chunk.imageOutputs);
@@ -975,6 +979,7 @@ class StatefulAgent {
                 finalUsage = null;
                 finalMetadata = null;
                 aggregatedThought.clear();
+                aggregatedContentBlocks.clear();
                 thoughtSignature = null;
                 controller?.publish(LLMRetryingEvent(this, retryReason));
               }
@@ -1001,6 +1006,9 @@ class StatefulAgent {
           }
           if (fullMessage.functionCalls.isNotEmpty) {
             aggregatedTools.addAll(fullMessage.functionCalls);
+          }
+          if (fullMessage.contentBlocks.isNotEmpty) {
+            aggregatedContentBlocks.addAll(fullMessage.contentBlocks);
           }
           if (fullMessage.imageOutputs.isNotEmpty) {
             imageOutputs.addAll(fullMessage.imageOutputs);
@@ -1091,6 +1099,7 @@ class StatefulAgent {
               ? aggregatedText.toString()
               : null,
           functionCalls: aggregatedTools,
+          contentBlocks: aggregatedContentBlocks,
           imageOutputs: imageOutputs,
           videoOutputs: videoOutputs,
           audioOutputs: audioOutputs,

--- a/lib/src/core/message.dart
+++ b/lib/src/core/message.dart
@@ -379,6 +379,14 @@ class StreamingEvent {
 class ModelMessage extends LLMMessage {
   final String? thought;
   final String? thoughtSignature; // Optional verification signature
+  /// Provider-native assistant content blocks.
+  ///
+  /// Some providers, notably Anthropic Messages, require exact block-level
+  /// round-tripping for content such as `thinking`, `redacted_thinking`, and
+  /// interleaved `tool_use` blocks. The flattened fields below remain the
+  /// provider-neutral view used by agents, while this field preserves the raw
+  /// provider order for clients that need it.
+  final List<Map<String, dynamic>> contentBlocks;
   final List<FunctionCall> functionCalls;
   final String? textOutput;
   final List<ModelImagePart> imageOutputs;
@@ -394,6 +402,7 @@ class ModelMessage extends LLMMessage {
   ModelMessage({
     this.thought,
     this.thoughtSignature,
+    this.contentBlocks = const [],
     this.functionCalls = const [],
     this.textOutput,
     this.imageOutputs = const [],
@@ -412,6 +421,8 @@ class ModelMessage extends LLMMessage {
     'role': 'assistant',
     if (thought != null) 'thought': thought,
     if (thoughtSignature != null) 'thoughtSignature': thoughtSignature,
+    if (contentBlocks.isNotEmpty)
+      'contentBlocks': contentBlocks.map((e) => Map.of(e)).toList(),
     if (textOutput != null) 'textOutput': textOutput,
     if (functionCalls.isNotEmpty)
       'functionCalls': functionCalls.map((e) => e.toJson()).toList(),
@@ -433,6 +444,11 @@ class ModelMessage extends LLMMessage {
     return ModelMessage(
       thought: json['thought'] as String?,
       thoughtSignature: json['thoughtSignature'] as String?,
+      contentBlocks:
+          (json['contentBlocks'] as List?)
+              ?.map((e) => Map<String, dynamic>.from(e as Map))
+              .toList() ??
+          [],
       textOutput: json['textOutput'] as String?,
       functionCalls:
           (json['functionCalls'] as List?)

--- a/lib/src/llm/claude_client.dart
+++ b/lib/src/llm/claude_client.dart
@@ -222,19 +222,26 @@ class ClaudeClient extends LLMClient {
     _ClaudeStreamParser parser,
     StreamController<StreamingMessage> controller,
   ) {
-    final buffer = StringBuffer();
+    String? eventType;
 
     stream
         .transform(utf8.decoder)
         .transform(const LineSplitter())
         .listen(
           (line) {
-            if (line.startsWith('data: ')) {
+            if (line.isEmpty) {
+              eventType = null;
+            } else if (line.startsWith('data: ')) {
               final data = line.substring(6);
               if (data == '[DONE]') return;
 
               try {
                 final json = jsonDecode(data) as Map<String, dynamic>;
+                if (eventType == 'error' || json['type'] == 'error') {
+                  controller.addError(_createStreamError(json));
+                  return;
+                }
+
                 final message = parser.parse(json);
                 if (message != null) {
                   controller.add(StreamingMessage(modelMessage: message));
@@ -243,14 +250,11 @@ class ClaudeClient extends LLMClient {
                 _logger.warning('Error parsing SSE chunk: $e, data: $data');
               }
             } else if (line.startsWith('event: ')) {
-              // Event type hint — parser handles type from the data payload
+              eventType = line.substring(7);
             } else if (line.startsWith('error: ')) {
-              buffer.clear();
               try {
                 final errorData = jsonDecode(line.substring(7));
-                controller.addError(
-                  Exception('Claude Stream Error: ${errorData['message']}'),
-                );
+                controller.addError(_createStreamError(errorData));
               } catch (_) {
                 controller.addError(Exception('Claude Stream Error: $line'));
               }
@@ -264,6 +268,17 @@ class ClaudeClient extends LLMClient {
             controller.close();
           },
         );
+  }
+
+  Exception _createStreamError(Map<String, dynamic> payload) {
+    final error = payload['error'];
+    if (error is Map && error['message'] != null) {
+      return Exception('Claude Stream Error: ${error['message']}');
+    }
+    if (payload['message'] != null) {
+      return Exception('Claude Stream Error: ${payload['message']}');
+    }
+    return Exception('Claude Stream Error: $payload');
   }
 
   Map<String, dynamic> _createRequestBody(
@@ -313,65 +328,16 @@ class ClaudeClient extends LLMClient {
                 'content': content.isNotEmpty ? content : '',
               };
             } else if (m is ModelMessage) {
-              final content = <Map<String, dynamic>>[];
-
-              if (m.thought != null &&
-                  m.thought!.isNotEmpty &&
-                  m.thoughtSignature != null) {
-                content.add({
-                  'type': 'thinking',
-                  'thinking': m.thought,
-                  'signature': m.thoughtSignature,
-                });
-              }
-
-              if (m.textOutput != null) {
-                content.add({'type': 'text', 'text': m.textOutput});
-              }
-              if (m.functionCalls.isNotEmpty) {
-                final validCalls = <FunctionCall>[];
-                for (final call in m.functionCalls) {
-                  if (call.id.isNotEmpty) {
-                    validCalls.add(call);
-                  } else if (validCalls.isNotEmpty) {
-                    final previous = validCalls.last;
-                    validCalls[validCalls.length - 1] = FunctionCall(
-                      id: previous.id,
-                      name: previous.name,
-                      arguments: previous.arguments + call.arguments,
-                    );
-                  }
-                }
-
-                for (final call in validCalls) {
-                  dynamic input;
-                  if (call.arguments.isEmpty) {
-                    input = {};
-                  } else {
-                    try {
-                      input = jsonDecode(call.arguments);
-                    } catch (e) {
-                      _logger.warning(
-                        'Error decoding tool input: ${call.arguments} - $e',
-                      );
-                      input = {};
-                    }
-                  }
-                  content.add({
-                    'type': 'tool_use',
-                    'id': call.id,
-                    'name': call.name,
-                    'input': input,
-                  });
-                }
-              }
+              final content = m.contentBlocks.isNotEmpty
+                  ? _copyContentBlocks(m.contentBlocks)
+                  : _buildAssistantContent(m);
               return {
                 'role': 'assistant',
                 'content': content.isNotEmpty ? content : '',
               };
             } else if (m is FunctionExecutionResultMessage) {
               final content = m.results.map((r) {
-                return {
+                final result = {
                   'type': 'tool_result',
                   'tool_use_id': r.id,
                   'content': r.content
@@ -394,6 +360,10 @@ class ClaudeClient extends LLMClient {
                       .where((e) => e != null)
                       .toList(),
                 };
+                if (r.isError) {
+                  result['is_error'] = true;
+                }
+                return result;
               }).toList();
 
               return {'role': 'user', 'content': content};
@@ -464,6 +434,84 @@ class ClaudeClient extends LLMClient {
     return body;
   }
 
+  List<Map<String, dynamic>> _buildAssistantContent(ModelMessage message) {
+    final content = <Map<String, dynamic>>[];
+
+    if (message.thought != null &&
+        message.thought!.isNotEmpty &&
+        message.thoughtSignature != null) {
+      content.add({
+        'type': 'thinking',
+        'thinking': message.thought,
+        'signature': message.thoughtSignature,
+      });
+    }
+
+    if (message.textOutput != null) {
+      content.add({'type': 'text', 'text': message.textOutput});
+    }
+    if (message.functionCalls.isNotEmpty) {
+      final validCalls = <FunctionCall>[];
+      for (final call in message.functionCalls) {
+        if (call.id.isNotEmpty) {
+          validCalls.add(call);
+        } else if (validCalls.isNotEmpty) {
+          final previous = validCalls.last;
+          validCalls[validCalls.length - 1] = FunctionCall(
+            id: previous.id,
+            name: previous.name,
+            arguments: previous.arguments + call.arguments,
+          );
+        }
+      }
+
+      for (final call in validCalls) {
+        content.add({
+          'type': 'tool_use',
+          'id': call.id,
+          'name': call.name,
+          'input': _decodeToolInput(call.arguments),
+        });
+      }
+    }
+
+    return content;
+  }
+
+  dynamic _decodeToolInput(String arguments) {
+    if (arguments.isEmpty) {
+      return {};
+    }
+    try {
+      return jsonDecode(arguments);
+    } catch (e) {
+      _logger.warning('Error decoding tool input: $arguments - $e');
+      return {};
+    }
+  }
+
+  List<Map<String, dynamic>> _copyContentBlocks(
+    List<Map<String, dynamic>> blocks,
+  ) {
+    return blocks.map((block) => _deepCopyMap(block)).toList();
+  }
+
+  Map<String, dynamic> _deepCopyMap(Map<String, dynamic> map) {
+    return map.map((key, value) => MapEntry(key, _deepCopyValue(value)));
+  }
+
+  dynamic _deepCopyValue(dynamic value) {
+    if (value is Map) {
+      return value.map(
+        (key, child) => MapEntry(key.toString(), _deepCopyValue(child)),
+      );
+    }
+    if (value is List) {
+      return value.map(_deepCopyValue).toList();
+    }
+    return value;
+  }
+
   ModelMessage _parseResponse(
     Map<String, dynamic> data,
     ModelConfig modelConfig,
@@ -475,11 +523,15 @@ class ClaudeClient extends LLMClient {
     final content = data['content'] as List?;
     String text = '';
     final functionCalls = <FunctionCall>[];
+    final contentBlocks = <Map<String, dynamic>>[];
     String? thought;
     String? thoughtSignature;
 
     if (content != null) {
       for (final part in content) {
+        if (part is Map) {
+          contentBlocks.add(Map<String, dynamic>.from(part));
+        }
         if (part['type'] == 'text') {
           text += part['text'] ?? '';
         } else if (part['type'] == 'tool_use') {
@@ -505,6 +557,7 @@ class ClaudeClient extends LLMClient {
 
     return ModelMessage(
       textOutput: text,
+      contentBlocks: contentBlocks,
       functionCalls: functionCalls,
       model: modelConfig.model,
       stopReason: data['stop_reason'],
@@ -529,9 +582,14 @@ class ClaudeClient extends LLMClient {
 
 class _ClaudeStreamParser {
   final ModelConfig modelConfig;
+  String? _currentBlockType;
+  Map<String, dynamic>? _currentRawBlock;
   String? _currentToolId;
   String? _currentToolName;
   final StringBuffer _currentToolJson = StringBuffer();
+  final StringBuffer _currentText = StringBuffer();
+  final StringBuffer _currentThinking = StringBuffer();
+  String? _currentThinkingSignature;
 
   int _promptTokens = 0;
   int _completionTokens = 0;
@@ -545,6 +603,11 @@ class _ClaudeStreamParser {
 
     if (type == 'content_block_start') {
       final start = chunk['content_block'];
+      _currentBlockType = start['type'] as String?;
+      _currentRawBlock = Map<String, dynamic>.from(start as Map);
+      _currentText.clear();
+      _currentThinking.clear();
+      _currentThinkingSignature = null;
       if (start['type'] == 'tool_use') {
         _currentToolId = start['id'];
         _currentToolName = start['name'];
@@ -559,18 +622,21 @@ class _ClaudeStreamParser {
     } else if (type == 'content_block_delta') {
       final delta = chunk['delta'];
       if (delta['type'] == 'text_delta') {
+        _currentText.write(delta['text'] ?? '');
         return ModelMessage(
           textOutput: delta['text'],
           model: modelConfig.model,
           usage: _currentUsage(),
         );
       } else if (delta['type'] == 'thinking_delta') {
+        _currentThinking.write(delta['thinking'] ?? '');
         return ModelMessage(
           thought: delta['thinking'],
           model: modelConfig.model,
           usage: _currentUsage(),
         );
       } else if (delta['type'] == 'signature_delta') {
+        _currentThinkingSignature = delta['signature'];
         return ModelMessage(
           thoughtSignature: delta['signature'],
           model: modelConfig.model,
@@ -580,21 +646,7 @@ class _ClaudeStreamParser {
         _currentToolJson.write(delta['partial_json']);
       }
     } else if (type == 'content_block_stop') {
-      if (_currentToolId != null) {
-        final toolCall = FunctionCall(
-          id: _currentToolId!,
-          name: _currentToolName!,
-          arguments: _currentToolJson.toString(),
-        );
-        _currentToolId = null;
-        _currentToolName = null;
-        _currentToolJson.clear();
-        return ModelMessage(
-          functionCalls: [toolCall],
-          model: modelConfig.model,
-          usage: _currentUsage(),
-        );
-      }
+      return _finishCurrentBlock();
     } else if (type == 'message_start') {
       final message = chunk['message'];
       if (message != null && message['usage'] != null) {
@@ -641,5 +693,62 @@ class _ClaudeStreamParser {
       thoughtToken: _thoughtTokens,
       model: modelConfig.model,
     );
+  }
+
+  ModelMessage? _finishCurrentBlock() {
+    final blockType = _currentBlockType;
+    if (blockType == null) {
+      return null;
+    }
+
+    final block = Map<String, dynamic>.from(_currentRawBlock ?? {});
+    FunctionCall? toolCall;
+
+    if (blockType == 'text') {
+      block['text'] = _currentText.toString();
+    } else if (blockType == 'thinking') {
+      block['thinking'] = _currentThinking.toString();
+      if (_currentThinkingSignature != null) {
+        block['signature'] = _currentThinkingSignature;
+      }
+    } else if (blockType == 'tool_use') {
+      final arguments = _currentToolJson.toString();
+      toolCall = FunctionCall(
+        id: _currentToolId!,
+        name: _currentToolName!,
+        arguments: arguments,
+      );
+      block['input'] = _parseToolInput(arguments);
+    }
+
+    _clearCurrentBlock();
+    return ModelMessage(
+      contentBlocks: [block],
+      functionCalls: toolCall == null ? const [] : [toolCall],
+      model: modelConfig.model,
+      usage: _currentUsage(),
+    );
+  }
+
+  void _clearCurrentBlock() {
+    _currentBlockType = null;
+    _currentRawBlock = null;
+    _currentToolId = null;
+    _currentToolName = null;
+    _currentToolJson.clear();
+    _currentText.clear();
+    _currentThinking.clear();
+    _currentThinkingSignature = null;
+  }
+
+  dynamic _parseToolInput(String input) {
+    if (input.isEmpty) {
+      return {};
+    }
+    try {
+      return jsonDecode(input);
+    } catch (_) {
+      return {};
+    }
   }
 }

--- a/test/claude_client_test.dart
+++ b/test/claude_client_test.dart
@@ -1,0 +1,259 @@
+import 'dart:convert';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ClaudeClient', () {
+    test('保留并原样回传 Anthropic assistant content blocks', () async {
+      final assistantContent = [
+        {'type': 'thinking', 'thinking': '先分析需要读取文件', 'signature': 'sig-1'},
+        {
+          'type': 'tool_use',
+          'id': 'toolu_1',
+          'name': 'Read',
+          'input': {'path': 'a.md'},
+        },
+        {'type': 'redacted_thinking', 'data': 'opaque-redacted-data'},
+        {'type': 'thinking', 'thinking': '兼容服务可能没有 signature'},
+        {
+          'type': 'tool_use',
+          'id': 'toolu_2',
+          'name': 'Write',
+          'input': {'path': 'b.md'},
+        },
+      ];
+      final adapter = _CaptureAdapter([
+        (_) => _jsonResponse({
+          'content': assistantContent,
+          'stop_reason': 'tool_use',
+          'usage': {'input_tokens': 10, 'output_tokens': 20},
+        }),
+        (_) => _jsonResponse({
+          'content': [
+            {'type': 'text', 'text': 'ok'},
+          ],
+          'stop_reason': 'end_turn',
+          'usage': {'input_tokens': 1, 'output_tokens': 1},
+        }),
+      ]);
+      final client = ClaudeClient(
+        apiKey: 'test-key',
+        client: Dio()..httpClientAdapter = adapter,
+      );
+
+      final modelMessage = await client.generate([
+        UserMessage.text('开始'),
+      ], modelConfig: ModelConfig(model: 'claude-test'));
+      await client.generate([
+        UserMessage.text('开始'),
+        modelMessage,
+        FunctionExecutionResultMessage(
+          results: [
+            FunctionExecutionResult(
+              id: 'toolu_1',
+              name: 'Read',
+              isError: false,
+              arguments: '{}',
+              content: [TextPart('file content')],
+            ),
+          ],
+        ),
+      ], modelConfig: ModelConfig(model: 'claude-test'));
+
+      expect(modelMessage.contentBlocks, equals(assistantContent));
+      final secondRequest =
+          jsonDecode(adapter.requests[1] as String) as Map<String, dynamic>;
+      final assistantMessage =
+          secondRequest['messages'][1] as Map<String, dynamic>;
+      expect(assistantMessage['content'], equals(assistantContent));
+    });
+
+    test('tool_result 会带上 Anthropic 官方 is_error 字段', () async {
+      final adapter = _CaptureAdapter([
+        (_) => _jsonResponse({
+          'content': [
+            {'type': 'text', 'text': 'ok'},
+          ],
+          'stop_reason': 'end_turn',
+          'usage': {'input_tokens': 1, 'output_tokens': 1},
+        }),
+      ]);
+      final client = ClaudeClient(
+        apiKey: 'test-key',
+        client: Dio()..httpClientAdapter = adapter,
+      );
+
+      await client.generate([
+        FunctionExecutionResultMessage(
+          results: [
+            FunctionExecutionResult(
+              id: 'toolu_error',
+              name: 'Read',
+              isError: true,
+              arguments: '{}',
+              content: [TextPart('权限不足')],
+            ),
+          ],
+        ),
+      ], modelConfig: ModelConfig(model: 'claude-test'));
+
+      final request =
+          jsonDecode(adapter.requests.single as String) as Map<String, dynamic>;
+      final toolResult =
+          (request['messages'][0] as Map<String, dynamic>)['content'][0]
+              as Map<String, dynamic>;
+      expect(toolResult['is_error'], isTrue);
+    });
+
+    test('stream 会产出完整有序 content blocks', () async {
+      final adapter = _CaptureAdapter([
+        (_) => _streamResponse([
+          {
+            'type': 'message_start',
+            'message': {
+              'usage': {'input_tokens': 1, 'output_tokens': 0},
+            },
+          },
+          {
+            'type': 'content_block_start',
+            'index': 0,
+            'content_block': {'type': 'thinking', 'thinking': ''},
+          },
+          {
+            'type': 'content_block_delta',
+            'index': 0,
+            'delta': {'type': 'thinking_delta', 'thinking': '先想'},
+          },
+          {
+            'type': 'content_block_delta',
+            'index': 0,
+            'delta': {'type': 'signature_delta', 'signature': 'sig'},
+          },
+          {'type': 'content_block_stop', 'index': 0},
+          {
+            'type': 'content_block_start',
+            'index': 1,
+            'content_block': {
+              'type': 'tool_use',
+              'id': 'toolu_1',
+              'name': 'Read',
+              'input': {},
+            },
+          },
+          {
+            'type': 'content_block_delta',
+            'index': 1,
+            'delta': {'type': 'input_json_delta', 'partial_json': '{"path"'},
+          },
+          {
+            'type': 'content_block_delta',
+            'index': 1,
+            'delta': {'type': 'input_json_delta', 'partial_json': ':"a.md"}'},
+          },
+          {'type': 'content_block_stop', 'index': 1},
+          {
+            'type': 'message_delta',
+            'delta': {'stop_reason': 'tool_use'},
+            'usage': {'output_tokens': 8},
+          },
+          {'type': 'message_stop'},
+        ]),
+      ]);
+      final client = ClaudeClient(
+        apiKey: 'test-key',
+        client: Dio()..httpClientAdapter = adapter,
+      );
+
+      final stream = await client.stream([
+        UserMessage.text('开始'),
+      ], modelConfig: ModelConfig(model: 'claude-test'));
+      final chunks = await stream.map((e) => e.modelMessage).toList();
+      final blocks = chunks
+          .whereType<ModelMessage>()
+          .expand((message) => message.contentBlocks)
+          .toList();
+
+      expect(blocks, [
+        {'type': 'thinking', 'thinking': '先想', 'signature': 'sig'},
+        {
+          'type': 'tool_use',
+          'id': 'toolu_1',
+          'name': 'Read',
+          'input': {'path': 'a.md'},
+        },
+      ]);
+    });
+
+    test('stream 会把 Anthropic SSE error event 转成异常', () async {
+      final adapter = _CaptureAdapter([
+        (_) => _rawStreamResponse(
+          'event: error\n'
+          'data: {"type":"error","error":{"type":"overloaded_error","message":"过载"}}\n\n',
+        ),
+      ]);
+      final client = ClaudeClient(
+        apiKey: 'test-key',
+        client: Dio()..httpClientAdapter = adapter,
+      );
+
+      final stream = await client.stream([
+        UserMessage.text('开始'),
+      ], modelConfig: ModelConfig(model: 'claude-test'));
+
+      await expectLater(
+        stream,
+        emitsError(predicate((error) => error.toString().contains('过载'))),
+      );
+    });
+  });
+}
+
+class _CaptureAdapter implements HttpClientAdapter {
+  final List<ResponseBody Function(RequestOptions)> responses;
+  final List<Object?> requests = [];
+
+  _CaptureAdapter(this.responses);
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add(options.data);
+    return responses.removeAt(0)(options);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+ResponseBody _jsonResponse(Map<String, dynamic> body) {
+  return ResponseBody.fromString(
+    jsonEncode(body),
+    200,
+    headers: {
+      Headers.contentTypeHeader: [Headers.jsonContentType],
+    },
+  );
+}
+
+ResponseBody _streamResponse(List<Map<String, dynamic>> events) {
+  final data = events.map((event) {
+    return 'event: ${event['type']}\n'
+        'data: ${jsonEncode(event)}\n\n';
+  }).join();
+  return _rawStreamResponse(data);
+}
+
+ResponseBody _rawStreamResponse(String data) {
+  return ResponseBody.fromString(
+    data,
+    200,
+    headers: {
+      Headers.contentTypeHeader: ['text/event-stream'],
+    },
+  );
+}


### PR DESCRIPTION
## 背景

Fixes #9。

Memex 的 KnowledgeInsightAgent 在使用 MIMO 这类 Anthropic-compatible provider 时，遇到 thinking mode + tool use 的历史恢复失败：服务端要求上一轮的 reasoning/thinking 内容必须在下一轮请求中被带回。

根因是 `ClaudeClient` 把 Anthropic Messages API 的 assistant `content` blocks 压扁成 `thought`、`thoughtSignature`、`textOutput` 和 `functionCalls`。这样会丢失 `redacted_thinking`，也会改变 interleaved `thinking`/`tool_use` 的 block 顺序；当 provider 没有返回官方 `signature` 但仍要求回传 thinking 时，请求会失败。

## 改动

- 在 `ModelMessage` 增加 `contentBlocks`，用于持久化 provider-native assistant content blocks。
- `ClaudeClient` 解析响应时保存原始 content blocks，构造请求时优先原样回传这些 blocks。
- streaming parser 在 content block 完成时产出完整 block，让 `StatefulAgent` 可以聚合并保存 block 顺序。
- `StatefulAgent` 聚合并写入 streaming/non-streaming 返回的 `contentBlocks`。
- `tool_result` 会把 `FunctionExecutionResult.isError` 映射为 Anthropic 官方 `is_error`。
- 正确处理 Anthropic SSE 的 `event: error`。
- 新增 ClaudeClient 单测覆盖上述行为。

## 兼容性

旧字段仍保留：`thought`、`thoughtSignature`、`textOutput`、`functionCalls` 继续作为 provider-neutral 视图使用。只有当 `ModelMessage.contentBlocks` 非空时，`ClaudeClient` 才优先使用原始 blocks 回传历史。

## 验证

```bash
dart test
dart analyze
```

两项均通过。