### PR TITLE
[codex] Fix legacy Claude thinking round-trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Fix legacy `ModelMessage.thought` round-tripping in Claude and Bedrock Claude
   fallback request construction when provider-native `contentBlocks` are absent.
+- Preserve explicit empty `reasoning_content` for OpenAI-compatible thinking
+  models and add a DeepSeek V4 legacy tool-call fallback.
+- Align Gemini function-call replay with the SDK shape by using the function
+  name in `functionResponse.name` and preserving optional function call IDs.
 
 ## 1.0.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Fix legacy `ModelMessage.thought` round-tripping in Claude and Bedrock Claude
+  fallback request construction when provider-native `contentBlocks` are absent.
+
 ## 1.0.9
 
 - **BREAKING**: Replace `SystemCallback` return type from Dart Record `(SystemMessage?, List<Tool>, List<LLMMessage>)` to `SystemCallbackResult` class for broader SDK compatibility and clearer semantics. Callers using `systemCallback` must update to access `.systemMessage`, `.tools`, `.requestMessages` properties instead of positional destructuring.

--- a/lib/src/llm/bedrock_claude_client.dart
+++ b/lib/src/llm/bedrock_claude_client.dart
@@ -458,13 +458,12 @@ class BedrockClaudeClient extends LLMClient {
   List<Map<String, dynamic>> _buildAssistantContent(ModelMessage message) {
     final content = <Map<String, dynamic>>[];
 
-    if (message.thought != null &&
-        message.thought!.isNotEmpty &&
-        message.thoughtSignature != null) {
+    if (message.thought != null && message.thought!.isNotEmpty) {
       content.add({
         'type': 'thinking',
         'thinking': message.thought,
-        'signature': message.thoughtSignature,
+        if (message.thoughtSignature != null)
+          'signature': message.thoughtSignature,
       });
     }
 

--- a/lib/src/llm/claude_client.dart
+++ b/lib/src/llm/claude_client.dart
@@ -437,13 +437,12 @@ class ClaudeClient extends LLMClient {
   List<Map<String, dynamic>> _buildAssistantContent(ModelMessage message) {
     final content = <Map<String, dynamic>>[];
 
-    if (message.thought != null &&
-        message.thought!.isNotEmpty &&
-        message.thoughtSignature != null) {
+    if (message.thought != null && message.thought!.isNotEmpty) {
       content.add({
         'type': 'thinking',
         'thinking': message.thought,
-        'signature': message.thoughtSignature,
+        if (message.thoughtSignature != null)
+          'signature': message.thoughtSignature,
       });
     }
 

--- a/lib/src/llm/gemini_client.dart
+++ b/lib/src/llm/gemini_client.dart
@@ -450,7 +450,8 @@ Map<String, dynamic> _createRequestBody(
 
         parts.add({
           'functionResponse': {
-            'name': res.id,
+            'name': res.name,
+            if (res.id != res.name) 'id': res.id,
             'response': {'content': textContent},
             if (partsList.isNotEmpty) 'parts': partsList,
           },
@@ -562,7 +563,7 @@ ModelMessage? _parseResponse(
         final fc = part['functionCall'];
         functionCalls.add(
           FunctionCall(
-            id: fc['name'],
+            id: fc['id'] ?? fc['name'],
             name: fc['name'],
             arguments: jsonEncode(fc['args'] ?? {}),
           ),

--- a/lib/src/llm/openai_client.dart
+++ b/lib/src/llm/openai_client.dart
@@ -356,8 +356,9 @@ Map<String, dynamic> _createRequestBody(
     } else if (m is ModelMessage) {
       final msg = <String, dynamic>{'role': 'assistant'};
       if (m.textOutput != null) msg['content'] = m.textOutput;
-      if (m.thought != null && m.thought!.isNotEmpty) {
-        msg['reasoning_content'] = m.thought;
+      if (m.thought != null ||
+          _requiresReasoningContentForToolCalls(modelConfig, m)) {
+        msg['reasoning_content'] = m.thought ?? '';
       }
       if (m.functionCalls.isNotEmpty) {
         msg['tool_calls'] = m.functionCalls
@@ -467,6 +468,21 @@ Map<String, dynamic> _createRequestBody(
   }
 
   return body;
+}
+
+bool _requiresReasoningContentForToolCalls(
+  ModelConfig modelConfig,
+  ModelMessage message,
+) {
+  if (message.functionCalls.isEmpty) return false;
+
+  final thinking = modelConfig.extra?['thinking'];
+  if (thinking is Map) {
+    return thinking['type'] != 'disabled';
+  }
+
+  final model = modelConfig.model.toLowerCase();
+  return model.contains('deepseek-v4');
 }
 
 ModelMessage _parseResponse(

--- a/test/bedrock_claude_client_test.dart
+++ b/test/bedrock_claude_client_test.dart
@@ -1,0 +1,105 @@
+import 'dart:convert';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BedrockClaudeClient', () {
+    test(
+      'legacy thought without content blocks is sent as thinking block',
+      () async {
+        final adapter = _CaptureAdapter([
+          (_) => _jsonResponse({
+            'content': [
+              {'type': 'text', 'text': 'ok'},
+            ],
+            'stop_reason': 'end_turn',
+            'usage': {'input_tokens': 1, 'output_tokens': 1},
+          }),
+        ]);
+        final client = BedrockClaudeClient(
+          region: 'us-east-1',
+          accessKeyId: 'test-access-key',
+          secretAccessKey: 'test-secret-key',
+          client: Dio()..httpClientAdapter = adapter,
+        );
+
+        await client.generate([
+          UserMessage.text('开始'),
+          ModelMessage(
+            model: 'claude-test',
+            thought: '需要先读取文件',
+            textOutput: '我会调用工具。',
+            functionCalls: [
+              FunctionCall(
+                id: 'toolu_1',
+                name: 'Read',
+                arguments: '{"path":"a.md"}',
+              ),
+            ],
+          ),
+        ], modelConfig: ModelConfig(model: 'claude-test'));
+
+        final request =
+            jsonDecode(adapter.requests.single) as Map<String, dynamic>;
+        final assistantMessage = request['messages'][1] as Map<String, dynamic>;
+        expect(assistantMessage['content'], [
+          {'type': 'thinking', 'thinking': '需要先读取文件'},
+          {'type': 'text', 'text': '我会调用工具。'},
+          {
+            'type': 'tool_use',
+            'id': 'toolu_1',
+            'name': 'Read',
+            'input': {'path': 'a.md'},
+          },
+        ]);
+      },
+    );
+  });
+}
+
+class _CaptureAdapter implements HttpClientAdapter {
+  final List<ResponseBody Function(RequestOptions)> responses;
+  final List<String> requests = [];
+
+  _CaptureAdapter(this.responses);
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final bytes = <int>[];
+    if (requestStream != null) {
+      await for (final chunk in requestStream) {
+        bytes.addAll(chunk);
+      }
+    } else if (options.data is Stream<List<int>>) {
+      await for (final chunk in options.data as Stream<List<int>>) {
+        bytes.addAll(chunk);
+      }
+    } else if (options.data is List<int>) {
+      bytes.addAll(options.data as List<int>);
+    } else if (options.data != null) {
+      bytes.addAll(utf8.encode(options.data.toString()));
+    }
+
+    requests.add(utf8.decode(bytes));
+    return responses.removeAt(0)(options);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+ResponseBody _jsonResponse(Map<String, dynamic> body) {
+  return ResponseBody.fromString(
+    jsonEncode(body),
+    200,
+    headers: {
+      Headers.contentTypeHeader: [Headers.jsonContentType],
+    },
+  );
+}

--- a/test/claude_client_test.dart
+++ b/test/claude_client_test.dart
@@ -107,6 +107,56 @@ void main() {
       expect(toolResult['is_error'], isTrue);
     });
 
+    test(
+      'legacy thought without content blocks is sent as thinking block',
+      () async {
+        final adapter = _CaptureAdapter([
+          (_) => _jsonResponse({
+            'content': [
+              {'type': 'text', 'text': 'ok'},
+            ],
+            'stop_reason': 'end_turn',
+            'usage': {'input_tokens': 1, 'output_tokens': 1},
+          }),
+        ]);
+        final client = ClaudeClient(
+          apiKey: 'test-key',
+          client: Dio()..httpClientAdapter = adapter,
+        );
+
+        await client.generate([
+          UserMessage.text('开始'),
+          ModelMessage(
+            model: 'claude-test',
+            thought: '需要先读取文件',
+            textOutput: '我会调用工具。',
+            functionCalls: [
+              FunctionCall(
+                id: 'toolu_1',
+                name: 'Read',
+                arguments: '{"path":"a.md"}',
+              ),
+            ],
+          ),
+        ], modelConfig: ModelConfig(model: 'claude-test'));
+
+        final request =
+            jsonDecode(adapter.requests.single as String)
+                as Map<String, dynamic>;
+        final assistantMessage = request['messages'][1] as Map<String, dynamic>;
+        expect(assistantMessage['content'], [
+          {'type': 'thinking', 'thinking': '需要先读取文件'},
+          {'type': 'text', 'text': '我会调用工具。'},
+          {
+            'type': 'tool_use',
+            'id': 'toolu_1',
+            'name': 'Read',
+            'input': {'path': 'a.md'},
+          },
+        ]);
+      },
+    );
+
     test('stream 会产出完整有序 content blocks', () async {
       final adapter = _CaptureAdapter([
         (_) => _streamResponse([

--- a/test/gemini_client_test.dart
+++ b/test/gemini_client_test.dart
@@ -1,0 +1,129 @@
+import 'dart:convert';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GeminiClient', () {
+    test('uses function name and optional id in functionResponse', () async {
+      final adapter = _CaptureAdapter([
+        (_) => _jsonResponse({
+          'candidates': [
+            {
+              'content': {
+                'parts': [
+                  {'text': 'ok'},
+                ],
+              },
+              'finishReason': 'STOP',
+            },
+          ],
+          'usageMetadata': {
+            'promptTokenCount': 1,
+            'candidatesTokenCount': 1,
+            'totalTokenCount': 2,
+          },
+        }),
+      ]);
+      final client = GeminiClient(
+        apiKey: 'test-key',
+        client: Dio()..httpClientAdapter = adapter,
+      );
+
+      await client.generate([
+        UserMessage.text('run tool'),
+        FunctionExecutionResultMessage(
+          results: [
+            FunctionExecutionResult(
+              id: 'call_1',
+              name: 'lookup',
+              isError: false,
+              arguments: '{}',
+              content: [TextPart('result')],
+            ),
+          ],
+        ),
+      ], modelConfig: ModelConfig(model: 'gemini-test'));
+
+      final request = adapter.requests.single as Map<String, dynamic>;
+      final toolContent = request['contents'][1] as Map<String, dynamic>;
+      final functionResponse =
+          (toolContent['parts'][0] as Map<String, dynamic>)['functionResponse']
+              as Map<String, dynamic>;
+      expect(functionResponse['name'], 'lookup');
+      expect(functionResponse['id'], 'call_1');
+    });
+
+    test('parses functionCall id separately from function name', () async {
+      final adapter = _CaptureAdapter([
+        (_) => _jsonResponse({
+          'candidates': [
+            {
+              'content': {
+                'parts': [
+                  {
+                    'functionCall': {
+                      'id': 'call_1',
+                      'name': 'lookup',
+                      'args': {'q': 'x'},
+                    },
+                    'thoughtSignature': 'sig-1',
+                  },
+                ],
+              },
+              'finishReason': 'STOP',
+            },
+          ],
+          'usageMetadata': {
+            'promptTokenCount': 1,
+            'candidatesTokenCount': 1,
+            'totalTokenCount': 2,
+          },
+        }),
+      ]);
+      final client = GeminiClient(
+        apiKey: 'test-key',
+        client: Dio()..httpClientAdapter = adapter,
+      );
+
+      final response = await client.generate([
+        UserMessage.text('run tool'),
+      ], modelConfig: ModelConfig(model: 'gemini-test'));
+
+      expect(response.functionCalls.single.id, 'call_1');
+      expect(response.functionCalls.single.name, 'lookup');
+      expect(response.thoughtSignature, 'sig-1');
+    });
+  });
+}
+
+class _CaptureAdapter implements HttpClientAdapter {
+  final List<ResponseBody Function(RequestOptions)> responses;
+  final List<Object?> requests = [];
+
+  _CaptureAdapter(this.responses);
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add(options.data);
+    return responses.removeAt(0)(options);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+ResponseBody _jsonResponse(Map<String, dynamic> body) {
+  return ResponseBody.fromString(
+    jsonEncode(body),
+    200,
+    headers: {
+      Headers.contentTypeHeader: [Headers.jsonContentType],
+    },
+  );
+}

--- a/test/openai_client_test.dart
+++ b/test/openai_client_test.dart
@@ -1,0 +1,115 @@
+import 'dart:convert';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OpenAIClient', () {
+    test('round-trips explicit empty reasoning_content', () async {
+      final adapter = _CaptureAdapter([
+        (_) => _jsonResponse({
+          'choices': [
+            {
+              'message': {'role': 'assistant', 'content': 'ok'},
+              'finish_reason': 'stop',
+            },
+          ],
+          'usage': {
+            'prompt_tokens': 1,
+            'completion_tokens': 1,
+            'total_tokens': 2,
+          },
+        }),
+      ]);
+      final client = OpenAIClient(
+        apiKey: 'test-key',
+        client: Dio()..httpClientAdapter = adapter,
+      );
+
+      await client.generate([
+        UserMessage.text('hi'),
+        ModelMessage(
+          model: 'deepseek-v4-pro',
+          thought: '',
+          functionCalls: [
+            FunctionCall(id: 'call_1', name: 'lookup', arguments: '{}'),
+          ],
+        ),
+      ], modelConfig: ModelConfig(model: 'deepseek-v4-pro'));
+
+      final request = adapter.requests.single as Map<String, dynamic>;
+      final assistantMessage = request['messages'][1] as Map<String, dynamic>;
+      expect(assistantMessage, containsPair('reasoning_content', ''));
+    });
+
+    test(
+      'adds DeepSeek V4 empty reasoning_content for legacy tool-call turns',
+      () async {
+        final adapter = _CaptureAdapter([
+          (_) => _jsonResponse({
+            'choices': [
+              {
+                'message': {'role': 'assistant', 'content': 'ok'},
+                'finish_reason': 'stop',
+              },
+            ],
+            'usage': {
+              'prompt_tokens': 1,
+              'completion_tokens': 1,
+              'total_tokens': 2,
+            },
+          }),
+        ]);
+        final client = OpenAIClient(
+          apiKey: 'test-key',
+          client: Dio()..httpClientAdapter = adapter,
+        );
+
+        await client.generate([
+          UserMessage.text('hi'),
+          ModelMessage(
+            model: 'deepseek-v4-pro',
+            functionCalls: [
+              FunctionCall(id: 'call_1', name: 'lookup', arguments: '{}'),
+            ],
+          ),
+        ], modelConfig: ModelConfig(model: 'deepseek-v4-pro'));
+
+        final request = adapter.requests.single as Map<String, dynamic>;
+        final assistantMessage = request['messages'][1] as Map<String, dynamic>;
+        expect(assistantMessage, containsPair('reasoning_content', ''));
+      },
+    );
+  });
+}
+
+class _CaptureAdapter implements HttpClientAdapter {
+  final List<ResponseBody Function(RequestOptions)> responses;
+  final List<Object?> requests = [];
+
+  _CaptureAdapter(this.responses);
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add(options.data);
+    return responses.removeAt(0)(options);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+ResponseBody _jsonResponse(Map<String, dynamic> body) {
+  return ResponseBody.fromString(
+    jsonEncode(body),
+    200,
+    headers: {
+      Headers.contentTypeHeader: [Headers.jsonContentType],
+    },
+  );
+}


### PR DESCRIPTION
## 摘要

- 修复旧版 `ModelMessage.thought` 在 Claude / Bedrock Claude fallback 请求构造中没有被回放为 `thinking` block 的问题。
- 对 OpenAI-compatible thinking 模型补齐 `reasoning_content` 回放：保留显式空字符串，并为 DeepSeek V4 旧 tool-call turn 加兜底。
- 对齐 Gemini 官方 SDK / 文档的 tool replay 结构：`functionResponse.name` 使用函数名，单独保留可选 call id。
- 增加 Claude、Bedrock Claude、OpenAI-compatible reasoning、Gemini tool replay 的回归测试。

## 根因

PR #10 修到了 Anthropic provider-native `contentBlocks` 主路径，但旧状态 / 手动构造的 fallback 路径仍然会在 `thoughtSignature == null` 时丢掉 thinking 内容。thinking/tool-use provider 在下一轮继续请求时需要看到前一轮 reasoning/thinking 内容，因此会报 400。

系统排查后还发现两个同类协议坑：

- DeepSeek V4 thinking mode 中，带 tool call 的 assistant turn 必须把 `reasoning_content` 继续传回 API。
- Gemini function response 的 `name` 是函数名，call id 是独立字段；thought signature 也需要跟随上一轮模型 part 回放。

## 兼容性

- 有 provider-native `contentBlocks` 时继续优先原样回放。
- Anthropic `signature` 存在时继续保留。
- OpenAI-compatible 的新响应仍然保留真实 `reasoning_content`；空值兜底只覆盖旧状态 / 丢失 reasoning 的 tool-call turn。
- Gemini 兼容未返回 call id 的 provider：没有 id 时仍用函数名作为 fallback。

## 验证

```bash
dart test test/openai_client_test.dart test/gemini_client_test.dart test/claude_client_test.dart test/bedrock_claude_client_test.dart
dart analyze
```

本轮已重新回归，全部通过。