### PR TITLE
fix: BedrockClaudeClient content block round-trip

### DIFF
--- a/lib/src/llm/bedrock_claude_client.dart
+++ b/lib/src/llm/bedrock_claude_client.dart
@@ -346,62 +346,9 @@ class BedrockClaudeClient extends LLMClient {
                 'content': content.isNotEmpty ? content : '',
               };
             } else if (m is ModelMessage) {
-              final content = <Map<String, dynamic>>[];
-
-              // Add thinking block first if present
-              if (m.thought != null &&
-                  m.thought!.isNotEmpty &&
-                  m.thoughtSignature != null) {
-                content.add({
-                  'type': 'thinking',
-                  'thinking': m.thought,
-                  'signature': m.thoughtSignature,
-                });
-              }
-
-              if (m.textOutput != null) {
-                content.add({'type': 'text', 'text': m.textOutput});
-              }
-              if (m.functionCalls.isNotEmpty) {
-                // Sanitize function calls to handle fragmented history from previous bug
-                // where partial streams were saved as separate calls with empty IDs.
-                final validCalls = <FunctionCall>[];
-                for (final call in m.functionCalls) {
-                  if (call.id.isNotEmpty) {
-                    validCalls.add(call);
-                  } else if (validCalls.isNotEmpty) {
-                    // unexpected empty ID, merge args to previous call
-                    final previous = validCalls.last;
-                    validCalls[validCalls.length - 1] = FunctionCall(
-                      id: previous.id,
-                      name: previous.name,
-                      arguments: previous.arguments + call.arguments,
-                    );
-                  }
-                }
-
-                for (final call in validCalls) {
-                  dynamic input;
-                  if (call.arguments.isEmpty) {
-                    input = {};
-                  } else {
-                    try {
-                      input = jsonDecode(call.arguments);
-                    } catch (e) {
-                      _logger.warning(
-                        'Error decoding tool input: ${call.arguments} - $e',
-                      );
-                      input = {};
-                    }
-                  }
-                  content.add({
-                    'type': 'tool_use',
-                    'id': call.id,
-                    'name': call.name,
-                    'input': input,
-                  });
-                }
-              }
+              final content = m.contentBlocks.isNotEmpty
+                  ? _copyContentBlocks(m.contentBlocks)
+                  : _buildAssistantContent(m);
               return {
                 'role': 'assistant',
                 'content': content.isNotEmpty ? content : '',
@@ -409,7 +356,7 @@ class BedrockClaudeClient extends LLMClient {
             } else if (m is FunctionExecutionResultMessage) {
               final content = m.results.map((r) {
                 // Bedrock/Claude expects tool_result
-                return {
+                final result = {
                   'type': 'tool_result',
                   'tool_use_id': r.id,
                   'content': r.content
@@ -432,6 +379,10 @@ class BedrockClaudeClient extends LLMClient {
                       .where((e) => e != null)
                       .toList(),
                 };
+                if (r.isError) {
+                  result['is_error'] = true;
+                }
+                return result;
               }).toList();
 
               return {'role': 'user', 'content': content};
@@ -504,6 +455,84 @@ class BedrockClaudeClient extends LLMClient {
     return body;
   }
 
+  List<Map<String, dynamic>> _buildAssistantContent(ModelMessage message) {
+    final content = <Map<String, dynamic>>[];
+
+    if (message.thought != null &&
+        message.thought!.isNotEmpty &&
+        message.thoughtSignature != null) {
+      content.add({
+        'type': 'thinking',
+        'thinking': message.thought,
+        'signature': message.thoughtSignature,
+      });
+    }
+
+    if (message.textOutput != null) {
+      content.add({'type': 'text', 'text': message.textOutput});
+    }
+    if (message.functionCalls.isNotEmpty) {
+      final validCalls = <FunctionCall>[];
+      for (final call in message.functionCalls) {
+        if (call.id.isNotEmpty) {
+          validCalls.add(call);
+        } else if (validCalls.isNotEmpty) {
+          final previous = validCalls.last;
+          validCalls[validCalls.length - 1] = FunctionCall(
+            id: previous.id,
+            name: previous.name,
+            arguments: previous.arguments + call.arguments,
+          );
+        }
+      }
+
+      for (final call in validCalls) {
+        content.add({
+          'type': 'tool_use',
+          'id': call.id,
+          'name': call.name,
+          'input': _decodeToolInput(call.arguments),
+        });
+      }
+    }
+
+    return content;
+  }
+
+  dynamic _decodeToolInput(String arguments) {
+    if (arguments.isEmpty) {
+      return {};
+    }
+    try {
+      return jsonDecode(arguments);
+    } catch (e) {
+      _logger.warning('Error decoding tool input: $arguments - $e');
+      return {};
+    }
+  }
+
+  List<Map<String, dynamic>> _copyContentBlocks(
+    List<Map<String, dynamic>> blocks,
+  ) {
+    return blocks.map((block) => _deepCopyMap(block)).toList();
+  }
+
+  Map<String, dynamic> _deepCopyMap(Map<String, dynamic> map) {
+    return map.map((key, value) => MapEntry(key, _deepCopyValue(value)));
+  }
+
+  dynamic _deepCopyValue(dynamic value) {
+    if (value is Map) {
+      return value.map(
+        (key, child) => MapEntry(key.toString(), _deepCopyValue(child)),
+      );
+    }
+    if (value is List) {
+      return value.map(_deepCopyValue).toList();
+    }
+    return value;
+  }
+
   ModelMessage _parseResponse(
     Map<String, dynamic> data,
     ModelConfig modelConfig,
@@ -515,11 +544,15 @@ class BedrockClaudeClient extends LLMClient {
     final content = data['content'] as List?;
     String text = '';
     final functionCalls = <FunctionCall>[];
+    final contentBlocks = <Map<String, dynamic>>[];
     String? thought;
     String? thoughtSignature;
 
     if (content != null) {
       for (final part in content) {
+        if (part is Map) {
+          contentBlocks.add(Map<String, dynamic>.from(part));
+        }
         if (part['type'] == 'text') {
           text += part['text'] ?? '';
         } else if (part['type'] == 'tool_use') {
@@ -545,6 +578,7 @@ class BedrockClaudeClient extends LLMClient {
 
     return ModelMessage(
       textOutput: text,
+      contentBlocks: contentBlocks,
       functionCalls: functionCalls,
       model: modelConfig.model,
       stopReason: data['stop_reason'],
@@ -572,9 +606,14 @@ class BedrockClaudeClient extends LLMClient {
 
 class _BedrockStreamParser {
   final ModelConfig modelConfig;
+  String? _currentBlockType;
+  Map<String, dynamic>? _currentRawBlock;
   String? _currentToolId;
   String? _currentToolName;
   final StringBuffer _currentToolJson = StringBuffer();
+  final StringBuffer _currentText = StringBuffer();
+  final StringBuffer _currentThinking = StringBuffer();
+  String? _currentThinkingSignature;
 
   // Accumulate usage across the stream
   int _promptTokens = 0;
@@ -589,16 +628,18 @@ class _BedrockStreamParser {
 
     if (type == 'content_block_start') {
       final start = chunk['content_block'];
-      // Handle tool_use start by resetting state
+      _currentBlockType = start['type'] as String?;
+      _currentRawBlock = Map<String, dynamic>.from(start as Map);
+      _currentText.clear();
+      _currentThinking.clear();
+      _currentThinkingSignature = null;
       if (start['type'] == 'tool_use') {
         _currentToolId = start['id'];
         _currentToolName = start['name'];
         _currentToolJson.clear();
-        // Don't yield start event, wait for end to ensure complete call
       } else if (start['type'] == 'thinking') {
-        // Start of thinking block
         return ModelMessage(
-          thought: '', // Initialize thought
+          thought: '',
           model: modelConfig.model,
           usage: _currentUsage(),
         );
@@ -606,18 +647,21 @@ class _BedrockStreamParser {
     } else if (type == 'content_block_delta') {
       final delta = chunk['delta'];
       if (delta['type'] == 'text_delta') {
+        _currentText.write(delta['text'] ?? '');
         return ModelMessage(
           textOutput: delta['text'],
           model: modelConfig.model,
           usage: _currentUsage(),
         );
       } else if (delta['type'] == 'thinking_delta') {
+        _currentThinking.write(delta['thinking'] ?? '');
         return ModelMessage(
           thought: delta['thinking'],
           model: modelConfig.model,
           usage: _currentUsage(),
         );
       } else if (delta['type'] == 'signature_delta') {
+        _currentThinkingSignature = delta['signature'];
         return ModelMessage(
           thoughtSignature: delta['signature'],
           model: modelConfig.model,
@@ -625,25 +669,9 @@ class _BedrockStreamParser {
         );
       } else if (delta['type'] == 'input_json_delta') {
         _currentToolJson.write(delta['partial_json']);
-        // Don't yield partial arguments
       }
     } else if (type == 'content_block_stop') {
-      // If we are aggregating a tool, finalize it here
-      if (_currentToolId != null) {
-        final toolCall = FunctionCall(
-          id: _currentToolId!,
-          name: _currentToolName!,
-          arguments: _currentToolJson.toString(),
-        );
-        _currentToolId = null;
-        _currentToolName = null;
-        _currentToolJson.clear();
-        return ModelMessage(
-          functionCalls: [toolCall],
-          model: modelConfig.model,
-          usage: _currentUsage(),
-        );
-      }
+      return _finishCurrentBlock();
     } else if (type == 'message_start') {
       final message = chunk['message'];
       if (message['usage'] != null) {
@@ -652,8 +680,6 @@ class _BedrockStreamParser {
         _cachedTokens =
             (usage['cache_read_input_tokens'] ?? 0) +
             (usage['cache_creation_input_tokens'] ?? 0);
-
-        // Even though completion tokens are 0 here, we verify
         _completionTokens += (usage['output_tokens'] as int? ?? 0);
         return ModelMessage(usage: _currentUsage(), model: modelConfig.model);
       }
@@ -667,13 +693,7 @@ class _BedrockStreamParser {
 
       if (chunk['usage'] != null) {
         final u = chunk['usage'];
-        final newOutputTokens = (u['output_tokens'] as int? ?? 0);
-        _completionTokens =
-            newOutputTokens; // Usually this is the total output tokens so far or final
-
-        // Bedrock/Anthropic might output reasoning_tokens inside output_tokens_details or similar
-        // Check for 'output_tokens_details' -> 'reasoning_tokens'
-        // If it's a delta, we might need to be careful, but message_delta usually has the final usage for the message
+        _completionTokens = (u['output_tokens'] as int? ?? 0);
         _thoughtTokens = u['output_tokens_details']?['reasoning_tokens'] ?? 0;
       }
 
@@ -687,6 +707,63 @@ class _BedrockStreamParser {
     }
 
     return null;
+  }
+
+  ModelMessage? _finishCurrentBlock() {
+    final blockType = _currentBlockType;
+    if (blockType == null) {
+      return null;
+    }
+
+    final block = Map<String, dynamic>.from(_currentRawBlock ?? {});
+    FunctionCall? toolCall;
+
+    if (blockType == 'text') {
+      block['text'] = _currentText.toString();
+    } else if (blockType == 'thinking') {
+      block['thinking'] = _currentThinking.toString();
+      if (_currentThinkingSignature != null) {
+        block['signature'] = _currentThinkingSignature;
+      }
+    } else if (blockType == 'tool_use') {
+      final arguments = _currentToolJson.toString();
+      toolCall = FunctionCall(
+        id: _currentToolId!,
+        name: _currentToolName!,
+        arguments: arguments,
+      );
+      block['input'] = _parseToolInput(arguments);
+    }
+
+    _clearCurrentBlock();
+    return ModelMessage(
+      contentBlocks: [block],
+      functionCalls: toolCall == null ? const [] : [toolCall],
+      model: modelConfig.model,
+      usage: _currentUsage(),
+    );
+  }
+
+  void _clearCurrentBlock() {
+    _currentBlockType = null;
+    _currentRawBlock = null;
+    _currentToolId = null;
+    _currentToolName = null;
+    _currentToolJson.clear();
+    _currentText.clear();
+    _currentThinking.clear();
+    _currentThinkingSignature = null;
+  }
+
+  dynamic _parseToolInput(String input) {
+    if (input.isEmpty) {
+      return {};
+    }
+    try {
+      return jsonDecode(input);
+    } catch (_) {
+      return {};
+    }
   }
 
   ModelUsage _currentUsage() {


### PR DESCRIPTION
Port the same fixes from PR #10 (ClaudeClient) to BedrockClaudeClient:

- Preserve raw contentBlocks for multi-turn round-trip
- Support is_error field in tool_result
- Stream parser emits contentBlocks on block stop