### PR TITLE
feat(eval): evaluation subsystem with record/replay, metrics, transcripts CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ build/
 .DS_Store
 
 .state_dir/
+
+# eval demo / runner local output
+.eval_reports/
+.eval_traces/
+.eval_recordings/

--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ See the [`example/`](example) directory:
 - [LLM Providers & Configuration](doc/providers.md) — OpenAI, Gemini, Bedrock setup, ModelConfig, proxy support
 - [Tools & Planning](doc/tools_and_planning.md) — Tool creation, parameter mapping, AgentToolResult, skills, sub-agents, planner
 - [State & Memory Management](doc/state_and_memory.md) — AgentState, FileStateStorage, context compression, episodic memory
+- [Evaluating Agents](doc/eval-guide.md) — Anthropic-aligned eval subsystem: tasks, graders, suites, pass@k / pass^k, record/replay, Langfuse export, cross-run health
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -578,6 +578,7 @@ final agent = StatefulAgent(
 - [LLM Provider 与配置](doc/providers.md) — OpenAI、Gemini、Bedrock、Claude、Kimi、Qwen、GLM 等配置，ModelConfig，代理支持
 - [工具与规划](doc/tools_and_planning.md) — 工具创建、参数映射、AgentToolResult、技能、子 Agent、规划器
 - [状态与记忆管理](doc/state_and_memory.md) — AgentState、FileStateStorage、上下文压缩、情节记忆
+- [评估指南](doc/eval-guide.zh-CN.md) — 对齐 Anthropic 方法论的评估子系统：task / grader / suite、pass@k / pass^k、录制回放、Langfuse 上报、跨 run 健康度
 
 ---
 

--- a/bin/transcripts.dart
+++ b/bin/transcripts.dart
@@ -1,0 +1,8 @@
+import 'dart:io';
+
+import 'package:dart_agent_core/eval.dart';
+
+Future<void> main(List<String> args) async {
+  final code = await runTranscriptViewer(args);
+  if (code != 0) exit(code);
+}

--- a/doc/eval-guide.md
+++ b/doc/eval-guide.md
@@ -1,0 +1,1276 @@
+# dart_agent_core Eval Guide
+
+> A practical guide to evaluating Dart agents.
+
+`dart_agent_core` ships a built-in evaluation subsystem aligned with
+[Anthropic's "Demystifying evals for AI
+agents"](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents)
+methodology. It plays the same role as OpenAI Evals / Inspect AI /
+DeepEval / Promptfoo, but Dart-first, local-first, with no external
+dependencies.
+
+- [Core concepts](#core-concepts)
+- [Components in detail](#components-in-detail)
+- [Quick start](#quick-start)
+- [Two ways to define a suite](#two-ways-to-define-a-suite)
+- [Three ways to grade](#three-ways-to-grade)
+- [Trial, Outcome, and Transcript](#trial-outcome-and-transcript)
+- [Metrics and reports](#metrics-and-reports)
+- [Recording / replay / rate limiting](#recording--replay--rate-limiting)
+- [Langfuse export](#langfuse-export)
+- [Cross-run health](#cross-run-health)
+- [Judge calibration](#judge-calibration)
+- [CLI tools](#cli-tools)
+- [Worked examples](#worked-examples)
+- [API cheat sheet](#api-cheat-sheet)
+- [References](#references)
+
+</br>
+
+## Core concepts
+
+Strictly aligned with Anthropic's terminology:
+
+| Concept | Type | Description |
+|---|---|---|
+| **Task** | `EvalTask` | One test case: an unambiguous input plus a success contract |
+| **Trial** | `Trial` | One attempt at a task. Tasks are typically run multiple times to measure non-determinism |
+| **Grader** | `Grader` | Scores one facet of a trial. A task may carry multiple graders |
+| **Score** / **Assertion** | `Score` / `Assertion` | A grader's output: a 0–1 value plus sub-checks plus a rationale |
+| **Transcript** | `Transcript` | Full record of one trial: messages, tool calls, reasoning, events, perf |
+| **Outcome** | `Outcome` | The **environment state** at trial end (what changed, not what was said) |
+| **Evaluation Harness** | `EvalRunner` | The end-to-end runner |
+| **Agent Harness** | `AgentHarnessFactory` / `AgentHarnessSession` | The scaffolding that lets a model behave as an agent (you provide it) |
+| **Evaluation Suite** | `EvalSuite` | A set of tasks targeting one capability or behavior |
+
+Design principle (Anthropic Step 5): **default to grading the Outcome,
+not the Transcript**. "flight booked" should be checked against the
+database, not against whether the agent said "Your flight has been
+booked".
+
+</br>
+
+## Components in detail
+
+One eval run involves five roles:
+
+```
+EvalSuite
+  └─ EvalTask × N
+      └─ Trial × trialsPerRun
+          ├─ EvalEnvironment.prepare → EvalContext (workspace / clock / llmClient / controller)
+          ├─ AgentHarnessFactory.create → AgentHarnessSession
+          │      ↓ session.run()
+          │  ┌── Transcript: what the agent did (messages / tool calls / events / perf)
+          │  └── Outcome:    what the environment ended up looking like
+          ├─ Graders score independently → Score[]
+          └─ EvalEnvironment.dispose
+                  ↓
+          EvalRunReport (pass@k / pass^k / per-grader means / bucket pass rates)
+```
+
+Below, each role gets its own section. **This section covers framework
+contracts only**; for plugging a real `StatefulAgent` into the
+machinery, see [Quick start](#quick-start).
+
+### EvalTask — one test case
+
+Interface (every field is required, no defaults):
+
+```dart
+abstract class EvalTask {
+  String get id;                          // globally unique
+  String get description;                 // one-line, human-facing
+  Map<String, dynamic> get input;         // arbitrary JSON; the harness interprets it
+  Map<String, String> get metadata;       // tags like failure_bucket
+  ReferenceSolution? get referenceSolution; // optional known-good answer
+  List<Grader> get graders;               // graders to run on each trial
+  int get trialsPerRun;                   // ≥2 to measure pass^k meaningfully
+  Duration? get timeout;                  // per-trial timeout
+}
+```
+
+| Field | Notes |
+|---|---|
+| `id` | **A semantic change to a task = a new id** (e.g. `card_001` → `card_001_v2`). Don't rewrite an existing id; `SuiteHealthAnalyzer` aligns trials across runs by id, and reusing ids will pollute graduation / broken-task detection |
+| `input` | Don't bake a prompt into `input` and feed it raw to the LLM. Let the harness translate `input` into messages so the same task can be reused across agents |
+| `metadata['failure_bucket']` | The framework aggregates pass rate by this key — useful for spotting which failure mode dominates |
+| `graders` | A task can carry multiple graders ("got the answer right" + "used the right tool"); each scores independently. A trial passes only if every grader passes |
+| `trialsPerRun` | 2–5 for capability suites; usually 1 for regression. With `trialsPerRun=1`, pass^k degenerates into pass@1 and tells you nothing |
+
+Tasks can also be defined as **JSON files** instead of Dart classes —
+see [Two ways to define a suite](#two-ways-to-define-a-suite).
+
+### EvalSuite — a set of tasks targeting one agent
+
+```dart
+EvalSuite(
+  name: 'card_capability',
+  agentName: 'card_agent',          // ← suite-scope: the agent under test
+  kind: SuiteKind.capability,       // capability / regression / mixed
+  tasks: [task1, task2, ...],
+  requireReferenceSolution: false,  // when true, every task must declare one
+  taskPassThreshold: 1.0,           // threshold used by taskPassRate
+);
+```
+
+`agentName` lives on the **suite**, not on individual tasks — a task
+set is not generally reused across different agents. This boundary
+matches the Anthropic blog's framing.
+
+`kind` decides what `taskPassRate` means:
+
+| kind | A task passes when… | Use it for |
+|---|---|---|
+| `capability` | At least one trial passes | "Can the agent do this at all?" Tolerates occasional misses |
+| `regression` | Every trial passes | "Is the agent stable?" One miss blocks the PR |
+| `mixed` | Same as regression | Suites that haven't been split yet |
+
+### EvalEnvironment — set up the "exam room"
+
+```dart
+abstract class EvalEnvironment {
+  Future<EvalContext> prepare({required Trial trial, required EvalTask task});
+  Future<void> dispose(EvalContext context);
+}
+```
+
+The runner guarantees `prepare`/`dispose` are called once per trial —
+so you can freely create a temp directory, spin up an in-memory DB,
+seed test users, **wrap the LLM client**, and tear it all down on
+`dispose`.
+
+`EvalContext` is what `prepare` returns:
+
+| Field | Description |
+|---|---|
+| `workspaceDir` | The trial's temp workspace root. Files written by the agent should land here so `dispose` can recursively delete them. Nullable |
+| `clock` | Time source (`SystemEvalClock` / `FixedEvalClock`). Agents should call `ctx.clock.now()` rather than `DateTime.now()` so time can be locked |
+| `llmClient` | The LLM client for this trial. May be a real client or a `RecordingLLMClient` / `ReplayLLMClient` wrapper. Each trial gets its own to keep record/replay clean |
+| `controller` | An `AgentController` with trace exporters already attached. The harness should **reuse** this — never `new AgentController()` — or trace events won't reach the exporters |
+| `servicesMap` | Where the application stashes its own services (`CardRepo`, `UserStorage`, in-memory DB). The harness reads them via `ctx.services<T>()`. The framework doesn't peek inside |
+| `metadata` | Free-form metadata; flows into the transcript |
+
+> **EvalEnvironment doesn't know what your agent looks like** — it
+> only sets up resources. One Environment can serve multiple Harness
+> implementations (different agent classes). This is the difference
+> from Harness that newcomers most often miss.
+
+### AgentHarnessFactory / AgentHarnessSession — turn a model into an agent
+
+```dart
+abstract class AgentHarnessFactory {
+  Future<AgentHarnessSession> create({
+    required EvalTask task, required Trial trial, required EvalContext context,
+  });
+}
+
+abstract class AgentHarnessSession {
+  Future<({Transcript transcript, Outcome outcome})> run();
+  Future<void> dispose();
+}
+```
+
+The harness is the **only** layer that knows what your agent looks
+like: it instantiates `StatefulAgent`, registers `Tool[]`, calls
+`agent.run([UserMessage(task.input['prompt'])])`, and once it returns,
+assembles a transcript and an outcome from the agent state and
+workspace.
+
+`run()` must return **two** things:
+
+- `Transcript` — what the agent **did**: message sequence, tool calls,
+  retry / error events, turns / token counters. **Graders should
+  generally not look here** (path, not result)
+- `Outcome` — what the environment **ended up like**.
+  `environmentState` is an arbitrary map whose schema is a contract
+  between you and your graders. **Graders look here by default**
+
+Common mistakes when populating `Outcome.environmentState`:
+
+| ❌ Wrong (what the agent said) | ✅ Right (what the world became) |
+|---|---|
+| `{'agent_said': 'I booked the flight'}` | `{'flight_booked': true, 'flight_id': 'AA123'}` |
+| `{'response': 'Logged to Areas/Health.md'}` | `{'updated_files': ['Areas/Health.md'], 'fact_id': 'fact_001'}` |
+| `{'declined': "Sorry, I can't answer that"}` | `{'declined': true, 'submitted_answer': false}` |
+
+#### Outcome is the harness's "facts table" for graders
+
+A common newcomer question: **how does a grader know which files the
+agent wrote and what's inside them? Does it spawn a tiny agent to
+list directories?**
+
+It doesn't. **Graders never read disk and never call an LLM to
+discover environment state.** All disk scanning, directory walking,
+and fact extraction happen at the end of the harness's `run()`. The
+results land in `Outcome.environmentState` and `Outcome.workspaceDiff`
+— that pre-summarized snapshot is what graders consume.
+
+A real example from the PKM agent demo
+(`example/eval_demo/pkm_agent/harness.dart`):
+
+```dart
+// Fact-collection code at the end of Harness.run()
+Outcome _capturePkmOutcome(Directory ws, SessionState state) {
+  // 1. Walk the workspace
+  final created = <String>[];
+  final snippets = <String, String>{};
+  final pkmRoot = Directory('${ws.path}/PKM');
+  if (pkmRoot.existsSync()) {
+    for (final entry in pkmRoot.listSync(recursive: true)) {
+      if (entry is! File) continue;
+      final rel = entry.path.replaceFirst('${pkmRoot.path}/', '');
+      created.add(rel);
+      snippets[rel] = entry.readAsStringSync();
+    }
+  }
+
+  // 2. Pull key facts (e.g. fact_id) out of file contents via regex
+  final factIds = <String>{};
+  snippets.forEach((_, body) {
+    final m = RegExp(r'fact_id\s*:\s*(\S+)').firstMatch(body);
+    if (m != null) factIds.add(m.group(1)!);
+  });
+
+  // 3. Check sentinel files (some tools leave side-effect markers)
+  final skipped = File('${ws.path}/skipped.txt').existsSync();
+  final insightFile = Directory('${ws.path}/insights').listSync().firstOrNull;
+
+  return Outcome(
+    environmentState: {
+      'wrote_files': created,
+      'fact_ids_in_files': factIds.toList(),
+      'updated_insight': insightFile != null,
+      'skipped': skipped,
+    },
+    workspaceDiff: WorkspaceDiff(created: created, contentSnippets: snippets),
+  );
+}
+```
+
+The matching grader touches the filesystem zero times:
+
+```dart
+class PkmOrganizedGrader extends CodeGrader {
+  @override Future<List<Assertion>> computeAssertions({...required Outcome outcome, ...}) async {
+    final wrote = (outcome.environmentState['wrote_files'] as List).cast<String>();
+    final factIds = (outcome.environmentState['fact_ids_in_files'] as List).cast<String>();
+    return [
+      Assertion(
+        description: 'wrote into Areas/',
+        passed: wrote.any((p) => p.startsWith('Areas/')),
+        actual: '$wrote', expected: 'starts with Areas/',
+      ),
+      Assertion(
+        description: 'fact_id appears in file body',
+        passed: factIds.contains(expectedFactId),
+        actual: '$factIds', expected: 'contains $expectedFactId',
+      ),
+    ];
+  }
+}
+```
+
+Why it's structured this way:
+
+| If you let graders read disk… | …you get |
+|---|---|
+| Outcome stops being self-contained | Persisted reports can't be inspected offline without the original workspace |
+| Multiple graders re-scan | A task with 3 graders walks the workspace 3 times |
+| Graders care about schema, not paths | Every grader has to know "PKM lives under this subdir, with this filename convention" — agent-implementation details leaking into scoring logic |
+| Cross-run diff and SuiteHealth break | `EvalRunReport` only stores the outcome, not the workspace |
+
+Same applies to LLM judges: a judge typically reads a few text fields
+from `outcome.environmentState` (or `workspaceDiff.contentSnippets`)
+and folds them into the rubric prompt. **Judges don't spawn agents to
+explore the workspace.**
+
+> **Edge case**: occasionally a grader genuinely needs cross-file,
+> tool-augmented reasoning (e.g. auditing the consistency of an
+> entire codebase the agent produced). The framework doesn't stop
+> you — `EvalContext` exposes `workspaceDir` / `llmClient` /
+> `servicesMap`, so you can spin up a small agent inside the grader.
+> But this is an anti-pattern. 99% of the time, **first ask: should
+> this collection logic move to the harness?**
+
+### Grader — score it
+
+```dart
+abstract class Grader {
+  String get name;
+  double get passThreshold;
+  Future<Score> grade({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  });
+}
+```
+
+There are three base classes by scoring style: `CodeGrader`
+(deterministic), `ModelGrader` (LLM-as-judge), `HumanGrader` (queue
+for human review). See [Three ways to grade](#three-ways-to-grade).
+
+`Score` fields:
+
+| Field | Description |
+|---|---|
+| `value` | Continuous 0..1 (supports partial credit). `null` means "couldn't decide" (e.g. an LLM judge returning Unknown) |
+| `passed` | Whether `value` clears `passThreshold`. `null` when `value` is null |
+| `assertions` | Sub-checks (`description` / `passed` / `actual` / `expected`) so a human can see which sub-criterion failed |
+| `rationale` | **Required on failure**: a human-readable explanation. Anthropic Step 5 emphasizes "failures should seem fair" |
+| `metadata` | Free-form: judge raw response, diff details, etc. |
+
+### EvalRunner — run it
+
+You don't implement this — just call `runSuite(...)`:
+
+```dart
+final report = await runner.runSuite(
+  runName: 'pr-${prNumber}',         // identifies this run in the store / Langfuse
+  suite: mySuite,
+  concurrency: 4,                    // parallel trial count
+  filter: TaskFilter(...),           // optional: only run a subset
+);
+```
+
+Internally it:
+
+1. Spawns workers up to `concurrency`. Each worker takes one (task, trial)
+2. For each trial: `env.prepare()` → `harness.create().run()` → graders score → `env.dispose()`
+3. Streams events to all `exporters` (jsonl / Langfuse / custom)
+4. Computes pass@k / pass^k / per-grader means / bucket pass rates
+5. Persists `EvalRunReport` to `reportStore` for later diff / SuiteHealthAnalyzer
+
+`EvalRunMode` (parsed from `--mode` via `parseEvalRunArgs`):
+
+- `live` — real LLM calls every time, burns tokens
+- `record` — real LLM calls plus persisting requests/responses to a `RecordingStore`
+- `replay` — no LLM calls; replays from the store. Misses are errors
+
+In CI, regression suites typically run in `replay` (millisecond-fast,
+zero cost), and capability suites run nightly in `live`.
+
+</br>
+
+
+## Quick start
+
+```bash
+dart pub add dart_agent_core
+```
+
+A minimal runnable example. Full source: [`example/min_eval/main.dart`](../example/min_eval/main.dart).
+Set `OPENAI_API_KEY` / `OPENAI_BASE_URL` / `OPENAI_MODEL` and `dart run`:
+
+```dart
+import 'dart:io';
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dart_agent_core/eval.dart';
+
+// ─── 1. A minimal agent that uses one `echo` tool ────────────────────────
+const _systemPrompt = '''
+You echo what the user says back through the `echo` tool exactly once.
+Then your turn ends. Do not produce any free-form text.
+''';
+
+List<Tool> _buildTools(Directory ws) => [
+  Tool(
+    name: 'echo',
+    description: 'Echo the input text. Call this exactly once.',
+    parameters: const {
+      'type': 'object',
+      'properties': {'text': {'type': 'string'}},
+      'required': ['text'],
+    },
+    executable: (String text) async {
+      File('${ws.path}/echo.txt').writeAsStringSync(text);
+      return AgentToolResult(content: TextPart('echoed'), stopFlag: true);
+    },
+  ),
+];
+
+// ─── 2. EvalEnvironment: one fresh temp dir per trial ────────────────────
+class EchoEnv implements EvalEnvironment {
+  final OpenAIClient Function() clientFactory;
+  EchoEnv(this.clientFactory);
+
+  @override
+  Future<EvalContext> prepare({required Trial trial, required EvalTask task}) async {
+    final dir = await Directory.systemTemp.createTemp('echo_eval_');
+    return EvalContext(
+      workspaceDir: dir,
+      clock: const SystemEvalClock(),
+      llmClient: clientFactory(),
+      controller: AgentController(),
+    );
+  }
+
+  @override
+  Future<void> dispose(EvalContext ctx) async {
+    final d = ctx.workspaceDir;
+    if (d != null && await d.exists()) await d.delete(recursive: true);
+    ctx.controller.close();
+  }
+}
+
+// ─── 3. AgentHarnessFactory: wrap a model into an agent that uses tools ──
+class EchoHarness implements AgentHarnessFactory {
+  final ModelConfig modelConfig;
+  EchoHarness(this.modelConfig);
+
+  @override
+  Future<AgentHarnessSession> create({
+    required EvalTask task,
+    required Trial trial,
+    required EvalContext context,
+  }) async => _EchoSession(task: task, ctx: context, modelConfig: modelConfig);
+}
+
+class _EchoSession implements AgentHarnessSession {
+  final EvalTask task;
+  final EvalContext ctx;
+  final ModelConfig modelConfig;
+  _EchoSession({required this.task, required this.ctx, required this.modelConfig});
+
+  @override
+  Future<({Transcript transcript, Outcome outcome})> run() async {
+    final agent = StatefulAgent(
+      name: 'echo_agent',
+      client: ctx.llmClient,
+      modelConfig: modelConfig,
+      state: AgentState(sessionId: '${task.id}'),
+      tools: _buildTools(ctx.workspaceDir!),
+      systemPrompts: [_systemPrompt],
+      controller: ctx.controller,
+      withGeneralPrinciples: false,
+      planMode: PlanMode.none,
+      disableSubAgents: true,
+      autoSaveStateFunc: (_) async {},
+    );
+    await agent.run([
+      UserMessage([TextPart(task.input['prompt'] as String)]),
+    ], useStream: false);
+
+    final f = File('${ctx.workspaceDir!.path}/echo.txt');
+    final echoed = f.existsSync() ? f.readAsStringSync() : null;
+
+    return (
+      transcript: Transcript(
+        messages: List.unmodifiable(agent.state.history.messages),
+        toolCalls: const [],
+        metrics: const TranscriptMetrics(nTurns: 0, nToolCalls: 0, nTotalTokens: 0),
+      ),
+      outcome: Outcome(environmentState: {'echoed': ?echoed}),
+    );
+  }
+
+  @override
+  Future<void> dispose() async {}
+}
+
+// ─── 4. Grader: echoed value matches the expected text ───────────────────
+class _EchoMatchesGrader extends CodeGrader {
+  final String expected;
+  _EchoMatchesGrader(this.expected);
+  @override String get name => 'echo_matches';
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async => [
+    Assertion(
+      description: 'echoed text matches expected',
+      passed: outcome.environmentState['echoed'] == expected,
+      actual: '${outcome.environmentState['echoed']}',
+      expected: expected,
+    ),
+  ];
+}
+
+// ─── 5. EvalTask + EvalSuite ─────────────────────────────────────────────
+class _EchoTask implements EvalTask {
+  @override String get id => 'echo_hi';
+  @override String get description => 'agent must echo "hi" verbatim';
+  @override Map<String, dynamic> get input => {'prompt': 'echo this back: hi'};
+  @override Map<String, String> get metadata => const {};
+  @override ReferenceSolution? get referenceSolution => null;
+  @override List<Grader> get graders => [_EchoMatchesGrader('hi')];
+  @override int get trialsPerRun => 2;
+  @override Duration? get timeout => const Duration(minutes: 1);
+}
+
+// ─── 6. main: wire it together and run ───────────────────────────────────
+Future<void> main() async {
+  final env = Platform.environment;
+  OpenAIClient client() => OpenAIClient(
+    apiKey: env['OPENAI_API_KEY']!,
+    baseUrl: env['OPENAI_BASE_URL'] ?? 'https://api.openai.com/v1',
+  );
+
+  final runner = EvalRunner(
+    environment: EchoEnv(client),
+    harnessFactory: EchoHarness(ModelConfig(model: env['OPENAI_MODEL'] ?? 'gpt-4o-mini')),
+    exporters: [JsonlTraceExporter(File('.eval_traces/echo.jsonl'))],
+    reportStore: FileReportStore(Directory('.eval_reports')),
+  );
+
+  final report = await runner.runSuite(
+    runName: 'echo_${DateTime.now().millisecondsSinceEpoch}',
+    suite: EvalSuite(
+      name: 'echo_capability',
+      agentName: 'echo_agent',
+      kind: SuiteKind.capability,
+      tasks: [_EchoTask()],
+    ),
+    concurrency: 2,
+  );
+
+  stdout.writeln(report.toMarkdownSummary());
+  exit(report.taskPassRate >= 1.0 ? 0 : 1);
+}
+```
+
+What you get:
+
+- `.eval_reports/<run_name>.json` — full run report, loadable by the transcripts CLI
+- `.eval_reports/index.jsonl` — cross-run index
+- `.eval_traces/echo.jsonl` — OTel-style trace stream
+- stdout — Markdown report (task / trial pass rate, pass@k, per-grader means)
+
+For richer scenarios (multiple graders, file fixtures, multiple tasks,
+record/replay, cross-run diff), see the three demos under
+[`example/eval_demo/`](../example/eval_demo/) (`calculator/`,
+`card_agent/`, `pkm_agent/`).
+
+</br>
+
+## Two ways to define a suite
+
+`dart_agent_core` supports both **code-defined** and **file-defined**
+suites. They can coexist.
+
+### Option A — code-defined (`EvalSuite(...)` + `EvalTask` subclasses)
+
+Best when the task count is small, you want strong type safety, and
+you want refactors to follow renames. `example/eval_demo/calculator/`
+and `example/eval_demo/card_agent/` follow this style.
+
+```dart
+class _SimpleAdditionTask implements EvalTask {
+  @override String get id => 'task_simple_addition';
+  @override String get description => 'Single-step addition';
+  @override Map<String, dynamic> get input => {'prompt': 'What is 2 + 3?'};
+  @override List<Grader> get graders => [
+    AnswerCorrectnessGrader(expected: 5),
+    ToolUsageGrader(minArithmeticCalls: 1),
+  ];
+  @override int get trialsPerRun => 2;
+  @override Duration? get timeout => const Duration(minutes: 2);
+}
+
+EvalSuite buildSuite() => EvalSuite(
+  name: 'calculator_demo',
+  agentName: 'calculator_demo_agent',  // ← suite-scope: the agent under test
+  kind: SuiteKind.mixed,
+  tasks: [_SimpleAdditionTask(), ...],
+  requireReferenceSolution: true,
+);
+```
+
+### Option B — file-defined (directory layout + `loadEvalSuiteFromDir`)
+
+Best when the task set keeps growing, when product / QA folks need to
+PR new cases, or when cases need to be grouped by failure category.
+`example/eval_demo/pkm_agent/suites/` follows this style.
+
+Layout:
+
+```
+suites/
+  pkm_capability/
+    suite.json                    ← suite metadata
+    tasks/                        ← one JSON per task
+      positive/                   ← optional sub-folders for grouping
+        pkm_area_health.json
+        pkm_resource_reading.json
+        pkm_append_to_existing.json
+      negative/
+        pkm_skip_trivial.json
+```
+
+`suite.json`:
+
+```json
+{
+  "name": "pkm_agent_demo",
+  "agent_name": "pkm_agent_demo",
+  "kind": "mixed",
+  "requireReferenceSolution": true,
+  "taskPassThreshold": 1.0
+}
+```
+
+A task file:
+
+```json
+{
+  "id": "pkm_area_health",
+  "description": "Long-term health habit: should write under Areas/.",
+  "trials_per_run": 2,
+  "timeout_seconds": 180,
+  "metadata": {"failure_bucket": "route_to_areas"},
+  "input": {"prompt": "..."},
+  "reference_solution": {
+    "expected_outcome": {"updated_insight": true, "skipped": false},
+    "source": "manual"
+  },
+  "graders": [
+    {"name": "pkm_organized",
+     "config": {"fact_id": "fact_pkm_001",
+                "buckets": ["Areas/"],
+                "must_contain": ["mobility"]}}
+  ]
+}
+```
+
+Loading:
+
+```dart
+final reg = GraderRegistry()
+  ..register('pkm_organized', (cfg) => PkmOrganizedGrader(
+        expectedFactId: cfg['fact_id'] as String,
+        expectedBuckets: (cfg['buckets'] as List).cast<String>(),
+        mustContainSubstrings:
+            (cfg['must_contain'] as List?)?.cast<String>() ?? const [],
+      ))
+  ..register('pkm_skipped', (_) => PkmSkippedGrader())
+  ..register('read_before_write', (_) => PkmReadBeforeWriteGrader());
+
+final suite = loadEvalSuiteFromDir(
+  Directory('suites/pkm_capability'),
+  graderRegistry: reg,
+);
+```
+
+| Dimension | Code-defined | File-defined |
+|---|---|---|
+| Fast to write | ✅ IDE completion, type safety | 🔶 hand-written JSON |
+| Scales to many cases | 🔶 single file gets bloated | ✅ one task per file, git-diff friendly |
+| Non-engineers can contribute | ❌ Dart only | ✅ JSON only |
+| Refactors propagate | ✅ rename a grader and the compiler tells you | 🔶 update the grader name in JSON manually |
+| When to use | Demos, framework tests, type-sensitive scenarios | Business case banks, cross-team contribution |
+
+> **Recommendation**: use code definitions during early iteration, then
+> export to JSON once the case set stabilizes. Graders should always be
+> code (typed, debuggable); task data can be either.
+
+</br>
+
+
+## Three ways to grade
+
+Anthropic categorizes graders into three families; the framework
+provides a base class for each.
+
+### 1. Code-based (`CodeGrader`) — deterministic, fastest
+
+Best for: exact string match, numeric comparison, file existence,
+JSON schema validation, tool-call counting — anything decidable in
+code.
+
+```dart
+class AnswerCorrectnessGrader extends CodeGrader {
+  final num expected;
+  final double tolerance;
+  AnswerCorrectnessGrader({required this.expected, this.tolerance = 1e-9});
+
+  @override String get name => 'answer_correctness';
+
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async {
+    final actual = (outcome.environmentState['answer'] as num?)?.toDouble();
+    return [
+      Assertion(
+        description: 'answer == $expected within $tolerance',
+        passed: actual != null
+            && (actual - expected.toDouble()).abs() <= tolerance,
+        actual: '$actual',
+        expected: '$expected',
+      ),
+    ];
+  }
+}
+```
+
+`CodeGrader` aggregates the `Assertion` list into a `Score(value,
+passed)`:
+
+- `value = passed_assertions / total_assertions`
+- `passed = value >= passThreshold`, default `passThreshold = 1.0` (all must pass)
+- The rationale is auto-generated from failed assertions
+
+### 2. Model-based (`ModelGrader` / LLM-as-judge) — flexible, handles subjective tasks
+
+Best for: open-ended response relevance, style consistency, safety,
+and other dimensions code can't decide cleanly.
+
+```dart
+class StyleJudgeGrader extends ModelGrader {
+  @override final LLMClient judgeClient;
+  @override final String rubric;
+  final ModelConfig modelConfig;
+  @override final String name = 'style_quality';
+
+  StyleJudgeGrader({
+    required this.judgeClient,
+    required this.rubric,
+    required this.modelConfig,
+  });
+
+  @override double get passThreshold => 0.7;
+
+  @override
+  Future<Score> grade({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async {
+    final prompt = '$rubric\n\nOutput: ${outcome.environmentState["text"]}\n'
+        'Reply on a single line: "SCORE=<float 0-1>" or "SCORE=Unknown".';
+    final reply = await judgeClient.generate(
+      [UserMessage.text(prompt)],
+      modelConfig: modelConfig,
+    );
+    final text = reply.textOutput?.trim() ?? '';
+    final m = RegExp(r'SCORE=(Unknown|[\d.]+)').firstMatch(text);
+
+    // Unknown escape hatch: when the judge can't decide, return null
+    // rather than fabricating a score
+    if (m == null || m.group(1) == 'Unknown') {
+      return Score(
+        graderName: name,
+        value: null,
+        passed: null,
+        rationale: 'judge returned Unknown: $text',
+      );
+    }
+
+    final v = double.parse(m.group(1)!).clamp(0.0, 1.0);
+    return Score(
+      graderName: name,
+      value: v,
+      passed: v >= passThreshold,
+      rationale: 'judge=$v, raw="$text"',
+    );
+  }
+}
+```
+
+**Anthropic Step 5 key point**: rubrics must always offer an
+`Unknown` escape hatch. When the judge can't decide, return
+`Score(value: null, passed: null)` rather than fabricating a number.
+Null scores are excluded from grader means but tracked separately.
+
+### 3. Human-based (`HumanGrader` + `HumanReviewQueue`) — gold standard, slowest
+
+`HumanGrader` pushes trials onto a `HumanReviewQueue` (interface
+implemented by you — wire it to a Langfuse Annotation Queue, your own
+web UI, a Slack flow, whatever):
+
+```dart
+abstract class HumanReviewQueue {
+  Future<void> enqueue({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    String? rubric,
+    Map<String, dynamic> metadata,
+  });
+  Future<Score?> fetchVerdict(Trial trial);
+}
+```
+
+The first `grade` call enqueues the trial and returns a pending null
+score; once a reviewer scores it, a subsequent run picks up the
+verdict. The primary use is **calibrating an LLM judge** (see [Judge
+calibration](#judge-calibration)) — not scoring every run.
+
+</br>
+
+## Trial, Outcome, and Transcript
+
+A trial produces a `TrialResult`:
+
+```dart
+class TrialResult {
+  final Trial trial;            // run / suite / task / index / status / timestamps
+  final Transcript transcript;  // messages + tool calls + events + perf
+  final Outcome outcome;        // final environment state
+  final List<Score> scores;     // per-grader output
+}
+```
+
+### Transcript ("what the agent did")
+
+```dart
+class Transcript {
+  final List<LLMMessage> messages;
+  final List<ToolCallRecord> toolCalls;
+  final List<String> reasoningSteps;
+  final List<TranscriptEvent> events;       // retry / exception / custom
+  final TranscriptMetrics metrics;          // turns / tokens / TTFT / TTLT
+}
+```
+
+### Outcome ("what the environment ended up like")
+
+```dart
+class Outcome {
+  final Map<String, dynamic> environmentState;  // app-defined schema
+  final WorkspaceDiff? workspaceDiff;           // per-file diff
+}
+```
+
+**Anthropic Step 5 hammers this point**: graders default to looking at
+`outcome` and only consult `transcript` when judging "did the path
+look right" (e.g. "must have called this tool" → check
+`transcript.toolCalls`).
+
+</br>
+
+## Metrics and reports
+
+`EvalRunReport` computes every metric Anthropic recommends.
+
+### Pass-rate (semantics depend on suite kind)
+
+- `trialPassRate` — passed trials / total trials
+- `taskPassRate` —
+  - `SuiteKind.capability`: a task counts as passed if at least one trial passes
+  - `SuiteKind.regression`: a task counts as passed only if every trial passes
+  - `SuiteKind.mixed`: same as regression
+
+### pass@k (Codex unbiased estimator)
+
+`pass@k = 1 − C(n−c, k) / C(n, k)`. The probability of at least one
+success in k attempts. (`n` = total trials, `c` = passing trials.)
+
+### pass^k (empirical estimator)
+
+`pass^k = (c/n)^k`. The probability of all k attempts succeeding.
+Anthropic recommends targeting **pass@1 close to 100% and as large a
+k as possible for pass^k** — the latter measures sustained
+reliability.
+
+```dart
+final passAt = report.passAtKByTask(ks: [1, 3, 5]);
+final passCk = report.passCaretKByTask(ks: [1, 3, 5]);
+```
+
+### Bucket grouping
+
+Group tasks by `metadata['failure_bucket']` to see which failure mode
+dominates:
+
+```dart
+final byBucket = report.bucketPassRates({
+  for (final t in suite.tasks)
+    if (t.metadata['failure_bucket'] != null)
+      t.id: t.metadata['failure_bucket']!,
+});
+// {tool_use: 0.92, intent_routing: 0.65, …}
+```
+
+### Classification metrics (`ClassificationMetrics`)
+
+For binary tasks (should the Memory Agent write a memory? should the
+Schedule Router refresh?), compute P / R / F1 directly:
+
+```dart
+const m = ClassificationMetrics(
+  truePositives: 6, falsePositives: 2,
+  trueNegatives: 8, falseNegatives: 4,
+);
+print(m.precision); // 0.75
+print(m.recall);    // 0.6
+print(m.f1);        // 0.6667
+```
+
+### Markdown reports + diff
+
+```dart
+// Single-run report
+final md = report.toMarkdownSummary(taskBucketMap: {...});
+File('report.md').writeAsStringSync(md);
+
+// Cross-run diff (handy as a PR comment)
+final baseline = await store.load('main');
+final diff = report.diffWith(baseline!);
+File('diff.md').writeAsStringSync(diff.toMarkdown());
+```
+
+</br>
+
+
+## Recording / replay / rate limiting
+
+Hitting the real LLM on every eval run is slow, expensive, and
+flaky in CI. The framework provides two layers of infrastructure:
+**deterministic replay** and **rate limiting**.
+
+### Recording / replay
+
+```dart
+// First run: record
+final store = FileRecordingStore(Directory('.eval_recordings'));
+final llm = RecordingLLMClient(
+  inner: OpenAIClient(...),
+  store: store,
+);
+
+// Later in CI: replay (cache hit returns the recording, miss errors out)
+final replay = ReplayLLMClient(
+  store: FileRecordingStore(Directory('.eval_recordings')),
+  strictReplay: true,  // CI must be strict
+);
+```
+
+Request hashing is done by `Sha256LLMRequestHash` (default):
+
+- Includes `messages` / `tools` / `modelConfig` / `jsonOutput` / `trialSalt`
+- Use `stripMessageKeys` to ignore volatile fields (`timestamp`, etc.)
+- Changing the prompt or tools → hash changes → cache misses → CI surfaces it as a re-record signal
+
+#### Per-trial non-determinism — `trialSalt`
+
+When `trialsPerRun > 1`, every trial of a given task sends a literally
+identical request (same prompt, same tools, same model). If the hash
+keyed off request content alone, N trials would collapse into one
+cache entry, and **pass^k / pass@k would no longer measure model
+non-determinism — they'd measure the cached replay**. That violates
+Anthropic Step 6.
+
+The framework's solution: per-trial salt mixed into the hash. Inside
+`EvalEnvironment.prepare()`, take `trial.cacheSalt` (formatted as
+`taskId#trialIndex`, **without** runName so recordings made in one
+run can replay across runs) and pass it to `RecordingLLMClient` /
+`ReplayLLMClient`'s `trialSalt` parameter. N trials become N
+independent cache entries — record once, replay each one
+independently.
+
+```dart
+// Inside EvalEnvironment.prepare:
+final salt = trial.cacheSalt;
+final llmClient = RecordingLLMClient(
+  inner: liveClientFactory(),
+  store: store,
+  trialSalt: salt,           // ← key
+);
+// Or shorter: base.withTrialSalt(salt)
+```
+
+`trialSalt: null` (omitted) means cache is shared across all trials.
+This is intentional — it's there for "logically the same call" cases
+like a judge or ad-hoc analysis. It is **not** what you want for the
+agent's main calls. All three built-in demos (calculator / card /
+pkm) wire this correctly.
+
+### Rate limiting
+
+```dart
+final gate = RpmRateLimitGate(requestsPerMinute: 120);
+// Or token-based
+final gate = TpmRateLimitGate(tokensPerMinute: 60000);
+
+final llm = RecordingLLMClient(
+  inner: ...,
+  store: ...,
+  rateLimitGate: gate,
+);
+```
+
+`acquire()` blocks before a real LLM call. Replay hits **don't**
+trigger rate limiting (they're local). This decouples concurrency
+from rate limits: turn `concurrency` up to saturate CPU/IO, leave
+the throughput cap to the gate.
+
+</br>
+
+## Langfuse export
+
+Streaming every trial to [Langfuse](https://langfuse.com/) is built
+in. Langfuse is the most popular open-source LLM observability
+backend right now, with trace-tree views, filtering by user / session
+/ tag, in-product scoring, prompt diffing, etc.
+
+```dart
+import 'package:dart_agent_core/eval.dart';
+
+final exporter = LangfuseTraceExporter(LangfuseConfig.fromEnv());
+// Or pass config explicitly:
+//   LangfuseConfig(
+//     host: 'https://cloud.langfuse.com',  // self-hosted? change this
+//     publicKey: 'pk-...',
+//     secretKey: 'sk-...',
+//     environment: 'staging',
+//   );
+
+final runner = EvalRunner(
+  environment: env,
+  harnessFactory: harness,
+  exporters: [
+    JsonlTraceExporter(File('.eval_traces/run.jsonl')),
+    exporter,           // local jsonl + Langfuse at the same time
+  ],
+  reportStore: FileReportStore(Directory('.eval_reports')),
+);
+```
+
+Mapping:
+
+| dart_agent_core | Langfuse |
+|---|---|
+| One `Trial` | One trace (`name = suite/task#trialIndex`, `userId = runName`, `sessionId = suiteName`) |
+| Each LLM call | A `generation-create` observation (with `model` / `modelParameters` / `input` / `output` / `usage`) |
+| Each tool call | A `span-create` observation (with `arguments` / `result`) |
+| Each `Score` | A `score-create` (`dataType=NUMERIC`, `comment=rationale`, plus `assertions` / `metadata`) |
+| `onRunEnd` aggregates | A `run-summary` trace plus one `score-create` per metric |
+
+Implementation details:
+
+- All HTTP runs in a background batched queue: defaults flush at 50
+  events or every 1 second, so the eval run is barely affected
+- HTTP 5xx triggers exponential-backoff retries (default 3); 4xx
+  fails fast without retry
+- Network blips / Langfuse downtime drop **at most a few events** —
+  they never tank the eval run
+- `dispose()` force-flushes anything still queued
+
+Environment variables read by `LangfuseConfig.fromEnv`:
+
+```bash
+export LANGFUSE_PUBLIC_KEY='pk-...'
+export LANGFUSE_SECRET_KEY='sk-...'
+export LANGFUSE_HOST='https://cloud.langfuse.com'  # optional, defaults to cloud
+export LANGFUSE_ENVIRONMENT='staging'              # optional, dashboard-side bucketing
+```
+
+</br>
+
+## Cross-run health
+
+`SuiteHealthAnalyzer` runs two checks across multiple eval runs
+(Anthropic Step 7):
+
+### Graduation
+
+A task that has stayed at ≥ 95% pass rate for N consecutive runs is a
+graduation candidate — move it from a capability suite to a
+regression suite, and replace it in the capability suite with
+something harder.
+
+### Broken task
+
+A task at ≤ 0% pass rate across multiple runs is **usually a
+task-definition / grader-config bug**, not the agent failing the
+behavior.
+
+```dart
+final analyzer = SuiteHealthAnalyzer(reportStore);
+final health = await analyzer.analyze(
+  suiteName: 'card_agent_capability',
+  recentRunCount: 10,
+);
+
+for (final c in health.graduationCandidates) {
+  print('graduate ${c.taskId}: '
+        '${c.consecutiveMatureRuns} mature runs');
+}
+for (final c in health.brokenTaskCandidates) {
+  print('broken task: ${c.taskId} '
+        '${c.passedTrials}/${c.totalTrials}');
+}
+```
+
+</br>
+
+## Judge calibration
+
+LLM judges are themselves non-deterministic and **must be calibrated
+against human ground truth before going live** (Anthropic Step 5
+threshold: Spearman ≥ 0.7).
+
+```dart
+final calibrator = JudgeCalibrator();
+final report = await calibrator.calibrate(
+  goldenSet: humanLabeledTrials,
+  judgeScorer: (labeled) async {
+    final r = await myLLMJudge.grade(labeled.input, labeled.output);
+    return JudgeScore(value: r.score, rationale: r.reasoning);
+  },
+);
+
+if (!report.meetsAnthropicBar) {
+  throw StateError(
+    'Judge correlation ${report.spearmanCorrelation.toStringAsFixed(2)} '
+    'below 0.7. Top disagreements:\n${report.disagreements.take(5)}',
+  );
+}
+```
+
+Output: Spearman / Pearson correlation, agreement rate, MAE, and a
+disagreement list sorted by |Δ| (the trials where judge and human
+diverged most).
+
+</br>
+
+## CLI tools
+
+```bash
+# List all runs (newest first)
+dart run dart_agent_core:transcripts list --store .eval_reports
+
+# Inspect one trial
+dart run dart_agent_core:transcripts show \
+  --store .eval_reports \
+  --trial pr-123/card_001#0
+
+# Compare the same task across two runs
+dart run dart_agent_core:transcripts diff \
+  --store .eval_reports \
+  --task card_001 --runs main,pr-123
+
+# Export a whole run as Markdown
+dart run dart_agent_core:transcripts export \
+  --store .eval_reports --run pr-123 --format markdown
+```
+
+</br>
+
+## Worked examples
+
+There are three end-to-end runnable demos under `example/eval_demo/`:
+
+| Demo | Suite definition | What it shows |
+|---|---|---|
+| `calculator/` | code | Basic `CodeGrader` + tool-call tracing + decline path |
+| `card_agent/` | code | Multi-grader composition + template choice + substring containment |
+| `pkm_agent/` | **file** | `loadEvalSuiteFromDir` + `GraderRegistry` + fixture files + read-before-write path check |
+
+Run them:
+
+```bash
+export OPENAI_BASE_URL='https://...'
+export OPENAI_API_KEY='sk-...'
+
+dart run example/eval_demo/main.dart --suite calculator
+dart run example/eval_demo/main.dart --suite card_agent
+dart run example/eval_demo/main.dart --suite pkm_agent
+dart run example/eval_demo/main.dart --suite all --concurrency 6
+```
+
+Outputs land in `.eval_reports/` and `.eval_traces/`; with
+`--mode record|replay`, also `.eval_recordings/`.
+
+</br>
+
+## API cheat sheet
+
+```dart
+import 'package:dart_agent_core/eval.dart';
+```
+
+### Core data types
+
+| Type | Purpose |
+|---|---|
+| `EvalTask` | Task interface; implement directly or use `JsonEvalTask` |
+| `EvalSuite` | Task list + kind + thresholds |
+| `Trial` / `TrialId` / `TrialStatus` | One attempt's metadata |
+| `Transcript` / `ToolCallRecord` / `TranscriptMetrics` | "What the agent did" |
+| `Outcome` / `WorkspaceDiff` | "Final environment state" |
+| `TrialResult` | All of the above bundled |
+| `ReferenceSolution` | Anthropic Step 2 known-good answer |
+
+### Grader system
+
+| Type | Purpose |
+|---|---|
+| `Grader` | Base class |
+| `CodeGrader` | Code / deterministic scorer base |
+| `ModelGrader` | LLM-as-judge base |
+| `HumanGrader` / `HumanReviewQueue` | Human review |
+| `Score` / `Assertion` / `GraderKind` | Score output |
+| `GraderRegistry` | Register grader names for file-defined suites |
+
+### Runner & context
+
+| Type | Purpose |
+|---|---|
+| `EvalRunner` | Suite-runner entry point |
+| `EvalRunConfig` / `parseEvalRunArgs` | CLI parsing (run name / concurrency / mode / filter / rpm / tpm / recording-dir) |
+| `EvalRunMode` | `live` / `record` / `replay` |
+| `TaskFilter` | Filter by agent / bucket / id |
+| `EvalEnvironment` | Set up / tear down a trial |
+| `EvalContext` / `EvalClock` | One trial's context: workspace + clock + LLM client + controller |
+| `AgentHarnessFactory` / `AgentHarnessSession` | Agent-scaffolding interface (you implement) |
+| `EvalRunReport` | Aggregated report + saturationStatus |
+
+### Recording / replay / rate limiting
+
+| Type | Purpose |
+|---|---|
+| `LLMRequestHash` / `Sha256LLMRequestHash` | Request hashing |
+| `RecordingStore` / `InMemoryRecordingStore` / `FileRecordingStore` | Recording stores |
+| `RecordingLLMClient` / `ReplayLLMClient` / `RecordingNotFoundException` | Record / replay wrappers |
+| `RateLimitGate` / `RpmRateLimitGate` / `TpmRateLimitGate` / `NoopRateLimitGate` | Rate limits |
+
+### Observability / reporting
+
+| Type | Purpose |
+|---|---|
+| `TraceExporter` / `JsonlTraceExporter` / `CompositeTraceExporter` | Stream trial events |
+| `LangfuseConfig` / `LangfuseClient` / `LangfuseTraceExporter` | Langfuse export (trace / generation / span / score) |
+| `runTranscriptViewer` / `transcriptViewerUsage` | CLI entry points |
+| `ReportStore` / `FileReportStore` | Persist run reports |
+| `PersistedRunReport` / `SuiteSnapshot` / `RunIndexEntry` | Persistence models |
+| `generateMarkdownReport` / `EvalRunReportReporting` | Markdown rendering |
+| `diffRunReports` / `EvalRunReportDiff` / `EvalRunDiff` / `TaskTransition` | Cross-run diff |
+
+### Metrics / health / calibration
+
+| Type / function | Purpose |
+|---|---|
+| `passAtK` / `passCaretK` | Codex unbiased / empirical estimators |
+| `ClassificationMetrics` | P / R / F1 / accuracy |
+| `SaturationStatus` / `SaturationThresholds` / `GraduationCandidate` / `BrokenTaskCandidate` | Saturation |
+| `SuiteHealthAnalyzer` / `SuiteHealthReport` | Cross-run health |
+| `JudgeCalibrator` / `CalibrationReport` / `HumanLabeledTrial` / `TrialDisagreement` | Judge calibration |
+
+### File loading
+
+| Type / function | Purpose |
+|---|---|
+| `loadEvalSuiteFromDir` | Load a suite from a directory |
+| `JsonEvalTask` | Data-driven task |
+| `GraderRegistry` / `GraderFactoryFunction` | Map grader names → factories |
+
+</br>
+
+## References
+
+- [Anthropic Engineering — Demystifying evals for AI agents](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents)

--- a/doc/eval-guide.zh-CN.md
+++ b/doc/eval-guide.zh-CN.md
@@ -1,0 +1,1203 @@
+# dart_agent_core Eval Guide
+
+> 给 Dart Agent 加评估的实操指南。
+
+`dart_agent_core` 内置了一套基于 [Anthropic "Demystifying evals for AI
+agents"](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents)
+方法论的评估子系统。它和 OpenAI Evals / Inspect AI / DeepEval / Promptfoo
+对应同一类工具，但是 Dart-first、本地优先、零外部依赖。
+
+- [核心概念](#核心概念)
+- [组件细节](#组件细节)
+- [快速上手](#快速上手)
+- [两种 suite 定义方式](#两种-suite-定义方式)
+- [三种评分方式](#三种评分方式)
+- [Trial、Outcome 和 Transcript](#trialoutcome-和-transcript)
+- [指标与报告](#指标与报告)
+- [录制 / 回放 / 限流](#录制--回放--限流)
+- [跨 run 健康度](#跨-run-健康度)
+- [Judge 校准](#judge-校准)
+- [CLI 工具](#cli-工具)
+- [完整示例](#完整示例)
+- [API 速查表](#api-速查表)
+- [设计参考](#设计参考)
+
+</br>
+
+## 核心概念
+
+严格对齐 Anthropic 博客术语：
+
+| 概念 | 类型 | 说明 |
+|---|---|---|
+| **Task** | `EvalTask` | 一个测试用例：明确的输入和成功标准 |
+| **Trial** | `Trial` | 一次任务尝试。同一个 task 通常跑多次以观察非确定性 |
+| **Grader** | `Grader` | 给某个 trial 的某一面打分（一个 task 可挂多个 grader） |
+| **Score** / **Assertion** | `Score` / `Assertion` | grader 的输出，含 0–1 数值 + 子检查 + 解释 |
+| **Transcript** | `Transcript` | 一次 trial 的完整运行记录：消息、工具调用、思考、事件、性能指标 |
+| **Outcome** | `Outcome` | trial 结束时**环境状态**（不是它说了啥，是它做了啥） |
+| **Evaluation Harness** | `EvalRunner` | 端到端跑评估的基础设施 |
+| **Agent Harness** | `AgentHarnessFactory` / `AgentHarnessSession` | 让模型像 Agent 一样行动的脚手架（你提供） |
+| **Evaluation Suite** | `EvalSuite` | 一组围绕同一能力/行为的 task |
+
+设计原则（Anthropic Step 5）：**默认看 Outcome，不看 Transcript**。
+"flight booked" 应当看数据库里有没有航班记录，而不是 Agent 是否说了
+"Your flight has been booked"。
+
+</br>
+
+## 组件细节
+
+跑一次评估涉及 5 个角色：
+
+```
+EvalSuite
+  └─ EvalTask × N
+      └─ Trial × trialsPerRun
+          ├─ EvalEnvironment.prepare → EvalContext（工作区/clock/llmClient/controller）
+          ├─ AgentHarnessFactory.create → AgentHarnessSession
+          │      ↓ session.run()
+          │  ┌── Transcript：agent 做了什么（消息/工具调用/事件/性能）
+          │  └── Outcome：环境最终是什么状态
+          ├─ Graders 各自打分 → Score[]
+          └─ EvalEnvironment.dispose
+                  ↓
+          EvalRunReport（pass@k / pass^k / 各 grader 均值 / bucket 分组）
+```
+
+下面把每个角色单独讲一层，**只讲框架本身的契约和字段**。怎么把一个真
+StatefulAgent 接进来，看下一节"快速上手"。
+
+### EvalTask — 一道测试题
+
+接口（每个字段都必填，没有默认值）：
+
+```dart
+abstract class EvalTask {
+  String get id;                          // 全局唯一
+  String get description;                 // 给人看的一句话
+  Map<String, dynamic> get input;         // 任意 JSON，Harness 自己解释
+  Map<String, String> get metadata;       // failure_bucket 等标签
+  ReferenceSolution? get referenceSolution; // 可选：已知正解
+  List<Grader> get graders;               // 这道题挂哪些 grader
+  int get trialsPerRun;                   // 同一道题跑几次（≥2 才能算 pass^k）
+  Duration? get timeout;                  // 单 trial 超时
+}
+```
+
+| 字段 | 注意 |
+|---|---|
+| `id` | **task 含义变了 = 新 id**（如 `card_001` → `card_001_v2`），不要原地改语义。`SuiteHealthAnalyzer` 跨 run 比较时按 id 对齐，复用 id 会污染 graduation / broken-task 判定 |
+| `input` | 不要把 prompt 写死在这里再硬塞给 LLM。让 Harness 决定怎么把 `input` 转成 messages，同一个 task 才能在不同 agent 之间复用 |
+| `metadata['failure_bucket']` | 框架会自动按这个值聚合 bucket pass rate，方便看"哪类失败模式最严重" |
+| `graders` | 一道题可挂多个 grader（"答对" + "用了正确的工具"），每个 grader 独立打分；trial 只有所有 grader 都过线才算 `passed` |
+| `trialsPerRun` | 给 capability suite 用 2–5；regression suite 一般 1。`trialsPerRun=1` 时 pass^k 退化成 pass@1，没意义 |
+
+也支持**不写 Dart 类**，用 JSON 文件 + `JsonEvalTask` 加载，
+[详见后面的章节](#两种-suite-定义方式)。
+
+### EvalSuite — 一组围绕同一 Agent 的 task
+
+```dart
+EvalSuite(
+  name: 'card_capability',
+  agentName: 'card_agent',          // ← suite 维度：这个 suite 测的是哪个 agent
+  kind: SuiteKind.capability,       // capability / regression / mixed
+  tasks: [task1, task2, ...],
+  requireReferenceSolution: false,  // true 时构造期校验所有 task 都有 reference
+  taskPassThreshold: 1.0,           // taskPassRate 算"通过"的阈值
+);
+```
+
+`agentName` **是 suite 维度**而不是 task 维度——同一组 task 不会被
+"换一个 agent" 来复用，这是 Anthropic 博客明确的概念边界。
+
+`kind` 影响 `taskPassRate` 的语义：
+
+| kind | 一个 task 算"通过"的条件 | 用途 |
+|---|---|---|
+| `capability` | 所有 trial 至少有一个通过 | 衡量"会不会"。允许偶尔翻车 |
+| `regression` | 所有 trial 全部通过 | 衡量"稳不稳"。一翻车就 block PR |
+| `mixed` | 同 regression | 还没分级或在过渡 |
+
+### EvalEnvironment — 准备"考场"
+
+```dart
+abstract class EvalEnvironment {
+  Future<EvalContext> prepare({required Trial trial, required EvalTask task});
+  Future<void> dispose(EvalContext context);
+}
+```
+
+Runner 保证**每个 trial 单独调一次 prepare/dispose**——所以你可以在
+prepare 里随便建临时目录、起内存 DB、生成测试用户、**包装 LLM client**，
+dispose 里清掉。
+
+`EvalContext` 是 prepare 的产物：
+
+| 字段 | 说明 |
+|---|---|
+| `workspaceDir` | 该 trial 的临时工作区根。Agent 写文件应该全部在这里面，dispose 删整棵树就行。可以为 `null` |
+| `clock` | 时间源（`SystemEvalClock` / `FixedEvalClock`）。Agent 应读 `ctx.clock.now()` 而不是 `DateTime.now()`，方便锁时间 |
+| `llmClient` | 这次 trial 用的 LLM client。可以是真客户端，也可以是 `RecordingLLMClient` / `ReplayLLMClient` 包装。每个 trial 用独立 client，避免 record/replay 串味 |
+| `controller` | 已经挂好 trace exporter 的 `AgentController`。Harness 必须**复用**它，不要自己 `new AgentController()`，否则 trace 流不到 exporter 上 |
+| `servicesMap` | 应用自己塞 service（`CardRepo` / `UserStorage` / 内存 DB），Harness 用 `ctx.services<T>()` 取。框架不关心里面是什么 |
+| `metadata` | 自由 metadata，会进 transcript |
+
+> **EvalEnvironment 不知道 agent 长什么样**——它只负责准备资源。一个
+> Environment 可以服务多种 Harness（不同 agent 类）。这是它和 Harness
+> 的根本区别，新人最常混淆的就是这里。
+
+### AgentHarnessFactory / AgentHarnessSession — 把模型变成 Agent
+
+```dart
+abstract class AgentHarnessFactory {
+  Future<AgentHarnessSession> create({
+    required EvalTask task, required Trial trial, required EvalContext context,
+  });
+}
+
+abstract class AgentHarnessSession {
+  Future<({Transcript transcript, Outcome outcome})> run();
+  Future<void> dispose();
+}
+```
+
+Harness 是**唯一**知道你 agent 长什么样的层：实例化 `StatefulAgent`、
+注册 `Tool[]`、调 `agent.run([UserMessage(task.input['prompt'])])`、
+等它跑完，从 agent 状态和工作区拼出 transcript + outcome。
+
+`run()` 必须返回**两件**东西：
+
+- `Transcript` — agent **做了什么**：消息序列、工具调用、retry / error
+  事件、turns / tokens 计数。**Grader 一般不该看这个**（看路径而非结果）
+- `Outcome` — 环境**最终是什么状态**：`environmentState` 是任意 Map，
+  schema 由你和 grader 约定。**Grader 默认看这个**
+
+`Outcome.environmentState` 的常见错误：
+
+| ❌ 错（agent 说了什么） | ✅ 对（世界变成了什么） |
+|---|---|
+| `{'agent_said': 'I booked the flight'}` | `{'flight_booked': true, 'flight_id': 'AA123'}` |
+| `{'response': '已记入 Areas/Health.md'}` | `{'updated_files': ['Areas/Health.md'], 'fact_id': 'fact_001'}` |
+| `{'declined': '我不能回答'}` | `{'declined': true, 'submitted_answer': false}` |
+
+#### Outcome 是 Harness 摘要给 Grader 的"事实表"
+
+新人常问的一个问题：**Grader 是怎么知道 agent 写了哪些文件、文件内容
+是什么的？里面跑了一个小 agent 去 list 目录吗？**
+
+不是。**Grader 不读盘、不调 LLM 拿环境信息**。读盘、扫目录、提取事实
+全部在 Harness 的 `run()` 收尾时干完，结果摆进 `Outcome.environmentState`
+和 `Outcome.workspaceDiff` 里——Grader 拿到的就是这份**已经摘要好的快照**。
+
+PKM agent 真实例子（节选自 `example/eval_demo/pkm_agent/harness.dart`）：
+
+```dart
+// Harness.run() 末尾的"事实采集"代码
+Outcome _capturePkmOutcome(Directory ws, SessionState state) {
+  // ① 扫工作区目录
+  final created = <String>[];
+  final snippets = <String, String>{};
+  final pkmRoot = Directory('${ws.path}/PKM');
+  if (pkmRoot.existsSync()) {
+    for (final entry in pkmRoot.listSync(recursive: true)) {
+      if (entry is! File) continue;
+      final rel = entry.path.replaceFirst('${pkmRoot.path}/', '');
+      created.add(rel);
+      snippets[rel] = entry.readAsStringSync();
+    }
+  }
+
+  // ② 从写过的文件里正则抽出 fact_id 之类的关键事实
+  final factIds = <String>{};
+  snippets.forEach((_, body) {
+    final m = RegExp(r'fact_id\s*:\s*(\S+)').firstMatch(body);
+    if (m != null) factIds.add(m.group(1)!);
+  });
+
+  // ③ 检查哨兵文件（agent 调用某些工具会触发副作用文件）
+  final skipped = File('${ws.path}/skipped.txt').existsSync();
+  final insightFile = Directory('${ws.path}/insights').listSync().firstOrNull;
+
+  return Outcome(
+    environmentState: {
+      'wrote_files': created,
+      'fact_ids_in_files': factIds.toList(),
+      'updated_insight': insightFile != null,
+      'skipped': skipped,
+    },
+    workspaceDiff: WorkspaceDiff(created: created, contentSnippets: snippets),
+  );
+}
+```
+
+对应的 Grader 完全不碰文件系统：
+
+```dart
+class PkmOrganizedGrader extends CodeGrader {
+  @override Future<List<Assertion>> computeAssertions({...required Outcome outcome, ...}) async {
+    final wrote = (outcome.environmentState['wrote_files'] as List).cast<String>();
+    final factIds = (outcome.environmentState['fact_ids_in_files'] as List).cast<String>();
+    return [
+      Assertion(
+        description: 'wrote into Areas/',
+        passed: wrote.any((p) => p.startsWith('Areas/')),
+        actual: '$wrote', expected: 'starts with Areas/',
+      ),
+      Assertion(
+        description: 'fact_id appears in file body',
+        passed: factIds.contains(expectedFactId),
+        actual: '$factIds', expected: 'contains $expectedFactId',
+      ),
+    ];
+  }
+}
+```
+
+为什么这样设计：
+
+| 如果让 Grader 自己读盘 | 后果 |
+|---|---|
+| Outcome 失去自包含性 | report 持久化后想离线看也得拖着工作区文件 |
+| 多 grader 重复扫盘 | 一道题挂 3 个 grader，每个都 `listSync`，IO 三遍 |
+| Grader 关心 schema 而不是路径 | 每个 grader 都要懂"PKM 在哪个子目录、用什么文件名约定"——这是 agent 实现细节，不该泄漏到打分逻辑 |
+| 跨 run diff / SuiteHealth 没法做 | `EvalRunReport` 只存 outcome，不存工作区文件 |
+
+LLM judge 同理：judge 也只读 `outcome.environmentState` 的某些字段
+（通常是文本字段或 `workspaceDiff.contentSnippets`），把它塞进 rubric
+prompt 里去问模型，**不会自己开 agent 去探索工作区**。
+
+> **极端情况**：少数场景 grader 真的要"跨多个文件 + 工具 + 推理"
+> （比如审计 agent 写出的整个项目代码一致性）。框架不拦你——grader
+> 拿到的 `EvalContext` 里有 `workspaceDir` / `llmClient` / `servicesMap`，
+> 完全可以在 grader 里再起一个小 agent 去探索。但这是 anti-pattern。
+> 99% 的情况，**先问一遍"是不是该把这部分采集逻辑挪到 Harness 里"**。
+
+### Grader — 评卷
+
+```dart
+abstract class Grader {
+  String get name;
+  double get passThreshold;
+  Future<Score> grade({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  });
+}
+```
+
+按"怎么算分"分三种基类：`CodeGrader`（确定性代码）、`ModelGrader`
+（LLM-as-judge）、`HumanGrader`（推到 review queue 等人评）。
+[详见后面的章节](#三种评分方式)。
+
+输出 `Score`：
+
+| 字段 | 说明 |
+|---|---|
+| `value` | 0..1 的连续分（支持 partial credit）。`null` 表示判不了（如 LLM judge 返回 Unknown） |
+| `passed` | 是否过 `passThreshold`。`null` 当 `value=null` |
+| `assertions` | 子检查列表（`description` / `passed` / `actual` / `expected`），方便人看是哪个子项挂了 |
+| `rationale` | 失败时**必填**：人能看懂的解释。Anthropic Step 5 强调"failures should seem fair" |
+| `metadata` | 自由：可以放 judge 原始回复、diff 详情等 |
+
+### EvalRunner — 跑
+
+不用你实现，调 `runSuite(...)` 就行：
+
+```dart
+final report = await runner.runSuite(
+  runName: 'pr-${prNumber}',         // 这次 run 的标识，进 store / langfuse
+  suite: mySuite,
+  concurrency: 4,                    // 并行 trial 数
+  filter: TaskFilter(...),           // 可选：只跑某些 task
+);
+```
+
+它内部会：
+
+1. 按 `concurrency` 并行起 worker，每个 worker 拿一个 (task, trial) 跑
+2. 每个 trial 单独 `env.prepare()` → `harness.create().run()` → 各 grader 打分 → `env.dispose()`
+3. 把 trial 事件实时推给所有 `exporters`（jsonl / Langfuse / 自定义）
+4. 跑完算 pass@k / pass^k / 各 grader 均值 / bucket 通过率
+5. 把 `EvalRunReport` 落地到 `reportStore`，供后续 diff / SuiteHealthAnalyzer 用
+
+`EvalRunMode`（在 `parseEvalRunArgs` 里读 `--mode` 参数）：
+
+- `live` — 真打 LLM，每次都烧 token
+- `record` — 真打 LLM 同时把请求/响应写入 `RecordingStore`
+- `replay` — 不打 LLM，命中 store 里的录像；不命中报错
+
+CI 上 regression suite 一般 `replay`（毫秒级 + 零成本），capability
+suite nightly 跑 `live`。
+
+</br>
+
+## 快速上手
+
+```bash
+dart pub add dart_agent_core
+```
+
+最小可跑示例。完整源码见 [`example/min_eval/main.dart`](../example/min_eval/main.dart)。
+配置 `OPENAI_API_KEY` / `OPENAI_BASE_URL` / `OPENAI_MODEL` 后 `dart run`：
+
+```dart
+import 'dart:io';
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dart_agent_core/eval.dart';
+
+// ─── 1. 写一个最小的 Agent（只会用 echo 工具回话） ──────────────────────
+const _systemPrompt = '''
+You echo what the user says back through the `echo` tool exactly once.
+Then your turn ends. Do not produce any free-form text.
+''';
+
+List<Tool> _buildTools(Directory ws) => [
+  Tool(
+    name: 'echo',
+    description: 'Echo the input text. Call this exactly once.',
+    parameters: const {
+      'type': 'object',
+      'properties': {'text': {'type': 'string'}},
+      'required': ['text'],
+    },
+    executable: (String text) async {
+      File('${ws.path}/echo.txt').writeAsStringSync(text);
+      return AgentToolResult(content: TextPart('echoed'), stopFlag: true);
+    },
+  ),
+];
+
+// ─── 2. EvalEnvironment：给每个 trial 一个临时工作目录 ──────────────────
+class EchoEnv implements EvalEnvironment {
+  final OpenAIClient Function() clientFactory;
+  EchoEnv(this.clientFactory);
+
+  @override
+  Future<EvalContext> prepare({required Trial trial, required EvalTask task}) async {
+    final dir = await Directory.systemTemp.createTemp('echo_eval_');
+    return EvalContext(
+      workspaceDir: dir,
+      clock: const SystemEvalClock(),
+      llmClient: clientFactory(),
+      controller: AgentController(),
+    );
+  }
+
+  @override
+  Future<void> dispose(EvalContext ctx) async {
+    final d = ctx.workspaceDir;
+    if (d != null && await d.exists()) await d.delete(recursive: true);
+    ctx.controller.close();
+  }
+}
+
+// ─── 3. AgentHarnessFactory：把模型包装成一个会调工具的 Agent ────────────
+class EchoHarness implements AgentHarnessFactory {
+  final ModelConfig modelConfig;
+  EchoHarness(this.modelConfig);
+
+  @override
+  Future<AgentHarnessSession> create({
+    required EvalTask task,
+    required Trial trial,
+    required EvalContext context,
+  }) async => _EchoSession(task: task, ctx: context, modelConfig: modelConfig);
+}
+
+class _EchoSession implements AgentHarnessSession {
+  final EvalTask task;
+  final EvalContext ctx;
+  final ModelConfig modelConfig;
+  _EchoSession({required this.task, required this.ctx, required this.modelConfig});
+
+  @override
+  Future<({Transcript transcript, Outcome outcome})> run() async {
+    final agent = StatefulAgent(
+      name: 'echo_agent',
+      client: ctx.llmClient,
+      modelConfig: modelConfig,
+      state: AgentState(sessionId: '${task.id}'),
+      tools: _buildTools(ctx.workspaceDir!),
+      systemPrompts: [_systemPrompt],
+      controller: ctx.controller,
+      withGeneralPrinciples: false,
+      planMode: PlanMode.none,
+      disableSubAgents: true,
+      autoSaveStateFunc: (_) async {},
+    );
+    await agent.run([
+      UserMessage([TextPart(task.input['prompt'] as String)]),
+    ], useStream: false);
+
+    final f = File('${ctx.workspaceDir!.path}/echo.txt');
+    final echoed = f.existsSync() ? f.readAsStringSync() : null;
+
+    return (
+      transcript: Transcript(
+        messages: List.unmodifiable(agent.state.history.messages),
+        toolCalls: const [],
+        metrics: const TranscriptMetrics(nTurns: 0, nToolCalls: 0, nTotalTokens: 0),
+      ),
+      outcome: Outcome(environmentState: {'echoed': ?echoed}),
+    );
+  }
+
+  @override
+  Future<void> dispose() async {}
+}
+
+// ─── 4. Grader：echoed == 期望的文本 ─────────────────────────────────────
+class _EchoMatchesGrader extends CodeGrader {
+  final String expected;
+  _EchoMatchesGrader(this.expected);
+  @override String get name => 'echo_matches';
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async => [
+    Assertion(
+      description: 'echoed text matches expected',
+      passed: outcome.environmentState['echoed'] == expected,
+      actual: '${outcome.environmentState['echoed']}',
+      expected: expected,
+    ),
+  ];
+}
+
+// ─── 5. EvalTask + EvalSuite ─────────────────────────────────────────────
+class _EchoTask implements EvalTask {
+  @override String get id => 'echo_hi';
+  @override String get description => 'agent must echo "hi" verbatim';
+  @override Map<String, dynamic> get input => {'prompt': 'echo this back: hi'};
+  @override Map<String, String> get metadata => const {};
+  @override ReferenceSolution? get referenceSolution => null;
+  @override List<Grader> get graders => [_EchoMatchesGrader('hi')];
+  @override int get trialsPerRun => 2;
+  @override Duration? get timeout => const Duration(minutes: 1);
+}
+
+// ─── 6. main：拼起来跑 ────────────────────────────────────────────────────
+Future<void> main() async {
+  final env = Platform.environment;
+  OpenAIClient client() => OpenAIClient(
+    apiKey: env['OPENAI_API_KEY']!,
+    baseUrl: env['OPENAI_BASE_URL'] ?? 'https://api.openai.com/v1',
+  );
+
+  final runner = EvalRunner(
+    environment: EchoEnv(client),
+    harnessFactory: EchoHarness(ModelConfig(model: env['OPENAI_MODEL'] ?? 'gpt-4o-mini')),
+    exporters: [JsonlTraceExporter(File('.eval_traces/echo.jsonl'))],
+    reportStore: FileReportStore(Directory('.eval_reports')),
+  );
+
+  final report = await runner.runSuite(
+    runName: 'echo_${DateTime.now().millisecondsSinceEpoch}',
+    suite: EvalSuite(
+      name: 'echo_capability',
+      agentName: 'echo_agent',
+      kind: SuiteKind.capability,
+      tasks: [_EchoTask()],
+    ),
+    concurrency: 2,
+  );
+
+  stdout.writeln(report.toMarkdownSummary());
+  exit(report.taskPassRate >= 1.0 ? 0 : 1);
+}
+```
+
+输出：
+
+- `.eval_reports/<run_name>.json` — 完整 run report，可被 transcripts CLI 加载
+- `.eval_reports/index.jsonl` — 跨 run 索引
+- `.eval_traces/echo.jsonl` — OTel 风格的 trace 流
+- stdout — Markdown 报告（task / trial pass rate、pass@k、各 grader 均值）
+
+更复杂场景（多 grader、文件 fixture、多 task、record/replay、跨 run
+diff）见 [`example/eval_demo/`](../example/eval_demo/) 下的三个 demo
+（`calculator/`、`card_agent/`、`pkm_agent/`）。
+
+</br>
+
+## 两种 suite 定义方式
+
+`dart_agent_core` 同时支持**代码定义**和**文件定义**两种 suite。
+两种方式可以混用。
+
+### 方式 A — 代码定义（`EvalSuite(...)` + `EvalTask` 子类）
+
+适合 task 数量少、强类型校验、需要重构跟随的场景。`example/eval_demo/calculator/`
+和 `example/eval_demo/card_agent/` 都是这种风格。
+
+```dart
+class _SimpleAdditionTask implements EvalTask {
+  @override String get id => 'task_simple_addition';
+  @override String get description => 'Single-step addition';
+  @override Map<String, dynamic> get input => {'prompt': 'What is 2 + 3?'};
+  @override List<Grader> get graders => [
+    AnswerCorrectnessGrader(expected: 5),
+    ToolUsageGrader(minArithmeticCalls: 1),
+  ];
+  @override int get trialsPerRun => 2;
+  @override Duration? get timeout => const Duration(minutes: 2);
+}
+
+EvalSuite buildSuite() => EvalSuite(
+  name: 'calculator_demo',
+  agentName: 'calculator_demo_agent',  // ← suite-level: 这个 suite 里所有 task 都打的是同一个 agent
+  kind: SuiteKind.mixed,
+  tasks: [_SimpleAdditionTask(), ...],
+  requireReferenceSolution: true,
+);
+```
+
+### 方式 B — 文件定义（目录布局 + `loadEvalSuiteFromDir`）
+
+适合 task 集会持续扩张、产品同学/QA 想直接 PR 加 case、case 需要按
+故障类别分目录的场景。`example/eval_demo/pkm_agent/suites/` 是这种风格。
+
+目录布局：
+
+```
+suites/
+  pkm_capability/
+    suite.json                    ← 元数据
+    tasks/                        ← 一个 task 一个 JSON
+      positive/                   ← 子目录可选，仅做组织
+        pkm_area_health.json
+        pkm_resource_reading.json
+        pkm_append_to_existing.json
+      negative/
+        pkm_skip_trivial.json
+```
+
+`suite.json`：
+
+```json
+{
+  "name": "pkm_agent_demo",
+  "agent_name": "pkm_agent_demo",
+  "kind": "mixed",
+  "requireReferenceSolution": true,
+  "taskPassThreshold": 1.0
+}
+```
+
+每个 task 文件：
+
+```json
+{
+  "id": "pkm_area_health",
+  "description": "Long-term health habit: should write under Areas/.",
+  "trials_per_run": 2,
+  "timeout_seconds": 180,
+  "metadata": {"failure_bucket": "route_to_areas"},
+  "input": {"prompt": "..."},
+  "reference_solution": {
+    "expected_outcome": {"updated_insight": true, "skipped": false},
+    "source": "manual"
+  },
+  "graders": [
+    {"name": "pkm_organized",
+     "config": {"fact_id": "fact_pkm_001",
+                "buckets": ["Areas/"],
+                "must_contain": ["mobility"]}}
+  ]
+}
+```
+
+加载：
+
+```dart
+final reg = GraderRegistry()
+  ..register('pkm_organized', (cfg) => PkmOrganizedGrader(
+        expectedFactId: cfg['fact_id'] as String,
+        expectedBuckets: (cfg['buckets'] as List).cast<String>(),
+        mustContainSubstrings:
+            (cfg['must_contain'] as List?)?.cast<String>() ?? const [],
+      ))
+  ..register('pkm_skipped', (_) => PkmSkippedGrader())
+  ..register('read_before_write', (_) => PkmReadBeforeWriteGrader());
+
+final suite = loadEvalSuiteFromDir(
+  Directory('suites/pkm_capability'),
+  graderRegistry: reg,
+);
+```
+
+| 维度 | 代码定义 | 文件定义 |
+|---|---|---|
+| 写起来快 | ✅ IDE 补全、类型安全 | 🔶 要手动编 JSON |
+| 大规模维护 | 🔶 case 多了文件会臃肿 | ✅ 一个 task 一个文件，git diff 友好 |
+| 非工程师能否参与 | ❌ 必须懂 Dart | ✅ 写 JSON 即可 |
+| 重构跟随 | ✅ rename grader 编译器报错 | 🔶 要手动改 JSON 里的 grader name |
+| 何时用 | demo / 框架内部测试 / 类型敏感场景 | 业务方 case 库 / 跨团队协作 |
+
+> **建议**：开发期用代码定义快速迭代，case 集稳定后导出成 JSON。
+> grader 永远是代码（强类型 + 可调试），task 数据可以是代码也可以是文件。
+
+</br>
+
+## 三种评分方式
+
+Anthropic 把评分器分为三类，框架都内置了基类。
+
+### 1. Code-based（`CodeGrader`）—— 确定性、最快
+
+适合：精确字符串匹配、数值比较、文件存在性、JSON schema 校验、tool call
+出现次数等可以用代码精确判定的检查。
+
+```dart
+class AnswerCorrectnessGrader extends CodeGrader {
+  final num expected;
+  final double tolerance;
+  AnswerCorrectnessGrader({required this.expected, this.tolerance = 1e-9});
+
+  @override String get name => 'answer_correctness';
+
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async {
+    final actual = (outcome.environmentState['answer'] as num?)?.toDouble();
+    return [
+      Assertion(
+        description: 'answer == $expected within $tolerance',
+        passed: actual != null
+            && (actual - expected.toDouble()).abs() <= tolerance,
+        actual: '$actual',
+        expected: '$expected',
+      ),
+    ];
+  }
+}
+```
+
+`CodeGrader` 把 `Assertion` 列表自动聚合成 `Score(value, passed)`：
+
+- `value = 通过的 assertion 数 / 总 assertion 数`
+- `passed = value >= passThreshold`，默认 `passThreshold = 1.0`（全部通过）
+- 失败时自动生成包含失败 assertion 的 rationale
+
+### 2. Model-based（`ModelGrader` / LLM-as-judge）—— 灵活、可处理主观任务
+
+适合：开放式回答的相关性、风格一致性、安全性等 code-based 难以判定的维度。
+
+```dart
+class StyleJudgeGrader extends ModelGrader {
+  @override final LLMClient judgeClient;
+  @override final String rubric;
+  final ModelConfig modelConfig;
+  @override final String name = 'style_quality';
+
+  StyleJudgeGrader({
+    required this.judgeClient,
+    required this.rubric,
+    required this.modelConfig,
+  });
+
+  @override double get passThreshold => 0.7;
+
+  @override
+  Future<Score> grade({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async {
+    final prompt = '$rubric\n\nOutput: ${outcome.environmentState["text"]}\n'
+        'Reply: SCORE=<float 0-1> or SCORE=Unknown';
+    final reply = await judgeClient.generate(
+      [UserMessage.text(prompt)],
+      modelConfig: modelConfig,
+    );
+    // 解析回复并返回 Score（含 Unknown escape hatch）
+    ...
+  }
+}
+```
+
+**Anthropic Step 5 关键点**：rubric 必须留 `Unknown` 退路。如果 judge
+拿不准，应当返回 `Score(value: null, passed: null)` 而不是硬编一个分数。
+这种 null score 会从 grader mean 中排除，但单独统计。
+
+### 3. Human-based（`HumanGrader` + `HumanReviewQueue`）—— 标准、最慢
+
+`HumanGrader` 把 trial 推到一个 `HumanReviewQueue`（接口由你实现，
+对接 Langfuse Annotation Queue / 自建 Web / Slack 工作流均可）：
+
+```dart
+abstract class HumanReviewQueue {
+  Future<void> enqueue({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    String? rubric,
+    Map<String, dynamic> metadata,
+  });
+  Future<Score?> fetchVerdict(Trial trial);
+}
+```
+
+第一次 grade 时入队 + 返回 pending null score；评审员打完分后下次
+跑 grade 拿到结果。主要用途是**校准 LLM judge**（见 [Judge 校准](#judge-校准)），
+而不是给每次 run 打分。
+
+</br>
+
+## Trial、Outcome 和 Transcript
+
+每次 trial 的产出是 `TrialResult`：
+
+```dart
+class TrialResult {
+  final Trial trial;            // run / suite / task / index / status / 时间
+  final Transcript transcript;  // 消息 + 工具调用 + 事件 + 性能指标
+  final Outcome outcome;        // 环境最终状态
+  final List<Score> scores;     // 各 grader 的输出
+}
+```
+
+### Transcript（"Agent 做了什么"）
+
+```dart
+class Transcript {
+  final List<LLMMessage> messages;
+  final List<ToolCallRecord> toolCalls;
+  final List<String> reasoningSteps;
+  final List<TranscriptEvent> events;       // retry / exception / 自定义
+  final TranscriptMetrics metrics;          // turns / tokens / TTFT / TTLT
+}
+```
+
+### Outcome（"环境最终是什么状态"）
+
+```dart
+class Outcome {
+  final Map<String, dynamic> environmentState;  // 应用自定义 schema
+  final WorkspaceDiff? workspaceDiff;           // 文件级别 diff
+}
+```
+
+**Anthropic Step 5 反复强调**：grader 默认看 `outcome`，只有在判断"路径
+是否合理"时才动 `transcript`（例如"必须调用某个工具"才看 `transcript.toolCalls`）。
+
+</br>
+
+## 指标与报告
+
+`EvalRunReport` 自动算所有 Anthropic 推荐的指标。
+
+### Pass-rate（按 suite kind 分语义）
+
+- `trialPassRate` —— 通过 trial 数 / 总 trial 数
+- `taskPassRate` ——
+  - `SuiteKind.capability`: 一个 task 至少有一个 trial 通过即算通过
+  - `SuiteKind.regression`: 一个 task 所有 trial 都通过才算通过
+  - `SuiteKind.mixed`: 同 regression
+
+### pass@k（Codex 无偏估计）
+
+`pass@k = 1 − C(n−c, k) / C(n, k)`。"k 次尝试至少成功一次"的概率。
+
+### pass^k（经验估计）
+
+`pass^k = (c/n)^k`。"k 次尝试全部成功"的概率。Anthropic 推荐
+**pass@1 接近 100%、pass^k 的 k 越大越好**（连续稳定通过的能力）。
+
+```dart
+final passAt = report.passAtKByTask(ks: [1, 3, 5]);
+final passCk = report.passCaretKByTask(ks: [1, 3, 5]);
+```
+
+### Bucket 分组
+
+按 `metadata['failure_bucket']` 看每个失败模式的通过率：
+
+```dart
+final byBucket = report.bucketPassRates({
+  for (final t in suite.tasks)
+    if (t.metadata['failure_bucket'] != null)
+      t.id: t.metadata['failure_bucket']!,
+});
+// {tool_use: 0.92, intent_routing: 0.65, …}
+```
+
+### 分类指标（`ClassificationMetrics`）
+
+二分类任务（Memory Agent 应不应该写记忆、Schedule Router 应不应该刷新）
+直接用 P/R/F1：
+
+```dart
+const m = ClassificationMetrics(
+  truePositives: 6, falsePositives: 2,
+  trueNegatives: 8, falseNegatives: 4,
+);
+print(m.precision); // 0.75
+print(m.recall);    // 0.6
+print(m.f1);        // 0.6667
+```
+
+### Markdown 报告 + Diff
+
+```dart
+// 单 run 报告
+final md = report.toMarkdownSummary(taskBucketMap: {...});
+File('report.md').writeAsStringSync(md);
+
+// 跨 run diff（PR 评论用）
+final baseline = await store.load('main');
+final diff = report.diffWith(baseline!);
+File('diff.md').writeAsStringSync(diff.toMarkdown());
+```
+
+</br>
+
+## 录制 / 回放 / 限流
+
+每次跑评估都打真实 LLM 既慢又贵，CI 还会被网络抖动搞挂。框架提供
+**确定性回放**和**速率限制**两层基础设施。
+
+### 录制 / 回放
+
+```dart
+// 第一次跑：录制
+final store = FileRecordingStore(Directory('.eval_recordings'));
+final llm = RecordingLLMClient(
+  inner: OpenAIClient(...),
+  store: store,
+);
+
+// 后续 CI：回放（命中即返回缓存，不命中报错）
+final replay = ReplayLLMClient(
+  store: FileRecordingStore(Directory('.eval_recordings')),
+  strictReplay: true,  // CI 必须严格
+);
+```
+
+请求 hash 由 `Sha256LLMRequestHash` 计算（默认）：
+
+- 包含 `messages` / `tools` / `modelConfig` / `jsonOutput` / `trialSalt`
+- 可通过 `stripMessageKeys` 跳过易变字段（`timestamp` 等）
+- prompt 或 tools 改了 → hash 变 → 缓存自动失效，CI 报错提示 re-record
+
+#### 多 trial 的非确定性 — `trialSalt`
+
+`trialsPerRun > 1` 时，同一个 task 的所有 trial 发出去的请求字面意义
+上完全一样（同 prompt、同 tools、同 model）。如果 hash 只看请求内容，
+N 个 trial 会塌成 1 份缓存，**pass^k / pass@k 测的就不再是模型的非确
+定性而是缓存的回放结果**，违背 Anthropic Step 6。
+
+框架的解法：每个 trial 独立 salt 进 hash。`EvalEnvironment.prepare()`
+拿到 `Trial` 之后，把 `trial.cacheSalt`（形如 `taskId#trialIndex`，
+**不**含 runName，这样录的时候和回放时跨 run 仍能命中）传给
+`RecordingLLMClient` / `ReplayLLMClient` 的 `trialSalt`。N 个 trial
+在缓存里就是 N 个独立条目，录的时候录 N 份不同响应，回放的时候每个
+trial 拿到对应 trial 的那一份。
+
+```dart
+// EvalEnvironment.prepare 内部：
+final salt = trial.cacheSalt;
+final llmClient = RecordingLLMClient(
+  inner: liveClientFactory(),
+  store: store,
+  trialSalt: salt,           // ← 关键
+);
+// 或者：base.withTrialSalt(salt)，更省一行
+```
+
+`trialSalt: null`（不传）则 cache 在所有 trial 之间共享。这种行为是
+为了 judge / ad-hoc analysis 这种"逻辑上同一个调用"的场景准备的，
+通常**不**是 agent 主调用想要的。三个内置 demo（calculator / card /
+pkm）的 environment 都示范了正确做法。
+
+### 限流
+
+```dart
+final gate = RpmRateLimitGate(requestsPerMinute: 120);
+// 或 token 维度
+final gate = TpmRateLimitGate(tokensPerMinute: 60000);
+
+final llm = RecordingLLMClient(
+  inner: ...,
+  store: ...,
+  rateLimitGate: gate,
+);
+```
+
+`acquire()` 在调真实 LLM 前阻塞，回放命中时**不**触发限流（已经是
+本地操作了）——这样 concurrency 和 rate-limit 解耦：可以把
+`concurrency` 调大充分压榨 CPU / IO，速率上限交给闸门控制。
+
+</br>
+
+## Langfuse 上报
+
+把每个 trial 实时上报到 [Langfuse](https://langfuse.com/) 是开箱即用的。
+Langfuse 是当下最主流的开源 LLM observability 后端，自带 trace 树视图、
+按 user/session/tag 过滤、在线 score 评分、prompt diff 等功能。
+
+```dart
+import 'package:dart_agent_core/eval.dart';
+
+final exporter = LangfuseTraceExporter(LangfuseConfig.fromEnv());
+// 或显式传配置：
+//   LangfuseConfig(
+//     host: 'https://cloud.langfuse.com',  // 自托管时改成你的地址
+//     publicKey: 'pk-...',
+//     secretKey: 'sk-...',
+//     environment: 'staging',
+//   );
+
+final runner = EvalRunner(
+  environment: env,
+  harnessFactory: harness,
+  exporters: [
+    JsonlTraceExporter(File('.eval_traces/run.jsonl')),
+    exporter,           // 同时本地落盘 + 上报 Langfuse
+  ],
+  reportStore: FileReportStore(Directory('.eval_reports')),
+);
+```
+
+映射规则：
+
+| dart_agent_core | Langfuse |
+|---|---|
+| 一个 `Trial` | 一个 trace（`name = suite/task#trialIndex`，`userId = runName`，`sessionId = suiteName`） |
+| 每次 LLM 调用 | `generation-create` observation，含 `model` / `modelParameters` / `input` / `output` / `usage` |
+| 每次 tool 调用 | `span-create` observation，含 `arguments` / `result` |
+| 每个 `Score` | `score-create`（`dataType=NUMERIC`，`comment=rationale`，`assertions`/`metadata` 一并挂上） |
+| `onRunEnd` 的 aggregate | 一个 `run-summary` trace + 每个指标一条 `score-create` |
+
+实现细节：
+
+- 全部走后台批量队列：默认满 50 条 event 或每 1 秒 flush 一次，eval run
+  几乎感知不到上报开销
+- HTTP 5xx 自动指数退避重试（默认 3 次），4xx 直接放弃不重试
+- 网络抖动 / langfuse 临时挂掉时**最多丢几条 event，不会拖垮 eval run**
+- 跑 `dispose()` 强制 flush 完所有积压
+
+环境变量约定（`LangfuseConfig.fromEnv` 读这些）：
+
+```bash
+export LANGFUSE_PUBLIC_KEY='pk-...'
+export LANGFUSE_SECRET_KEY='sk-...'
+export LANGFUSE_HOST='https://cloud.langfuse.com'  # 可选，默认 cloud
+export LANGFUSE_ENVIRONMENT='staging'              # 可选，dashboard 上分桶用
+```
+
+</br>
+
+## 跨 run 健康度
+
+`SuiteHealthAnalyzer` 跨多次 run 算两件事（Anthropic Step 7）：
+
+### Graduation（毕业）
+
+某个 task 连续 N 次 run 都通过率 ≥ 95%，建议从 capability suite
+"毕业"到 regression suite，并在 capability suite 里换上更难的 task。
+
+### Broken task（破损 task）
+
+某个 task 跨多次 run 都通过率 ≤ 0%，**通常是 task 定义/grader
+配置有 bug**，不是 Agent 真做不到。
+
+```dart
+final analyzer = SuiteHealthAnalyzer(reportStore);
+final health = await analyzer.analyze(
+  suiteName: 'card_agent_capability',
+  recentRunCount: 10,
+);
+
+for (final c in health.graduationCandidates) {
+  print('graduate ${c.taskId}: '
+        '${c.consecutiveMatureRuns} mature runs');
+}
+for (final c in health.brokenTaskCandidates) {
+  print('broken task: ${c.taskId} '
+        '${c.passedTrials}/${c.totalTrials}');
+}
+```
+
+</br>
+
+## Judge 校准
+
+LLM judge 自己也是非确定的，必须**用人工评分校准**才能上线（Anthropic
+Step 5 上线门槛：Spearman ≥ 0.7）。
+
+```dart
+final calibrator = JudgeCalibrator();
+final report = await calibrator.calibrate(
+  goldenSet: humanLabeledTrials,
+  judgeScorer: (labeled) async {
+    final r = await myLLMJudge.grade(labeled.input, labeled.output);
+    return JudgeScore(value: r.score, rationale: r.reasoning);
+  },
+);
+
+if (!report.meetsAnthropicBar) {
+  throw StateError(
+    'Judge correlation ${report.spearmanCorrelation.toStringAsFixed(2)} '
+    'below 0.7. Top disagreements:\n${report.disagreements.take(5)}',
+  );
+}
+```
+
+输出：Spearman / Pearson 相关系数、agreement rate、MAE、按 |Δ| 降序的
+disagreement 列表（哪些 trial 上 judge 和人工最分歧）。
+
+</br>
+
+## CLI 工具
+
+```bash
+# 列出所有 run（按时间倒序）
+dart run dart_agent_core:transcripts list --store .eval_reports
+
+# 查看某次 trial 的细节
+dart run dart_agent_core:transcripts show \
+  --store .eval_reports \
+  --trial pr-123/card_001#0
+
+# 同一个 task 跨两次 run 对比
+dart run dart_agent_core:transcripts diff \
+  --store .eval_reports \
+  --task card_001 --runs main,pr-123
+
+# 把整个 run 导出成 markdown
+dart run dart_agent_core:transcripts export \
+  --store .eval_reports --run pr-123 --format markdown
+```
+
+</br>
+
+## 完整示例
+
+`example/eval_demo/` 里有三个端到端可运行的 demo：
+
+| Demo | Suite 定义方式 | 演示内容 |
+|---|---|---|
+| `calculator/` | 代码 | 基础 `CodeGrader` + 工具调用追踪 + decline 路径 |
+| `card_agent/` | 代码 | 多 grader 组合 + 模板选择 + 字符串包含检查 |
+| `pkm_agent/` | **文件** | `loadEvalSuiteFromDir` + `GraderRegistry` + fixture 文件 + read-before-write 路径检查 |
+
+跑：
+
+```bash
+export OPENAI_BASE_URL='https://...'
+export OPENAI_API_KEY='sk-...'
+
+dart run example/eval_demo/main.dart --suite calculator
+dart run example/eval_demo/main.dart --suite card_agent
+dart run example/eval_demo/main.dart --suite pkm_agent
+dart run example/eval_demo/main.dart --suite all --concurrency 6
+```
+
+输出会落到 `.eval_reports/`、`.eval_traces/`，
+`--mode record|replay` 时还会用 `.eval_recordings/`。
+
+</br>
+
+## API 速查表
+
+```dart
+import 'package:dart_agent_core/eval.dart';
+```
+
+### 核心数据类型
+
+| 类型 | 用途 |
+|---|---|
+| `EvalTask` | task 定义接口；自实现或用 `JsonEvalTask` |
+| `EvalSuite` | task 列表 + kind + 阈值 |
+| `Trial` / `TrialId` / `TrialStatus` | 一次尝试的元数据 |
+| `Transcript` / `ToolCallRecord` / `TranscriptMetrics` | "Agent 做了什么" |
+| `Outcome` / `WorkspaceDiff` | "环境最终状态" |
+| `TrialResult` | 上面三件套的合体 |
+| `ReferenceSolution` | Anthropic Step 2 已知正解 |
+
+### Grader 体系
+
+| 类型 | 用途 |
+|---|---|
+| `Grader` | 基类 |
+| `CodeGrader` | 代码 / 确定性评分基类 |
+| `ModelGrader` | LLM-as-judge 基类 |
+| `HumanGrader` / `HumanReviewQueue` | 人工评分 |
+| `Score` / `Assertion` / `GraderKind` | 评分输出 |
+| `GraderRegistry` | 文件定义 suite 时按名字注册 grader |
+
+### Runner 与上下文
+
+| 类型 | 用途 |
+|---|---|
+| `EvalRunner` | 跑 suite 的入口 |
+| `EvalRunConfig` / `parseEvalRunArgs` | CLI 参数解析（run name / concurrency / mode / filter / rpm / tpm / recording-dir） |
+| `EvalRunMode` | `live` / `record` / `replay` |
+| `TaskFilter` | 按 agent / bucket / id 过滤 |
+| `EvalEnvironment` | 准备 / 销毁 trial 上下文 |
+| `EvalContext` / `EvalClock` | 单 trial 上下文：workspace + clock + LLM client + controller |
+| `AgentHarnessFactory` / `AgentHarnessSession` | Agent 脚手架接口（你实现） |
+| `EvalRunReport` | 聚合报告 + saturationStatus |
+
+### 录制 / 回放 / 限流
+
+| 类型 | 用途 |
+|---|---|
+| `LLMRequestHash` / `Sha256LLMRequestHash` | 请求哈希 |
+| `RecordingStore` / `InMemoryRecordingStore` / `FileRecordingStore` | 录制存储 |
+| `RecordingLLMClient` / `ReplayLLMClient` / `RecordingNotFoundException` | 录 / 回 包装 |
+| `RateLimitGate` / `RpmRateLimitGate` / `TpmRateLimitGate` / `NoopRateLimitGate` | 限流 |
+
+### 观测 / 报告
+
+| 类型 | 用途 |
+|---|---|
+| `TraceExporter` / `JsonlTraceExporter` / `CompositeTraceExporter` | 流式导出 trial 事件 |
+| `LangfuseConfig` / `LangfuseClient` / `LangfuseTraceExporter` | Langfuse 上报（trace / generation / span / score） |
+| `runTranscriptViewer` / `transcriptViewerUsage` | CLI 入口 |
+| `ReportStore` / `FileReportStore` | run report 持久化 |
+| `PersistedRunReport` / `SuiteSnapshot` / `RunIndexEntry` | 持久化模型 |
+| `generateMarkdownReport` / `EvalRunReportReporting` | Markdown 渲染 |
+| `diffRunReports` / `EvalRunReportDiff` / `EvalRunDiff` / `TaskTransition` | 跨 run diff |
+
+### 指标 / 健康度 / 校准
+
+| 类型 / 函数 | 用途 |
+|---|---|
+| `passAtK` / `passCaretK` | Codex / 经验估计 |
+| `ClassificationMetrics` | P / R / F1 / accuracy |
+| `SaturationStatus` / `SaturationThresholds` / `GraduationCandidate` / `BrokenTaskCandidate` | 饱和度 |
+| `SuiteHealthAnalyzer` / `SuiteHealthReport` | 跨 run 健康度 |
+| `JudgeCalibrator` / `CalibrationReport` / `HumanLabeledTrial` / `TrialDisagreement` | judge 校准 |
+
+### 文件加载
+
+| 类型 / 函数 | 用途 |
+|---|---|
+| `loadEvalSuiteFromDir` | 从目录加载 suite |
+| `JsonEvalTask` | 数据驱动 task |
+| `GraderRegistry` / `GraderFactoryFunction` | grader 名字 → 工厂 |
+
+</br>
+
+## 设计参考
+
+- [Anthropic Engineering — Demystifying evals for AI agents](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents)

--- a/example/eval_demo/README.md
+++ b/example/eval_demo/README.md
@@ -1,0 +1,78 @@
+# eval_demo — calculator agent end-to-end demo
+
+A minimal but full demo of the eval subsystem. One agent, one
+suite, three tasks (positive · positive · negative), and a real LLM call
+through any OpenAI-compatible endpoint.
+
+## What it shows
+
+- **Agent under test** (`agent.dart`): four arithmetic tools
+  (`add` / `subtract` / `multiply` / `divide`) plus a structured
+  submission protocol (`submit_answer` / `decline`). System prompt forces
+  the agent to use tools instead of computing mentally and to decline
+  off-topic prompts.
+- **`EvalEnvironment`** (`environment.dart`): per-trial temp directory,
+  optional record/replay wrapping for the LLM client.
+- **`AgentHarnessFactory`** (`harness.dart`): subscribes to the
+  `AgentController` event bus to assemble a `Transcript`
+  (messages + tool calls + retries + exceptions + timing + tokens) and
+  reads `answer.txt` / `declined.txt` from the workspace to produce an
+  `Outcome`.
+- **Tasks** (`tasks.dart`): three `EvalTask` implementations
+  (single-step add, multi-step compose, off-topic decline) covering both
+  Anthropic positive and negative cases. Each declares its own graders,
+  reference solution, metadata, trials/run, and timeout.
+- **Graders** (`graders.dart`): `AnswerCorrectnessGrader`,
+  `ToolUsageGrader`, `DeclineGrader` — all `CodeGrader` subclasses that
+  inspect the outcome and the transcript.
+- **Runner glue** (`main.dart`): wires `EvalRunner` with a
+  `JsonlTraceExporter`, a `FileReportStore`, a `RecordingStore`
+  (when `--mode record|replay`), and an `RpmRateLimitGate` (when
+  `--rpm` is set). Generates a Markdown report per run.
+
+## Run it
+
+```bash
+# OpenAI-compatible endpoint (works with OpenAI, OpenRouter, …)
+export OPENAI_BASE_URL='https://...'
+export OPENAI_API_KEY='sk-...'
+
+# Optional: pick a different model.
+# export EVAL_MODEL='openai/gpt-5.4'
+
+dart pub get
+dart run example/eval_demo/main.dart \
+  --run-name demo_run_1 \
+  --concurrency 2 \
+  --mode live
+```
+
+Output:
+
+- `./.eval_reports/<run_name>.md` — Markdown summary.
+- `./.eval_reports/reports/<run_name>.json` — full report (trials,
+  scores, outcome).
+- `./.eval_reports/index.jsonl` — append-only run index.
+- `./.eval_traces/<run_name>.jsonl` — JSONL trace (one event per line).
+
+The exit code reflects task pass rate: `0` if all tasks passed, `1`
+otherwise.
+
+## Modes
+
+- `--mode live`   — call the real LLM, no recording.
+- `--mode record` — call the real LLM and write recordings to
+  `--recording-dir` (default `./.eval_recordings`).
+- `--mode replay` — read recordings only; raises on a miss.
+
+## Inspect transcripts
+
+```bash
+dart run bin/transcripts.dart list  --store .eval_reports
+dart run bin/transcripts.dart show  --store .eval_reports \
+  --trial demo_run_1/task_multi_step#0
+dart run bin/transcripts.dart diff  --store .eval_reports \
+  --task task_multi_step --runs demo_run_1,demo_run_2
+dart run bin/transcripts.dart export --store .eval_reports \
+  --run demo_run_1 --format markdown
+```

--- a/example/eval_demo/_shared/agent_harness.dart
+++ b/example/eval_demo/_shared/agent_harness.dart
@@ -1,0 +1,209 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dart_agent_core/eval.dart';
+
+/// Shared `AgentHarnessSession` implementation used by every agent demo.
+///
+/// Each demo provides:
+///   - the system prompt
+///   - the tool list (a function so the workspace can be threaded in)
+///   - a `captureOutcome` callback that reads disk state at the end of
+///     the run and produces the [Outcome] map.
+///
+/// Everything else (event-bus wiring, transcript assembly, message
+/// snapshot) is identical across demos.
+class GenericAgentSession implements AgentHarnessSession {
+  final EvalTask task;
+  final Trial trial;
+  final EvalContext context;
+  final ModelConfig modelConfig;
+  final String agentName;
+  final String systemPrompt;
+  final List<Tool> Function(Directory workspace) buildTools;
+  final Outcome Function(Directory workspace, SessionState state)
+  captureOutcome;
+
+  GenericAgentSession({
+    required this.task,
+    required this.trial,
+    required this.context,
+    required this.modelConfig,
+    required this.agentName,
+    required this.systemPrompt,
+    required this.buildTools,
+    required this.captureOutcome,
+  });
+
+  final SessionState _state = SessionState();
+
+  @override
+  Future<({Transcript transcript, Outcome outcome})> run() async {
+    final ws = context.workspaceDir!;
+    final controller = context.controller;
+    _wireListeners(controller);
+
+    final tools = buildTools(ws);
+
+    final agentState = AgentState(
+      sessionId: '${trial.taskId}_${trial.trialIndex}',
+    );
+    agentState.metadata['userId'] = 'eval_demo';
+    agentState.metadata['scene'] = agentName;
+    agentState.metadata['sceneId'] = trial.taskId;
+
+    final agent = StatefulAgent(
+      name: agentName,
+      client: context.llmClient,
+      modelConfig: modelConfig,
+      state: agentState,
+      tools: tools,
+      systemPrompts: [systemPrompt],
+      controller: controller,
+      withGeneralPrinciples: false,
+      planMode: PlanMode.none,
+      disableSubAgents: true,
+      autoSaveStateFunc: (_) async {},
+    );
+
+    final userMessage = UserMessage([TextPart(task.input['prompt'] as String)]);
+
+    try {
+      await agent.run([userMessage], useStream: false);
+    } catch (e, st) {
+      _state.events.add(
+        TranscriptEvent(
+          at: DateTime.now(),
+          kind: 'agent_run_error',
+          message: e.toString(),
+          details: {'stackTrace': st.toString()},
+        ),
+      );
+    }
+
+    _state.messages
+      ..clear()
+      ..addAll(agentState.history.messages);
+
+    final outcome = captureOutcome(ws, _state);
+    final transcript = _buildTranscript();
+    return (transcript: transcript, outcome: outcome);
+  }
+
+  @override
+  Future<void> dispose() async {
+    // Controller is closed by the environment when the trial ends.
+  }
+
+  void _wireListeners(AgentController controller) {
+    controller.on<BeforeToolCallEvent>((e) {
+      _state.pendingToolCalls[e.functionCall.id] = ToolCallStart(
+        startedAt: DateTime.now(),
+        toolName: e.functionCall.name,
+        arguments: _decodeArgs(e.functionCall.arguments),
+      );
+    });
+
+    controller.on<AfterToolCallEvent>((e) {
+      final start = _state.pendingToolCalls.remove(e.result.id);
+      final endedAt = DateTime.now();
+      _state.toolCalls.add(
+        ToolCallRecord(
+          callId: e.result.id,
+          toolName: e.result.name,
+          arguments: start?.arguments ?? const {},
+          result: e.result,
+          startedAt: start?.startedAt ?? endedAt,
+          endedAt: endedAt,
+          isError: e.result.isError,
+        ),
+      );
+    });
+
+    controller.on<AfterCallLLMEvent>((e) {
+      _state.nTurns += 1;
+      _state.firstLLMReplyAt ??= DateTime.now();
+      _state.lastLLMReplyAt = DateTime.now();
+      final usage = e.response.usage;
+      if (usage != null) {
+        _state.totalTokens += usage.totalTokens;
+      }
+    });
+
+    controller.on<LLMRetryingEvent>((e) {
+      _state.events.add(
+        TranscriptEvent(
+          at: DateTime.now(),
+          kind: 'llm_retry',
+          message: e.reason,
+        ),
+      );
+    });
+
+    controller.on<OnAgentExceptionEvent>((e) {
+      _state.events.add(
+        TranscriptEvent(
+          at: DateTime.now(),
+          kind: 'agent_exception',
+          message: e.error.toString(),
+        ),
+      );
+    });
+  }
+
+  Map<String, dynamic> _decodeArgs(String raw) {
+    if (raw.trim().isEmpty) return const {};
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is Map<String, dynamic>) return decoded;
+      if (decoded is Map) return decoded.cast<String, dynamic>();
+      return const {};
+    } catch (_) {
+      return const {};
+    }
+  }
+
+  Transcript _buildTranscript() {
+    final ttft = _state.firstLLMReplyAt;
+    final ttlt = _state.lastLLMReplyAt;
+    return Transcript(
+      messages: List.unmodifiable(_state.messages),
+      toolCalls: List.unmodifiable(_state.toolCalls),
+      reasoningSteps: const [],
+      events: List.unmodifiable(_state.events),
+      metrics: TranscriptMetrics(
+        nTurns: _state.nTurns,
+        nToolCalls: _state.toolCalls.length,
+        nTotalTokens: _state.totalTokens,
+        timeToFirstToken: ttft?.difference(trial.startedAt),
+        timeToLastToken: ttlt?.difference(trial.startedAt),
+      ),
+    );
+  }
+}
+
+/// Tracks progress of a single agent run. Public so demo
+/// `captureOutcome` callbacks can read tool calls, messages, and timings
+/// without the analyzer warning about private types in public API.
+class SessionState {
+  final List<LLMMessage> messages = [];
+  final List<ToolCallRecord> toolCalls = [];
+  final List<TranscriptEvent> events = [];
+  final Map<String, ToolCallStart> pendingToolCalls = {};
+  DateTime? firstLLMReplyAt;
+  DateTime? lastLLMReplyAt;
+  int nTurns = 0;
+  int totalTokens = 0;
+}
+
+class ToolCallStart {
+  final DateTime startedAt;
+  final String toolName;
+  final Map<String, dynamic> arguments;
+  const ToolCallStart({
+    required this.startedAt,
+    required this.toolName,
+    required this.arguments,
+  });
+}

--- a/example/eval_demo/calculator/agent.dart
+++ b/example/eval_demo/calculator/agent.dart
@@ -1,0 +1,156 @@
+import 'dart:io';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+
+/// Builds the four arithmetic tools used by the calculator agent.
+/// Each tool writes nothing to disk — they only return numeric results.
+List<Tool> buildCalculatorTools() {
+  return [
+    Tool(
+      name: 'add',
+      description: 'Add two numbers and return their sum.',
+      parameters: {
+        'type': 'object',
+        'properties': {
+          'a': {'type': 'number'},
+          'b': {'type': 'number'},
+        },
+        'required': ['a', 'b'],
+      },
+      executable: (num a, num b) async {
+        return AgentToolResult(content: TextPart('${a + b}'));
+      },
+    ),
+    Tool(
+      name: 'subtract',
+      description: 'Subtract b from a and return the difference.',
+      parameters: {
+        'type': 'object',
+        'properties': {
+          'a': {'type': 'number'},
+          'b': {'type': 'number'},
+        },
+        'required': ['a', 'b'],
+      },
+      executable: (num a, num b) async {
+        return AgentToolResult(content: TextPart('${a - b}'));
+      },
+    ),
+    Tool(
+      name: 'multiply',
+      description: 'Multiply two numbers and return their product.',
+      parameters: {
+        'type': 'object',
+        'properties': {
+          'a': {'type': 'number'},
+          'b': {'type': 'number'},
+        },
+        'required': ['a', 'b'],
+      },
+      executable: (num a, num b) async {
+        return AgentToolResult(content: TextPart('${a * b}'));
+      },
+    ),
+    Tool(
+      name: 'divide',
+      description: 'Divide a by b. Returns an error if b is zero.',
+      parameters: {
+        'type': 'object',
+        'properties': {
+          'a': {'type': 'number'},
+          'b': {'type': 'number'},
+        },
+        'required': ['a', 'b'],
+      },
+      executable: (num a, num b) async {
+        if (b == 0) {
+          throw ArgumentError('division by zero');
+        }
+        return AgentToolResult(content: TextPart('${a / b}'));
+      },
+    ),
+  ];
+}
+
+/// Tool factory bound to a workspace directory. The `submit_answer` tool
+/// writes the final answer to `${workspace}/answer.txt`. This is the
+/// observable [Outcome] that graders inspect.
+///
+/// `decline` lets the agent gracefully refuse off-topic prompts (e.g.
+/// "what should I eat tomorrow"). It writes a sentinel file `declined.txt`
+/// whose presence the negative-case grader checks for.
+List<Tool> buildSubmissionTools(Directory workspace) {
+  return [
+    Tool(
+      name: 'submit_answer',
+      description:
+          'Submit the final numeric answer to the user\'s question. '
+          'Call this exactly once after you have computed the result. '
+          'After this call, your turn ends.',
+      parameters: {
+        'type': 'object',
+        'properties': {
+          'value': {'type': 'number', 'description': 'The numeric answer.'},
+          'explanation': {
+            'type': 'string',
+            'description': 'Short rationale (one sentence).',
+          },
+        },
+        'required': ['value'],
+      },
+      executable: (num value, String? explanation) async {
+        final f = File('${workspace.path}/answer.txt');
+        f.writeAsStringSync(value.toString());
+        if (explanation != null) {
+          File(
+            '${workspace.path}/explanation.txt',
+          ).writeAsStringSync(explanation);
+        }
+        return AgentToolResult(
+          content: TextPart('Answer submitted: $value'),
+          stopFlag: true,
+        );
+      },
+    ),
+    Tool(
+      name: 'decline',
+      description:
+          'Decline the request when it is not a math question. '
+          'Provide a short reason. After this call, your turn ends.',
+      parameters: {
+        'type': 'object',
+        'properties': {
+          'reason': {
+            'type': 'string',
+            'description': 'Why this prompt cannot be answered.',
+          },
+        },
+        'required': ['reason'],
+      },
+      executable: (String reason) async {
+        File('${workspace.path}/declined.txt').writeAsStringSync(reason);
+        return AgentToolResult(
+          content: TextPart('Declined: $reason'),
+          stopFlag: true,
+        );
+      },
+    ),
+  ];
+}
+
+/// System prompt for the calculator agent.
+const calculatorSystemPrompt = '''
+You are a careful calculator agent.
+
+Workflow for every user prompt:
+1. If the prompt is NOT a math question (e.g. about food, weather, life
+   advice), call the `decline` tool with a short reason. Do not invent a
+   numeric answer.
+2. Otherwise, decompose the problem into single arithmetic steps. Use only
+   the provided tools (add / subtract / multiply / divide). You MUST use
+   the tools — do not compute mentally.
+3. When you have the final numeric answer, call `submit_answer` with the
+   numeric value and a one-sentence explanation. After submitting, stop.
+
+Never call `submit_answer` and `decline` in the same turn. Pick exactly one.
+''';

--- a/example/eval_demo/calculator/environment.dart
+++ b/example/eval_demo/calculator/environment.dart
@@ -1,0 +1,93 @@
+import 'dart:io';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dart_agent_core/eval.dart';
+
+/// EvalEnvironment for the calculator demo.
+///
+/// Each trial gets its own temp directory. The trial's
+/// [submit_answer] / [decline] tools write into that directory; the
+/// graders read from it via [Outcome.environmentState].
+///
+/// LLM client is built fresh per-trial so that recorder/replayer wrapping
+/// — if any — is per-trial isolated.
+class CalculatorEvalEnvironment implements EvalEnvironment {
+  /// How to build the upstream (live) LLM client. The runner may wrap it
+  /// with RecordingLLMClient or replace it with ReplayLLMClient depending
+  /// on run mode.
+  final LLMClient Function() liveClientFactory;
+
+  /// Optional record / replay store; if non-null we wrap [liveClientFactory]
+  /// with RecordingLLMClient and the runner can read recordings later.
+  final RecordingStore? recordingStore;
+
+  /// Force replay mode (don't even create live client; raise on miss).
+  final bool replayOnly;
+
+  /// Optional rate gate forwarded to the LLM clients.
+  final RateLimitGate rateLimitGate;
+
+  /// `_recordingStore` for replay (when liveClientFactory is null and store
+  /// is set). If [replayOnly] is true and store is set, we use it for replay.
+  CalculatorEvalEnvironment({
+    required this.liveClientFactory,
+    this.recordingStore,
+    this.replayOnly = false,
+    RateLimitGate? rateLimitGate,
+  }) : rateLimitGate = rateLimitGate ?? const NoopRateLimitGate();
+
+  @override
+  Future<EvalContext> prepare({
+    required Trial trial,
+    required EvalTask task,
+  }) async {
+    final dir = await Directory.systemTemp.createTemp(
+      'eval_demo_${trial.taskId}_${trial.trialIndex}_',
+    );
+
+    final salt = trial.cacheSalt;
+    final LLMClient llmClient;
+    if (replayOnly) {
+      if (recordingStore == null) {
+        throw StateError(
+          'replayOnly mode requires a RecordingStore for replay.',
+        );
+      }
+      llmClient = ReplayLLMClient(
+        store: recordingStore!,
+        strictReplay: true,
+        rateLimitGate: rateLimitGate,
+        trialSalt: salt,
+      );
+    } else if (recordingStore != null) {
+      llmClient = RecordingLLMClient(
+        inner: liveClientFactory(),
+        store: recordingStore!,
+        rateLimitGate: rateLimitGate,
+        trialSalt: salt,
+      );
+    } else {
+      llmClient = liveClientFactory();
+    }
+
+    final controller = AgentController();
+
+    return EvalContext(
+      workspaceDir: dir,
+      clock: const SystemEvalClock(),
+      llmClient: llmClient,
+      controller: controller,
+      servicesMap: const {},
+      metadata: {'fixture_path': dir.path},
+    );
+  }
+
+  @override
+  Future<void> dispose(EvalContext context) async {
+    final dir = context.workspaceDir;
+    if (dir != null && await dir.exists()) {
+      await dir.delete(recursive: true);
+    }
+    context.controller.close();
+  }
+}

--- a/example/eval_demo/calculator/graders.dart
+++ b/example/eval_demo/calculator/graders.dart
@@ -1,0 +1,134 @@
+import 'package:dart_agent_core/eval.dart';
+
+/// Verifies that the agent submitted a numeric answer matching [expected].
+/// Tolerant of small floating-point error.
+class AnswerCorrectnessGrader extends CodeGrader {
+  /// Expected numeric answer for this task.
+  final num expected;
+
+  /// Maximum absolute error allowed when comparing doubles.
+  final double tolerance;
+
+  AnswerCorrectnessGrader({required this.expected, this.tolerance = 1e-9});
+
+  @override
+  String get name => 'answer_correctness';
+
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async {
+    final assertions = <Assertion>[];
+    final state = outcome.environmentState;
+    final submitted = state['submitted'] == true;
+    final declined = state['declined'] == true;
+
+    assertions.add(
+      Assertion(
+        description: 'agent submitted an answer (and did not decline)',
+        passed: submitted && !declined,
+        actual: 'submitted=$submitted declined=$declined',
+        expected: 'submitted=true declined=false',
+      ),
+    );
+
+    if (!submitted) {
+      // No answer to check — fail fast on the second assertion too.
+      assertions.add(
+        Assertion(
+          description: 'submitted answer equals $expected within tolerance',
+          passed: false,
+          actual: 'no answer',
+          expected: '$expected',
+        ),
+      );
+      return assertions;
+    }
+
+    final raw = state['answer'];
+    final actualNum = raw is num ? raw.toDouble() : double.tryParse('$raw');
+    final ok =
+        actualNum != null &&
+        (actualNum - expected.toDouble()).abs() <= tolerance;
+
+    assertions.add(
+      Assertion(
+        description: 'submitted answer equals $expected within tolerance',
+        passed: ok,
+        actual: '$raw',
+        expected: '$expected',
+      ),
+    );
+
+    return assertions;
+  }
+}
+
+/// Verifies that the agent declined (did not submit a numeric answer) for
+/// off-topic prompts.
+class DeclineGrader extends CodeGrader {
+  @override
+  String get name => 'declined_off_topic';
+
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async {
+    final state = outcome.environmentState;
+    final submitted = state['submitted'] == true;
+    final declined = state['declined'] == true;
+
+    return [
+      Assertion(
+        description: 'agent declined the off-topic prompt',
+        passed: declined && !submitted,
+        actual: 'submitted=$submitted declined=$declined',
+        expected: 'submitted=false declined=true',
+      ),
+    ];
+  }
+}
+
+/// Verifies that the agent actually used at least [minArithmeticCalls]
+/// arithmetic tools and did not "compute mentally".
+class ToolUsageGrader extends CodeGrader {
+  /// Minimum number of arithmetic tool calls expected.
+  final int minArithmeticCalls;
+
+  ToolUsageGrader({this.minArithmeticCalls = 1});
+
+  static const _arithmetic = {'add', 'subtract', 'multiply', 'divide'};
+
+  @override
+  String get name => 'used_arithmetic_tools';
+
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async {
+    final calls = transcript.toolCalls
+        .where((tc) => _arithmetic.contains(tc.toolName))
+        .length;
+
+    return [
+      Assertion(
+        description: 'agent invoked >= $minArithmeticCalls arithmetic tool(s)',
+        passed: calls >= minArithmeticCalls,
+        actual: '$calls calls',
+        expected: '>= $minArithmeticCalls',
+      ),
+    ];
+  }
+}

--- a/example/eval_demo/calculator/harness.dart
+++ b/example/eval_demo/calculator/harness.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dart_agent_core/eval.dart';
+
+import '../_shared/agent_harness.dart';
+import 'agent.dart';
+
+class CalculatorAgentHarnessFactory implements AgentHarnessFactory {
+  final ModelConfig modelConfig;
+
+  const CalculatorAgentHarnessFactory({required this.modelConfig});
+
+  @override
+  Future<AgentHarnessSession> create({
+    required EvalTask task,
+    required Trial trial,
+    required EvalContext context,
+  }) async {
+    return GenericAgentSession(
+      task: task,
+      trial: trial,
+      context: context,
+      modelConfig: modelConfig,
+      agentName: 'calculator_demo_agent',
+      systemPrompt: calculatorSystemPrompt,
+      buildTools: (ws) => [
+        ...buildCalculatorTools(),
+        ...buildSubmissionTools(ws),
+      ],
+      captureOutcome: _captureOutcome,
+    );
+  }
+}
+
+Outcome _captureOutcome(Directory ws, SessionState state) {
+  final answerFile = File('${ws.path}/answer.txt');
+  final declinedFile = File('${ws.path}/declined.txt');
+  final explanationFile = File('${ws.path}/explanation.txt');
+
+  String? answer;
+  if (answerFile.existsSync()) {
+    answer = answerFile.readAsStringSync().trim();
+  }
+  String? declined;
+  if (declinedFile.existsSync()) {
+    declined = declinedFile.readAsStringSync().trim();
+  }
+  String? explanation;
+  if (explanationFile.existsSync()) {
+    explanation = explanationFile.readAsStringSync().trim();
+  }
+
+  return Outcome(
+    environmentState: {
+      'answer': ?answer,
+      'declined_reason': ?declined,
+      'explanation': ?explanation,
+      'submitted': answer != null,
+      'declined': declined != null,
+    },
+    workspaceDiff: WorkspaceDiff(
+      created: [
+        if (answer != null) 'answer.txt',
+        if (declined != null) 'declined.txt',
+        if (explanation != null) 'explanation.txt',
+      ],
+    ),
+  );
+}

--- a/example/eval_demo/calculator/tasks.dart
+++ b/example/eval_demo/calculator/tasks.dart
@@ -1,0 +1,137 @@
+import 'package:dart_agent_core/eval.dart';
+
+import 'graders.dart';
+
+const _agentName = 'calculator_demo_agent';
+
+/// Single-step arithmetic. Tests that the agent uses at least one tool
+/// call and produces the correct numeric answer.
+class _SimpleAdditionTask implements EvalTask {
+  @override
+  String get id => 'task_simple_addition';
+
+  @override
+  String get description =>
+      'Single-step addition: should use the add tool and answer 5.';
+
+  @override
+  Map<String, dynamic> get input => {'prompt': 'What is 2 + 3?'};
+
+
+  @override
+  ReferenceSolution? get referenceSolution => const ReferenceSolution(
+    expectedOutcome: {'submitted': true, 'declined': false, 'answer': '5'},
+    source: ReferenceSolutionSource.manual,
+  );
+
+
+  @override
+  Map<String, String> get metadata => const {
+    'failure_bucket': 'arithmetic_basic',
+    'difficulty': 'easy',
+  };
+
+  @override
+  List<Grader> get graders => [
+    AnswerCorrectnessGrader(expected: 5),
+    ToolUsageGrader(minArithmeticCalls: 1),
+  ];
+
+  @override
+  int get trialsPerRun => 2;
+
+  @override
+  Duration? get timeout => const Duration(minutes: 2);
+}
+
+/// Multi-step arithmetic. Requires the agent to compose tool calls
+/// (multiply then subtract). Expected answer: (12*7) - 18 = 66.
+class _MultiStepTask implements EvalTask {
+  @override
+  String get id => 'task_multi_step';
+
+  @override
+  String get description =>
+      'Multi-step arithmetic: should chain at least two tool calls.';
+
+  @override
+  Map<String, dynamic> get input => {'prompt': 'What is (12 * 7) - 18?'};
+
+
+  @override
+  ReferenceSolution? get referenceSolution => const ReferenceSolution(
+    expectedOutcome: {'submitted': true, 'declined': false, 'answer': '66'},
+    source: ReferenceSolutionSource.manual,
+  );
+
+
+  @override
+  Map<String, String> get metadata => const {
+    'failure_bucket': 'arithmetic_compose',
+    'difficulty': 'medium',
+  };
+
+  @override
+  List<Grader> get graders => [
+    AnswerCorrectnessGrader(expected: 66),
+    ToolUsageGrader(minArithmeticCalls: 2),
+  ];
+
+  @override
+  int get trialsPerRun => 2;
+
+  @override
+  Duration? get timeout => const Duration(minutes: 2);
+}
+
+/// Negative case: prompt is not arithmetic. Agent MUST decline rather than
+/// fabricate a numeric answer. Anthropic Step 3: balanced suites need both
+/// positive and negative cases.
+class _OffTopicTask implements EvalTask {
+  @override
+  String get id => 'task_off_topic';
+
+  @override
+  String get description =>
+      'Off-topic prompt: agent should decline and not submit an answer.';
+
+  @override
+  Map<String, dynamic> get input => {
+    'prompt': 'What should I eat for dinner tomorrow?',
+  };
+
+
+  @override
+  ReferenceSolution? get referenceSolution => const ReferenceSolution(
+    expectedOutcome: {'submitted': false, 'declined': true},
+    source: ReferenceSolutionSource.manual,
+  );
+
+
+  @override
+  Map<String, String> get metadata => const {
+    'failure_bucket': 'off_topic_refusal',
+    'difficulty': 'easy',
+  };
+
+  @override
+  List<Grader> get graders => [DeclineGrader()];
+
+  @override
+  int get trialsPerRun => 2;
+
+  @override
+  Duration? get timeout => const Duration(minutes: 2);
+}
+
+/// The full demo suite. Mixed kind because it covers both basic capability
+/// (arithmetic) and a refusal case.
+EvalSuite buildCalculatorDemoSuite() {
+  return EvalSuite(
+    name: 'calculator_demo',
+    agentName: _agentName,
+    kind: SuiteKind.mixed,
+    tasks: [_SimpleAdditionTask(), _MultiStepTask(), _OffTopicTask()],
+    requireReferenceSolution: true,
+  );
+}

--- a/example/eval_demo/card_agent/agent.dart
+++ b/example/eval_demo/card_agent/agent.dart
@@ -1,0 +1,222 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+
+/// Demo of Memex's card_agent: turns multimodal user input into a
+/// structured Timeline Card YAML and writes it to disk.
+///
+/// Tools (mirror `lib/agent/card_agent/`):
+///   - get_card_metadata: return the catalog of available templates + tags
+///   - save_timeline_card: persist a card YAML to the workspace
+///   - decline: reject input that should not become a timeline card
+///
+/// Stop signal: `save_timeline_card` and `decline` set stopFlag = true so
+/// the agent runs at most one of them per trial.
+List<Tool> buildCardAgentTools(Directory workspace) {
+  return [
+    Tool(
+      name: 'get_card_metadata',
+      description:
+          'Return the catalog of available card templates and the user\'s '
+          'existing tags. Call this once before save_timeline_card so you '
+          'can pick the right template_id.',
+      parameters: const {'type': 'object', 'properties': <String, dynamic>{}},
+      executable: () async {
+        final catalog = jsonEncode(_cardCatalog);
+        return AgentToolResult(content: TextPart(catalog));
+      },
+    ),
+    Tool(
+      name: 'save_timeline_card',
+      description:
+          'Persist the structured timeline card. Call this exactly once '
+          'after you have chosen a template and filled in the fields. '
+          'After this call, your turn ends.',
+      parameters: const {
+        'type': 'object',
+        'properties': {
+          'fact_id': {
+            'type': 'string',
+            'description':
+                'The fact_id from the user input. Must match exactly.',
+          },
+          'template_id': {
+            'type': 'string',
+            'description':
+                'One of the template_id values returned by '
+                'get_card_metadata.',
+          },
+          'title': {
+            'type': 'string',
+            'description': 'Concise card title (≤ 30 chars).',
+          },
+          'tags': {
+            'type': 'array',
+            'items': {'type': 'string'},
+            'description':
+                'Tags. Reuse existing tags from get_card_metadata when '
+                'they match; only invent new ones if necessary.',
+          },
+          'fields': {
+            'type': 'object',
+            'description':
+                'Template-specific fields. Schema depends on '
+                'template_id.',
+          },
+        },
+        'required': ['fact_id', 'template_id', 'title', 'fields'],
+      },
+      parameterMode: ToolParameterMode.object,
+      executable: (Map<String, dynamic> args) async {
+        final factId = args['fact_id'] as String;
+        final templateId = args['template_id'] as String;
+        final title = args['title'] as String;
+        final tags =
+            (args['tags'] as List?)?.cast<String>() ?? const <String>[];
+        final fields =
+            (args['fields'] as Map?)?.cast<String, dynamic>() ??
+            <String, dynamic>{};
+
+        final card = <String, dynamic>{
+          'fact_id': factId,
+          'template_id': templateId,
+          'title': title,
+          'tags': tags,
+          'fields': fields,
+          'status': 'completed',
+          'persisted_at': DateTime.now().toIso8601String(),
+        };
+
+        // Naive YAML encoding. Demo only — production would use a real
+        // YAML lib.
+        final f = File('${workspace.path}/cards/$factId.yaml');
+        f.parent.createSync(recursive: true);
+        f.writeAsStringSync(_toYaml(card));
+
+        return AgentToolResult(
+          content: TextPart('Saved card $factId with template $templateId.'),
+          stopFlag: true,
+        );
+      },
+    ),
+    Tool(
+      name: 'decline',
+      description:
+          'Decline the input when it should NOT become a timeline card '
+          '(e.g. obvious spam, system test ping, empty content). After '
+          'this call, your turn ends.',
+      parameters: const {
+        'type': 'object',
+        'properties': {
+          'reason': {'type': 'string'},
+        },
+        'required': ['reason'],
+      },
+      executable: (String reason) async {
+        File('${workspace.path}/declined.txt').writeAsStringSync(reason);
+        return AgentToolResult(
+          content: TextPart('Declined: $reason'),
+          stopFlag: true,
+        );
+      },
+    ),
+  ];
+}
+
+/// Sample template catalog returned by get_card_metadata. Closely
+/// mirrors the shape that the real Memex `TimelineCardSkill` returns.
+const Map<String, dynamic> _cardCatalog = {
+  'templates': [
+    {
+      'template_id': 'note',
+      'description': 'Plain note. Fields: body (string).',
+      'fields_schema': {'body': 'string'},
+    },
+    {
+      'template_id': 'event',
+      'description':
+          'Time-bound event. Fields: body, start_at (ISO-8601), '
+          'location.',
+      'fields_schema': {
+        'body': 'string',
+        'start_at': 'string',
+        'location': 'string',
+      },
+    },
+    {
+      'template_id': 'task',
+      'description':
+          'Actionable item. Fields: body, due_at (optional), priority '
+          '(low|medium|high).',
+      'fields_schema': {
+        'body': 'string',
+        'due_at': 'string?',
+        'priority': 'string',
+      },
+    },
+    {
+      'template_id': 'reading',
+      'description':
+          'Article / book quote. Fields: body, source_title, '
+          'source_url (optional).',
+      'fields_schema': {
+        'body': 'string',
+        'source_title': 'string',
+        'source_url': 'string?',
+      },
+    },
+  ],
+  'existing_tags': ['work', 'health', 'meeting', 'reading', 'ideas', 'family'],
+};
+
+String _toYaml(Map<String, dynamic> m) {
+  final b = StringBuffer();
+  m.forEach((k, v) {
+    if (v is List) {
+      b.writeln('$k:');
+      for (final e in v) {
+        b.writeln('  - $e');
+      }
+    } else if (v is Map) {
+      b.writeln('$k:');
+      v.forEach((k2, v2) => b.writeln('  $k2: ${_yamlScalar(v2)}'));
+    } else {
+      b.writeln('$k: ${_yamlScalar(v)}');
+    }
+  });
+  return b.toString();
+}
+
+String _yamlScalar(Object? v) {
+  if (v == null) return '';
+  if (v is num || v is bool) return '$v';
+  // Quote strings to keep things simple and YAML-safe enough for the demo.
+  return '"${'$v'.replaceAll('"', r'\"')}"';
+}
+
+/// System prompt for the card agent demo.
+const cardAgentSystemPrompt = '''
+You are a Timeline Card agent. Your job is to take the user's raw input
+(some combination of text, time, location, asset description) and turn
+it into ONE structured timeline card.
+
+Workflow for every prompt:
+1. Call `get_card_metadata` once to learn the available templates and
+   the user's existing tag list.
+2. Pick the best `template_id` for the input:
+   - "note" for a plain reflection without strong time/place anchor.
+   - "event" when the input clearly refers to a calendar-like event
+     (meeting, appointment, gathering) with a date/time.
+   - "task" when the input is something the user wants to DO later.
+   - "reading" when the input is a quote or excerpt from another work.
+3. Reuse tags from `existing_tags` when they fit. Only invent a new
+   tag when none of the existing tags apply.
+4. Call `save_timeline_card` exactly once. The fact_id must match the
+   one in the user's input verbatim.
+5. ONLY call `decline` when the input is clearly not worth saving
+   (e.g. system ping like "test 123", empty content, obvious spam).
+
+Never call `save_timeline_card` and `decline` in the same turn. Pick
+exactly one. Do not repeat get_card_metadata.
+''';

--- a/example/eval_demo/card_agent/environment.dart
+++ b/example/eval_demo/card_agent/environment.dart
@@ -1,0 +1,75 @@
+import 'dart:io';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dart_agent_core/eval.dart';
+
+/// Per-trial workspace for the card agent demo. Layout:
+///
+/// ```
+/// <tmp>/
+///   cards/<fact_id>.yaml      # written by save_timeline_card
+///   declined.txt              # written by decline (if any)
+/// ```
+class CardAgentEnvironment implements EvalEnvironment {
+  final LLMClient Function() liveClientFactory;
+  final RecordingStore? recordingStore;
+  final bool replayOnly;
+  final RateLimitGate rateLimitGate;
+
+  CardAgentEnvironment({
+    required this.liveClientFactory,
+    this.recordingStore,
+    this.replayOnly = false,
+    RateLimitGate? rateLimitGate,
+  }) : rateLimitGate = rateLimitGate ?? const NoopRateLimitGate();
+
+  @override
+  Future<EvalContext> prepare({
+    required Trial trial,
+    required EvalTask task,
+  }) async {
+    final dir = await Directory.systemTemp.createTemp(
+      'eval_card_${trial.taskId}_${trial.trialIndex}_',
+    );
+
+    final salt = trial.cacheSalt;
+    final LLMClient llm;
+    if (replayOnly) {
+      if (recordingStore == null) {
+        throw StateError('replayOnly mode requires a RecordingStore.');
+      }
+      llm = ReplayLLMClient(
+        store: recordingStore!,
+        strictReplay: true,
+        rateLimitGate: rateLimitGate,
+        trialSalt: salt,
+      );
+    } else if (recordingStore != null) {
+      llm = RecordingLLMClient(
+        inner: liveClientFactory(),
+        store: recordingStore!,
+        rateLimitGate: rateLimitGate,
+        trialSalt: salt,
+      );
+    } else {
+      llm = liveClientFactory();
+    }
+
+    return EvalContext(
+      workspaceDir: dir,
+      clock: const SystemEvalClock(),
+      llmClient: llm,
+      controller: AgentController(),
+      metadata: {'fixture_path': dir.path},
+    );
+  }
+
+  @override
+  Future<void> dispose(EvalContext context) async {
+    final dir = context.workspaceDir;
+    if (dir != null && await dir.exists()) {
+      await dir.delete(recursive: true);
+    }
+    context.controller.close();
+  }
+}

--- a/example/eval_demo/card_agent/graders.dart
+++ b/example/eval_demo/card_agent/graders.dart
@@ -1,0 +1,177 @@
+import 'package:dart_agent_core/eval.dart';
+
+/// Confirms that a timeline card was saved and that the basic shape
+/// matches what the task asks for: same fact_id, expected template,
+/// title is non-empty and short, and (optionally) at least one of the
+/// expected tag candidates appears.
+class CardSavedGrader extends CodeGrader {
+  /// fact_id that the task input carries — must end up on the card.
+  final String expectedFactId;
+
+  /// The template the agent is expected to pick. Multiple values mean
+  /// "any of these is acceptable" (e.g. "note" OR "task" both fine).
+  final List<String> expectedTemplateIds;
+
+  /// Optional set of acceptable tags. The card must include at least
+  /// one if this list is non-empty.
+  final List<String> expectedTagCandidates;
+
+  /// Optional substrings that must all appear somewhere in the card's
+  /// title or fields (case-insensitive).
+  final List<String> mustContainSubstrings;
+
+  /// Maximum allowed title length.
+  final int maxTitleLength;
+
+  CardSavedGrader({
+    required this.expectedFactId,
+    required this.expectedTemplateIds,
+    this.expectedTagCandidates = const [],
+    this.mustContainSubstrings = const [],
+    this.maxTitleLength = 30,
+  });
+
+  @override
+  String get name => 'card_saved';
+
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async {
+    final state = outcome.environmentState;
+    final saved = state['card_saved'] == true;
+    final declined = state['declined'] == true;
+    final factId = state['fact_id'] as String?;
+    final templateId = state['card_template_id'] as String?;
+    final title = state['card_title'] as String?;
+    final tags =
+        (state['card_tags'] as List?)?.cast<String>() ?? const <String>[];
+    final fields =
+        (state['card_fields'] as Map?)?.cast<String, dynamic>() ?? const {};
+
+    final assertions = <Assertion>[
+      Assertion(
+        description: 'agent saved a card and did not decline',
+        passed: saved && !declined,
+        actual: 'saved=$saved declined=$declined',
+        expected: 'saved=true declined=false',
+      ),
+      Assertion(
+        description: 'fact_id on the card matches the input fact_id',
+        passed: factId == expectedFactId,
+        actual: '$factId',
+        expected: expectedFactId,
+      ),
+      Assertion(
+        description: 'template_id is one of ${expectedTemplateIds.join(" / ")}',
+        passed: templateId != null && expectedTemplateIds.contains(templateId),
+        actual: '$templateId',
+        expected: expectedTemplateIds.join('|'),
+      ),
+      Assertion(
+        description: 'title is non-empty and ≤ $maxTitleLength chars',
+        passed:
+            title != null &&
+            title.trim().isNotEmpty &&
+            title.length <= maxTitleLength,
+        actual: 'title="${title ?? ''}" len=${title?.length ?? 0}',
+        expected: '0 < len ≤ $maxTitleLength',
+      ),
+    ];
+
+    if (expectedTagCandidates.isNotEmpty) {
+      final lowerTags = tags.map((t) => t.toLowerCase()).toSet();
+      final lowerCandidates = expectedTagCandidates
+          .map((t) => t.toLowerCase())
+          .toSet();
+      final overlap = lowerTags.intersection(lowerCandidates);
+      assertions.add(
+        Assertion(
+          description:
+              'at least one tag from {${expectedTagCandidates.join(", ")}} '
+              'is present',
+          passed: overlap.isNotEmpty,
+          actual: 'tags=$tags',
+          expected: 'overlap with ${expectedTagCandidates.join(",")}',
+        ),
+      );
+    }
+
+    if (mustContainSubstrings.isNotEmpty) {
+      final blob = '${title ?? ''} ${fields.values.join(" ")}'.toLowerCase();
+      for (final needle in mustContainSubstrings) {
+        assertions.add(
+          Assertion(
+            description: 'card text contains "$needle"',
+            passed: blob.contains(needle.toLowerCase()),
+            actual: blob.length > 100 ? '${blob.substring(0, 100)}…' : blob,
+            expected: 'contains "$needle"',
+          ),
+        );
+      }
+    }
+
+    return assertions;
+  }
+}
+
+/// Grader for negative cases: the input should NOT become a card.
+/// Verifies the agent called `decline` and did not save anything.
+class DeclineCardGrader extends CodeGrader {
+  @override
+  String get name => 'declined_garbage_input';
+
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async {
+    final state = outcome.environmentState;
+    final saved = state['card_saved'] == true;
+    final declined = state['declined'] == true;
+    return [
+      Assertion(
+        description: 'agent declined and did not save a card',
+        passed: declined && !saved,
+        actual: 'saved=$saved declined=$declined',
+        expected: 'saved=false declined=true',
+      ),
+    ];
+  }
+}
+
+/// Verifies that the agent did NOT skip the metadata-discovery step.
+/// The system prompt says to call `get_card_metadata` once. This grader
+/// checks the transcript directly for that tool call.
+class CalledGetCardMetadataGrader extends CodeGrader {
+  @override
+  String get name => 'called_get_card_metadata';
+
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async {
+    final n = transcript.toolCalls
+        .where((tc) => tc.toolName == 'get_card_metadata')
+        .length;
+    return [
+      Assertion(
+        description: 'agent called get_card_metadata at least once',
+        passed: n >= 1,
+        actual: '$n calls',
+        expected: '>= 1',
+      ),
+    ];
+  }
+}

--- a/example/eval_demo/card_agent/harness.dart
+++ b/example/eval_demo/card_agent/harness.dart
@@ -1,0 +1,134 @@
+import 'dart:io';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dart_agent_core/eval.dart';
+
+import '../_shared/agent_harness.dart';
+import 'agent.dart';
+
+class CardAgentHarnessFactory implements AgentHarnessFactory {
+  final ModelConfig modelConfig;
+  const CardAgentHarnessFactory({required this.modelConfig});
+
+  @override
+  Future<AgentHarnessSession> create({
+    required EvalTask task,
+    required Trial trial,
+    required EvalContext context,
+  }) async {
+    return GenericAgentSession(
+      task: task,
+      trial: trial,
+      context: context,
+      modelConfig: modelConfig,
+      agentName: 'card_agent_demo',
+      systemPrompt: cardAgentSystemPrompt,
+      buildTools: buildCardAgentTools,
+      captureOutcome: _captureCardOutcome,
+    );
+  }
+}
+
+Outcome _captureCardOutcome(Directory ws, SessionState state) {
+  final factId = _findFactId(state);
+  final cardFile = factId == null
+      ? null
+      : File('${ws.path}/cards/$factId.yaml');
+  final declinedFile = File('${ws.path}/declined.txt');
+
+  Map<String, dynamic>? cardSummary;
+  if (cardFile != null && cardFile.existsSync()) {
+    final raw = cardFile.readAsStringSync();
+    cardSummary = _parseSimpleYaml(raw);
+  }
+
+  String? declined;
+  if (declinedFile.existsSync()) {
+    declined = declinedFile.readAsStringSync().trim();
+  }
+
+  return Outcome(
+    environmentState: {
+      'fact_id': ?factId,
+      'card_saved': cardSummary != null,
+      'card_status': ?cardSummary?['status'],
+      'card_template_id': ?cardSummary?['template_id'],
+      'card_title': ?cardSummary?['title'],
+      'card_tags': ?cardSummary?['tags'],
+      'card_fields': ?cardSummary?['fields'],
+      'declined': declined != null,
+      'declined_reason': ?declined,
+    },
+    workspaceDiff: WorkspaceDiff(
+      created: [
+        if (cardFile != null && cardFile.existsSync()) 'cards/$factId.yaml',
+        if (declinedFile.existsSync()) 'declined.txt',
+      ],
+    ),
+  );
+}
+
+/// Pull the fact_id from the most recent successful save_timeline_card
+/// tool call. Falls back to the fact_id in the input prompt.
+String? _findFactId(SessionState state) {
+  for (final tc in state.toolCalls.reversed) {
+    if (tc.toolName == 'save_timeline_card' && !tc.isError) {
+      final fid = tc.arguments['fact_id'];
+      if (fid is String) return fid;
+    }
+  }
+  return null;
+}
+
+/// Tiny YAML parser for the subset our demo writes. Returns scalars as
+/// strings, lists as `List<String>`, and maps as `Map<String, dynamic>`.
+Map<String, dynamic> _parseSimpleYaml(String text) {
+  final out = <String, dynamic>{};
+  String? currentKey;
+  Map<String, dynamic>? currentMap;
+  List<String>? currentList;
+  for (final raw in text.split('\n')) {
+    final line = raw;
+    if (line.trim().isEmpty) continue;
+
+    if (line.startsWith('  - ')) {
+      currentList ??= <String>[];
+      currentList.add(_unquote(line.substring(4).trim()));
+      if (currentKey != null) out[currentKey] = currentList;
+      continue;
+    }
+    if (line.startsWith('  ') && currentMap != null) {
+      final colon = line.indexOf(':');
+      if (colon < 0) continue;
+      final k = line.substring(2, colon).trim();
+      final v = line.substring(colon + 1).trim();
+      currentMap[k] = _unquote(v);
+      if (currentKey != null) out[currentKey] = currentMap;
+      continue;
+    }
+
+    final colon = line.indexOf(':');
+    if (colon < 0) continue;
+    final key = line.substring(0, colon).trim();
+    final rest = line.substring(colon + 1).trim();
+    currentKey = key;
+    currentMap = null;
+    currentList = null;
+    if (rest.isEmpty) {
+      // Collection follows.
+      currentMap = <String, dynamic>{};
+      currentList = null;
+      out[key] = currentMap;
+    } else {
+      out[key] = _unquote(rest);
+    }
+  }
+  return out;
+}
+
+String _unquote(String s) {
+  if (s.length >= 2 && s.startsWith('"') && s.endsWith('"')) {
+    return s.substring(1, s.length - 1).replaceAll(r'\"', '"');
+  }
+  return s;
+}

--- a/example/eval_demo/card_agent/tasks.dart
+++ b/example/eval_demo/card_agent/tasks.dart
@@ -1,0 +1,203 @@
+import 'package:dart_agent_core/eval.dart';
+
+import 'graders.dart';
+
+const _agentName = 'card_agent_demo';
+
+String _userPrompt({
+  required String factId,
+  required String text,
+  String? capturedAt,
+  String? location,
+  List<String> assets = const [],
+}) {
+  final b = StringBuffer();
+  b.writeln('Process the following user input into a timeline card.');
+  b.writeln();
+  b.writeln('fact_id: $factId');
+  if (capturedAt != null) b.writeln('captured_at: $capturedAt');
+  if (location != null) b.writeln('location: $location');
+  if (assets.isNotEmpty) {
+    b.writeln('assets:');
+    for (final a in assets) {
+      b.writeln('  - $a');
+    }
+  }
+  b.writeln();
+  b.writeln('text:');
+  b.writeln(text);
+  return b.toString();
+}
+
+/// Positive case 1: a clearly-event input. We expect template "event"
+/// and at least one of the {meeting, work} tags.
+class _EventCardTask implements EvalTask {
+  @override
+  String get id => 'card_event_meeting';
+  @override
+  String get description =>
+      'Calendar-style input: should pick "event" template.';
+  @override
+  Map<String, dynamic> get input => {
+    'prompt': _userPrompt(
+      factId: 'fact_001',
+      text:
+          'Sync with Alice tomorrow 3pm to review the Q3 launch plan. '
+          'Conference room B.',
+      capturedAt: '2025-09-01T10:30:00+08:00',
+      location: 'Office',
+    ),
+  };
+  @override
+  ReferenceSolution? get referenceSolution => const ReferenceSolution(
+    expectedOutcome: {
+      'card_saved': true,
+      'declined': false,
+      'card_template_id': 'event',
+    },
+    source: ReferenceSolutionSource.manual,
+  );
+  @override
+  Map<String, String> get metadata => const {
+    'failure_bucket': 'template_event',
+    'difficulty': 'easy',
+  };
+  @override
+  List<Grader> get graders => [
+    CardSavedGrader(
+      expectedFactId: 'fact_001',
+      expectedTemplateIds: const ['event'],
+      expectedTagCandidates: const ['meeting', 'work'],
+      mustContainSubstrings: const ['Alice'],
+    ),
+    CalledGetCardMetadataGrader(),
+  ];
+  @override
+  int get trialsPerRun => 2;
+  @override
+  Duration? get timeout => const Duration(minutes: 2);
+}
+
+/// Positive case 2: actionable item. Expect "task" template, priority
+/// keyword should land in the fields.
+class _TaskCardTask implements EvalTask {
+  @override
+  String get id => 'card_task_followup';
+  @override
+  String get description => 'Actionable to-do: should pick "task" template.';
+  @override
+  Map<String, dynamic> get input => {
+    'prompt': _userPrompt(
+      factId: 'fact_002',
+      text:
+          'Need to send the contract draft to the legal team by '
+          'Friday. High priority.',
+      capturedAt: '2025-09-01T11:00:00+08:00',
+    ),
+  };
+  @override
+  ReferenceSolution? get referenceSolution => const ReferenceSolution(
+    expectedOutcome: {'card_saved': true, 'card_template_id': 'task'},
+    source: ReferenceSolutionSource.manual,
+  );
+  @override
+  Map<String, String> get metadata => const {
+    'failure_bucket': 'template_task',
+    'difficulty': 'medium',
+  };
+  @override
+  List<Grader> get graders => [
+    CardSavedGrader(
+      expectedFactId: 'fact_002',
+      expectedTemplateIds: const ['task'],
+      mustContainSubstrings: const ['contract'],
+    ),
+  ];
+  @override
+  int get trialsPerRun => 2;
+  @override
+  Duration? get timeout => const Duration(minutes: 2);
+}
+
+/// Positive case 3: free-form reflection. Expect "note" template.
+class _NoteCardTask implements EvalTask {
+  @override
+  String get id => 'card_note_reflection';
+  @override
+  String get description =>
+      'Free-form reflection: should pick "note" template.';
+  @override
+  Map<String, dynamic> get input => {
+    'prompt': _userPrompt(
+      factId: 'fact_003',
+      text:
+          'Realized I do my best deep work in the morning. Should '
+          'protect that time on my calendar going forward.',
+    ),
+  };
+  @override
+  Map<String, String> get metadata => const {
+    'failure_bucket': 'template_note',
+    'difficulty': 'easy',
+  };
+  @override
+  ReferenceSolution? get referenceSolution => const ReferenceSolution(
+    expectedOutcome: {'card_saved': true, 'card_template_id': 'note'},
+    source: ReferenceSolutionSource.manual,
+  );
+  @override
+  List<Grader> get graders => [
+    CardSavedGrader(
+      expectedFactId: 'fact_003',
+      expectedTemplateIds: const ['note'],
+      mustContainSubstrings: const ['morning'],
+    ),
+  ];
+  @override
+  int get trialsPerRun => 2;
+  @override
+  Duration? get timeout => const Duration(minutes: 2);
+}
+
+/// Negative case: garbage input. Agent should call `decline`.
+class _DeclineCardTask implements EvalTask {
+  @override
+  String get id => 'card_decline_garbage';
+  @override
+  String get description => 'Empty / garbage input: should be declined.';
+  @override
+  Map<String, dynamic> get input => {
+    'prompt': _userPrompt(factId: 'fact_004', text: 'test 123'),
+  };
+  @override
+  Map<String, String> get metadata => const {
+    'failure_bucket': 'decline_garbage',
+    'difficulty': 'easy',
+  };
+  @override
+  ReferenceSolution? get referenceSolution => const ReferenceSolution(
+    expectedOutcome: {'card_saved': false, 'declined': true},
+    source: ReferenceSolutionSource.manual,
+  );
+  @override
+  List<Grader> get graders => [DeclineCardGrader()];
+  @override
+  int get trialsPerRun => 2;
+  @override
+  Duration? get timeout => const Duration(minutes: 2);
+}
+
+EvalSuite buildCardAgentDemoSuite() {
+  return EvalSuite(
+    name: 'card_agent_demo',
+    agentName: _agentName,
+    kind: SuiteKind.mixed,
+    tasks: [
+      _EventCardTask(),
+      _TaskCardTask(),
+      _NoteCardTask(),
+      _DeclineCardTask(),
+    ],
+    requireReferenceSolution: true,
+  );
+}

--- a/example/eval_demo/main.dart
+++ b/example/eval_demo/main.dart
@@ -1,0 +1,290 @@
+import 'dart:io';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dart_agent_core/eval.dart';
+import 'package:logging/logging.dart';
+
+import 'calculator/environment.dart';
+import 'calculator/harness.dart';
+import 'calculator/tasks.dart';
+import 'card_agent/environment.dart';
+import 'card_agent/harness.dart';
+import 'card_agent/tasks.dart';
+import 'pkm_agent/environment.dart';
+import 'pkm_agent/harness.dart';
+import 'pkm_agent/tasks.dart';
+
+/// End-to-end demo of the eval harness against multiple realistic
+/// agent scenarios:
+///
+/// ```bash
+/// export OPENAI_BASE_URL='https://...'
+/// export OPENAI_API_KEY='sk-...'
+///
+/// # Pick which suite to run:
+/// dart run example/eval_demo/main.dart --suite calculator
+/// dart run example/eval_demo/main.dart --suite card_agent
+/// dart run example/eval_demo/main.dart --suite pkm_agent
+/// dart run example/eval_demo/main.dart --suite all
+///
+/// # Common options:
+/// dart run example/eval_demo/main.dart \
+///   --suite all --concurrency 4 --mode live
+/// ```
+///
+/// Reports (markdown + JSON) land in `./.eval_reports/`, JSONL traces in
+/// `./.eval_traces/`, recordings (record/replay modes) in
+/// `./.eval_recordings/`. The exit code is the worst-case task pass
+/// rate across all suites: 0 only if every suite saw 100%.
+Future<void> main(List<String> argv) async {
+  _setupLogging();
+
+  final env = Platform.environment;
+  final suiteArg = _readArg(argv, '--suite') ?? 'calculator';
+
+  final config = parseEvalRunArgs(
+    argv,
+    env: env,
+    defaultRunName: '${suiteArg}_${DateTime.now().millisecondsSinceEpoch}',
+  );
+
+  final baseUrl = env['OPENAI_BASE_URL'];
+  final apiKey = env['OPENAI_API_KEY'];
+  if (config.mode != EvalRunMode.replay) {
+    if (baseUrl == null || baseUrl.isEmpty) {
+      stderr.writeln('OPENAI_BASE_URL is not set');
+      exit(2);
+    }
+    if (apiKey == null || apiKey.isEmpty) {
+      stderr.writeln('OPENAI_API_KEY is not set');
+      exit(2);
+    }
+  }
+
+  final modelName = env['EVAL_MODEL'] ?? 'anthropic/claude-opus-4.7';
+  final modelConfig = ModelConfig(model: modelName, temperature: 0.0);
+
+  final tracesDir = Directory('.eval_traces')..createSync(recursive: true);
+  final reportsRoot = Directory('.eval_reports')..createSync(recursive: true);
+  final recordingDir = config.recordingDir ?? '.eval_recordings';
+
+  RateLimitGate gate = const NoopRateLimitGate();
+  if (config.rpm != null) {
+    gate = RpmRateLimitGate(requestsPerMinute: config.rpm!);
+  }
+  final replayOnly = config.mode == EvalRunMode.replay;
+
+  OpenAIClient liveClientFactory() => OpenAIClient(
+    apiKey: apiKey ?? '',
+    baseUrl: baseUrl ?? 'https://api.openai.com/v1',
+  );
+
+  RecordingStore? buildStore() {
+    switch (config.mode) {
+      case EvalRunMode.record:
+      case EvalRunMode.replay:
+        return FileRecordingStore(Directory(recordingDir));
+      case EvalRunMode.live:
+        return null;
+    }
+  }
+
+  final reportStore = FileReportStore(reportsRoot);
+
+  // ─── Resolve which suite(s) to run ──────────────────────────────────────
+  final selected = <_DemoSuite>[];
+  switch (suiteArg) {
+    case 'calculator':
+      selected.add(
+        _calculatorDemo(modelConfig, liveClientFactory, gate, replayOnly),
+      );
+      break;
+    case 'card_agent':
+    case 'card':
+      selected.add(
+        _cardAgentDemo(modelConfig, liveClientFactory, gate, replayOnly),
+      );
+      break;
+    case 'pkm_agent':
+    case 'pkm':
+      selected.add(
+        _pkmAgentDemo(modelConfig, liveClientFactory, gate, replayOnly),
+      );
+      break;
+    case 'all':
+      selected.addAll([
+        _calculatorDemo(modelConfig, liveClientFactory, gate, replayOnly),
+        _cardAgentDemo(modelConfig, liveClientFactory, gate, replayOnly),
+        _pkmAgentDemo(modelConfig, liveClientFactory, gate, replayOnly),
+      ]);
+      break;
+    default:
+      stderr.writeln(
+        'Unknown --suite "$suiteArg". '
+        'Use one of: calculator | card_agent | pkm_agent | all',
+      );
+      exit(2);
+  }
+
+  // ─── Run each selected suite ────────────────────────────────────────────
+  final allReports = <EvalRunReport>[];
+  for (final demo in selected) {
+    if (!config.filter.matchesSuite(demo.suite)) {
+      stdout.writeln(
+        '\n• skipping suite=${demo.suite.name} '
+        '(agent=${demo.suite.agentName} filtered out)',
+      );
+      continue;
+    }
+
+    final runName = selected.length == 1
+        ? config.runName
+        : '${demo.suite.name}_${DateTime.now().millisecondsSinceEpoch}';
+
+    final tracesFile = File('${tracesDir.path}/${_safeName(runName)}.jsonl');
+    final exporter = JsonlTraceExporter(tracesFile);
+    final store = buildStore();
+
+    final runner = EvalRunner(
+      environment: demo.environmentBuilder(store),
+      harnessFactory: demo.harnessFactory,
+      exporters: [exporter],
+      recordingStore: store,
+      reportStore: reportStore,
+      rateLimitGate: gate,
+    );
+
+    stdout.writeln(
+      '\n• run_name=$runName suite=${demo.suite.name} '
+      'agent=${demo.suite.agentName} '
+      'mode=${config.mode.name} concurrency=${config.concurrency} '
+      'model=$modelName',
+    );
+
+    final report = await runner.runSuite(
+      runName: runName,
+      suite: demo.suite,
+      concurrency: config.concurrency,
+      trialsOverride: config.trialsOverride,
+      filter: config.filter.isEmpty ? null : config.filter.matchesTask,
+    );
+    allReports.add(report);
+
+    final taskBucketMap = <String, String>{
+      for (final t in demo.suite.tasks)
+        if (t.metadata['failure_bucket'] != null)
+          t.id: t.metadata['failure_bucket']!,
+    };
+    final md = generateMarkdownReport(
+      report,
+      taskBucketMap: taskBucketMap,
+      ksToReport: const [1, 2],
+    );
+    final mdFile = File('${reportsRoot.path}/${_safeName(runName)}.md');
+    await mdFile.writeAsString(md);
+    stdout.writeln('\n=== Markdown summary (${demo.suite.name}) ===\n');
+    stdout.writeln(md);
+    stdout.writeln('=== Saved to: ${mdFile.path} ===');
+  }
+
+  // ─── Combined summary ───────────────────────────────────────────────────
+  if (allReports.length > 1) {
+    stdout.writeln('\n=== All suites ===');
+    stdout.writeln('| Suite | Tasks | Trials | Task pass | Trial pass |');
+    stdout.writeln('|---|---|---|---|---|');
+    for (final r in allReports) {
+      stdout.writeln(
+        '| ${r.suite.name} | ${r.trialsByTask().length} | '
+        '${r.trials.length} | '
+        '${(r.taskPassRate * 100).toStringAsFixed(1)}% | '
+        '${(r.trialPassRate * 100).toStringAsFixed(1)}% |',
+      );
+    }
+  }
+
+  // Exit code: 0 iff every suite passed 100% of tasks.
+  final allPassed = allReports.every((r) => r.taskPassRate >= 1.0);
+  exit(allPassed ? 0 : 1);
+}
+
+class _DemoSuite {
+  final EvalSuite suite;
+  final EvalEnvironment Function(RecordingStore? store) environmentBuilder;
+  final AgentHarnessFactory harnessFactory;
+  const _DemoSuite({
+    required this.suite,
+    required this.environmentBuilder,
+    required this.harnessFactory,
+  });
+}
+
+_DemoSuite _calculatorDemo(
+  ModelConfig modelConfig,
+  LLMClient Function() liveClientFactory,
+  RateLimitGate gate,
+  bool replayOnly,
+) {
+  return _DemoSuite(
+    suite: buildCalculatorDemoSuite(),
+    harnessFactory: CalculatorAgentHarnessFactory(modelConfig: modelConfig),
+    environmentBuilder: (store) => CalculatorEvalEnvironment(
+      liveClientFactory: liveClientFactory,
+      recordingStore: store,
+      replayOnly: replayOnly,
+      rateLimitGate: gate,
+    ),
+  );
+}
+
+_DemoSuite _cardAgentDemo(
+  ModelConfig modelConfig,
+  LLMClient Function() liveClientFactory,
+  RateLimitGate gate,
+  bool replayOnly,
+) {
+  return _DemoSuite(
+    suite: buildCardAgentDemoSuite(),
+    harnessFactory: CardAgentHarnessFactory(modelConfig: modelConfig),
+    environmentBuilder: (store) => CardAgentEnvironment(
+      liveClientFactory: liveClientFactory,
+      recordingStore: store,
+      replayOnly: replayOnly,
+      rateLimitGate: gate,
+    ),
+  );
+}
+
+_DemoSuite _pkmAgentDemo(
+  ModelConfig modelConfig,
+  LLMClient Function() liveClientFactory,
+  RateLimitGate gate,
+  bool replayOnly,
+) {
+  return _DemoSuite(
+    suite: buildPkmAgentDemoSuite(),
+    harnessFactory: PkmAgentHarnessFactory(modelConfig: modelConfig),
+    environmentBuilder: (store) => PkmAgentEnvironment(
+      liveClientFactory: liveClientFactory,
+      recordingStore: store,
+      replayOnly: replayOnly,
+      rateLimitGate: gate,
+    ),
+  );
+}
+
+void _setupLogging() {
+  Logger.root.level = Level.INFO;
+  Logger.root.onRecord.listen((rec) {
+    stderr.writeln('[${rec.level.name}] ${rec.loggerName}: ${rec.message}');
+    if (rec.error != null) stderr.writeln('  err: ${rec.error}');
+  });
+}
+
+String? _readArg(List<String> args, String key) {
+  for (var i = 0; i < args.length - 1; i++) {
+    if (args[i] == key) return args[i + 1];
+  }
+  return null;
+}
+
+String _safeName(String s) => s.replaceAll(RegExp(r'[^A-Za-z0-9_.\-]'), '_');

--- a/example/eval_demo/pkm_agent/agent.dart
+++ b/example/eval_demo/pkm_agent/agent.dart
@@ -1,0 +1,206 @@
+import 'dart:io';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+
+/// Demo of Memex's pkm_agent: organizes user input into a P.A.R.A.
+/// (Projects, Areas, Resources, Archives) directory tree, updates the
+/// timeline card's "insight" field, or skips when the input isn't worth
+/// persisting.
+///
+/// Tools (mirror `lib/agent/pkm_agent/`):
+///   - ls_pkm:    list the structure under PKM/
+///   - read_file: read an existing PARA file
+///   - write_file: create or overwrite a PARA file
+///   - update_card_insight: write a one-paragraph reflection back onto
+///                          the originating timeline card
+///   - skip_pkm_organization: signal "not worth persisting", no files
+///                            written
+List<Tool> buildPkmAgentTools(Directory workspace) {
+  Directory pkmRoot() {
+    final d = Directory('${workspace.path}/PKM');
+    if (!d.existsSync()) {
+      // Pre-seed the four PARA buckets so the agent sees them.
+      for (final bucket in ['Projects', 'Areas', 'Resources', 'Archives']) {
+        Directory('${d.path}/$bucket').createSync(recursive: true);
+      }
+    }
+    return d;
+  }
+
+  return [
+    Tool(
+      name: 'ls_pkm',
+      description:
+          'List directories and files under the user\'s PKM/ tree. '
+          'Returns a tree-style listing.',
+      parameters: const {'type': 'object', 'properties': <String, dynamic>{}},
+      executable: () async {
+        final root = pkmRoot();
+        final lines = <String>['PKM/'];
+        for (final entry in root.listSync(
+          recursive: true,
+        )..sort((a, b) => a.path.compareTo(b.path))) {
+          final rel = entry.path.replaceFirst('${root.path}/', '');
+          final indent = '  ' * (rel.split('/').length);
+          if (entry is Directory) {
+            lines.add('$indent$rel/');
+          } else {
+            lines.add('$indent$rel');
+          }
+        }
+        return AgentToolResult(content: TextPart(lines.join('\n')));
+      },
+    ),
+    Tool(
+      name: 'read_file',
+      description: 'Read a markdown file under PKM/ as UTF-8 text.',
+      parameters: const {
+        'type': 'object',
+        'properties': {
+          'path': {
+            'type': 'string',
+            'description': 'PKM-relative path, e.g. "Areas/Health.md".',
+          },
+        },
+        'required': ['path'],
+      },
+      executable: (String path) async {
+        final root = pkmRoot();
+        final f = File('${root.path}/$path');
+        if (!f.existsSync()) {
+          return AgentToolResult(
+            content: TextPart('Error: file not found: $path'),
+          );
+        }
+        return AgentToolResult(content: TextPart(f.readAsStringSync()));
+      },
+    ),
+    Tool(
+      name: 'write_file',
+      description:
+          'Create or overwrite a markdown file under PKM/. '
+          'Path must start with one of: Projects/, Areas/, Resources/, '
+          'Archives/. The content MUST include a "fact_id: <id>" line '
+          'in the front-matter or body so we can trace the source.',
+      parameters: const {
+        'type': 'object',
+        'properties': {
+          'path': {
+            'type': 'string',
+            'description': 'PKM-relative path, e.g. "Areas/Sleep.md".',
+          },
+          'content': {
+            'type': 'string',
+            'description': 'Full file contents (UTF-8).',
+          },
+        },
+        'required': ['path', 'content'],
+      },
+      executable: (String path, String content) async {
+        final root = pkmRoot();
+        final allowed = ['Projects/', 'Areas/', 'Resources/', 'Archives/'];
+        if (!allowed.any(path.startsWith)) {
+          return AgentToolResult(
+            content: TextPart(
+              'Error: path must start with one of '
+              '${allowed.join(", ")}',
+            ),
+          );
+        }
+        final f = File('${root.path}/$path');
+        f.parent.createSync(recursive: true);
+        f.writeAsStringSync(content);
+        return AgentToolResult(
+          content: TextPart('Wrote ${content.length} bytes to PKM/$path'),
+        );
+      },
+    ),
+    Tool(
+      name: 'update_card_insight',
+      description:
+          'Write a short reflection back onto the originating timeline '
+          'card. Call this AFTER you have written the relevant PKM '
+          'file(s). After this call, your turn ends.',
+      parameters: const {
+        'type': 'object',
+        'properties': {
+          'fact_id': {
+            'type': 'string',
+            'description':
+                'fact_id of the source input — must match the input '
+                'verbatim.',
+          },
+          'insight': {
+            'type': 'string',
+            'description':
+                'One paragraph (≤ 200 chars) explaining how this fact '
+                'fits into the user\'s knowledge base.',
+          },
+        },
+        'required': ['fact_id', 'insight'],
+      },
+      executable: (String factId, String insight) async {
+        final f = File('${workspace.path}/insights/$factId.txt');
+        f.parent.createSync(recursive: true);
+        f.writeAsStringSync(insight);
+        return AgentToolResult(
+          content: TextPart('Insight saved for $factId.'),
+          stopFlag: true,
+        );
+      },
+    ),
+    Tool(
+      name: 'skip_pkm_organization',
+      description:
+          'Signal that this input is NOT worth persisting to PKM/ '
+          '(transient note, social acknowledgement, system test ping, '
+          'etc). Do not call any write tools alongside this. After '
+          'this call, your turn ends.',
+      parameters: const {
+        'type': 'object',
+        'properties': {
+          'reason': {'type': 'string'},
+        },
+        'required': ['reason'],
+      },
+      executable: (String reason) async {
+        File('${workspace.path}/skipped.txt').writeAsStringSync(reason);
+        return AgentToolResult(
+          content: TextPart('Skipped PKM organization: $reason'),
+          stopFlag: true,
+        );
+      },
+    ),
+  ];
+}
+
+/// System prompt for the PKM agent demo.
+const pkmAgentSystemPrompt = '''
+You are the PKM (Personal Knowledge Management) agent. You receive a
+single user fact and decide how to fit it into the user's PARA tree:
+
+  Projects/   active, time-bound efforts with a goal
+  Areas/      ongoing responsibilities (Health, Career, Family, …)
+  Resources/  topical references the user studies (Reading lists, …)
+  Archives/   completed projects / dormant material
+
+Workflow for every input:
+1. Call `ls_pkm` once to see the existing structure.
+2. If a relevant file already exists (e.g. "Areas/Sleep.md") for
+   roughly the same theme, call `read_file` to see what's there.
+3. Call `write_file` to either:
+   - append a dated entry to an existing file, or
+   - create a new file under the appropriate PARA bucket.
+   The file body MUST include a "fact_id: <the fact_id>" line so we
+   can trace the source.
+4. Call `update_card_insight` exactly once with a one-paragraph
+   reflection (≤ 200 chars) that ties the fact into the user's
+   broader knowledge base.
+
+Skip rule: if the input is NOT worth persisting (e.g. "good morning",
+"test", "lol"), call `skip_pkm_organization` instead. Don't write
+files in that case.
+
+Never call `update_card_insight` and `skip_pkm_organization` in the
+same trial.
+''';

--- a/example/eval_demo/pkm_agent/environment.dart
+++ b/example/eval_demo/pkm_agent/environment.dart
@@ -1,0 +1,95 @@
+import 'dart:io';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dart_agent_core/eval.dart';
+
+/// Per-trial workspace for the PKM agent demo. Layout:
+///
+/// ```
+/// <tmp>/
+///   PKM/
+///     Projects/
+///     Areas/
+///     Resources/
+///     Archives/
+///   insights/<fact_id>.txt   # written by update_card_insight
+///   skipped.txt              # written by skip_pkm_organization (if any)
+/// ```
+class PkmAgentEnvironment implements EvalEnvironment {
+  final LLMClient Function() liveClientFactory;
+  final RecordingStore? recordingStore;
+  final bool replayOnly;
+  final RateLimitGate rateLimitGate;
+
+  PkmAgentEnvironment({
+    required this.liveClientFactory,
+    this.recordingStore,
+    this.replayOnly = false,
+    RateLimitGate? rateLimitGate,
+  }) : rateLimitGate = rateLimitGate ?? const NoopRateLimitGate();
+
+  @override
+  Future<EvalContext> prepare({
+    required Trial trial,
+    required EvalTask task,
+  }) async {
+    final dir = await Directory.systemTemp.createTemp(
+      'eval_pkm_${trial.taskId}_${trial.trialIndex}_',
+    );
+    // Pre-seed PARA roots so `ls_pkm` returns something useful.
+    for (final bucket in ['Projects', 'Areas', 'Resources', 'Archives']) {
+      Directory('${dir.path}/PKM/$bucket').createSync(recursive: true);
+    }
+
+    // Optional fixture files mounted at PKM/ — task input may carry a
+    // map under `fixture_files`.
+    final fixture = task.input['fixture_files'];
+    if (fixture is Map) {
+      fixture.forEach((relPath, content) {
+        final f = File('${dir.path}/PKM/$relPath');
+        f.parent.createSync(recursive: true);
+        f.writeAsStringSync('$content');
+      });
+    }
+
+    final salt = trial.cacheSalt;
+    final LLMClient llm;
+    if (replayOnly) {
+      if (recordingStore == null) {
+        throw StateError('replayOnly mode requires a RecordingStore.');
+      }
+      llm = ReplayLLMClient(
+        store: recordingStore!,
+        strictReplay: true,
+        rateLimitGate: rateLimitGate,
+        trialSalt: salt,
+      );
+    } else if (recordingStore != null) {
+      llm = RecordingLLMClient(
+        inner: liveClientFactory(),
+        store: recordingStore!,
+        rateLimitGate: rateLimitGate,
+        trialSalt: salt,
+      );
+    } else {
+      llm = liveClientFactory();
+    }
+
+    return EvalContext(
+      workspaceDir: dir,
+      clock: const SystemEvalClock(),
+      llmClient: llm,
+      controller: AgentController(),
+      metadata: {'fixture_path': dir.path},
+    );
+  }
+
+  @override
+  Future<void> dispose(EvalContext context) async {
+    final dir = context.workspaceDir;
+    if (dir != null && await dir.exists()) {
+      await dir.delete(recursive: true);
+    }
+    context.controller.close();
+  }
+}

--- a/example/eval_demo/pkm_agent/graders.dart
+++ b/example/eval_demo/pkm_agent/graders.dart
@@ -1,0 +1,170 @@
+import 'package:dart_agent_core/eval.dart';
+
+/// Verifies the happy-path PKM organization:
+/// 1. Wrote at least one file under [expectedBuckets] (e.g. "Areas/")
+/// 2. The fact_id appears inside one of those files
+/// 3. update_card_insight was called with the same fact_id
+/// 4. Optional substring(s) appear in the written file content
+class PkmOrganizedGrader extends CodeGrader {
+  /// The fact_id from the user input.
+  final String expectedFactId;
+
+  /// Acceptable PARA buckets for THIS task. Eg ['Areas/'] for a
+  /// long-term-responsibility input, ['Resources/'] for a reading note.
+  final List<String> expectedBuckets;
+
+  /// Substrings that must appear (case-insensitive) in at least one of
+  /// the written files.
+  final List<String> mustContainSubstrings;
+
+  PkmOrganizedGrader({
+    required this.expectedFactId,
+    required this.expectedBuckets,
+    this.mustContainSubstrings = const [],
+  });
+
+  @override
+  String get name => 'pkm_organized';
+
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async {
+    final state = outcome.environmentState;
+    final wrote =
+        (state['wrote_files'] as List?)?.cast<String>() ?? const <String>[];
+    final factIdsInFiles =
+        (state['fact_ids_in_files'] as List?)?.cast<String>() ?? const [];
+    final updatedInsight = state['updated_insight'] == true;
+    final insightFactId = state['insight_for_fact_id'] as String?;
+    final skipped = state['skipped'] == true;
+
+    final assertions = <Assertion>[
+      Assertion(
+        description: 'agent did not skip and wrote at least one file',
+        passed: !skipped && wrote.isNotEmpty,
+        actual: 'skipped=$skipped wrote=$wrote',
+        expected: 'skipped=false wrote.length>=1',
+      ),
+      Assertion(
+        description: 'wrote into one of ${expectedBuckets.join(" / ")}',
+        passed: wrote.any((p) => expectedBuckets.any(p.startsWith)),
+        actual: '$wrote',
+        expected: 'starts-with one of ${expectedBuckets.join(",")}',
+      ),
+      Assertion(
+        description: 'fact_id $expectedFactId is referenced in the file body',
+        passed: factIdsInFiles.contains(expectedFactId),
+        actual: '$factIdsInFiles',
+        expected: 'contains $expectedFactId',
+      ),
+      Assertion(
+        description: 'update_card_insight was called for $expectedFactId',
+        passed: updatedInsight && insightFactId == expectedFactId,
+        actual: 'updated=$updatedInsight insight_fact_id=$insightFactId',
+        expected: 'updated=true insight_fact_id=$expectedFactId',
+      ),
+    ];
+
+    if (mustContainSubstrings.isNotEmpty) {
+      final diff = outcome.workspaceDiff;
+      final blob = (diff?.contentSnippets.values.join('\n') ?? '')
+          .toLowerCase();
+      for (final needle in mustContainSubstrings) {
+        assertions.add(
+          Assertion(
+            description: 'PKM file content contains "$needle"',
+            passed: blob.contains(needle.toLowerCase()),
+            actual: blob.length > 120 ? '${blob.substring(0, 120)}…' : blob,
+            expected: 'contains "$needle"',
+          ),
+        );
+      }
+    }
+
+    return assertions;
+  }
+}
+
+/// Verifies the negative path: agent should call skip_pkm_organization
+/// AND must not write any PKM files.
+class PkmSkippedGrader extends CodeGrader {
+  @override
+  String get name => 'pkm_skipped';
+
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async {
+    final state = outcome.environmentState;
+    final wrote =
+        (state['wrote_files'] as List?)?.cast<String>() ?? const <String>[];
+    final skipped = state['skipped'] == true;
+    final updated = state['updated_insight'] == true;
+
+    return [
+      Assertion(
+        description: 'skip_pkm_organization was called',
+        passed: skipped,
+        actual: 'skipped=$skipped',
+        expected: 'skipped=true',
+      ),
+      Assertion(
+        description: 'no PKM files were written',
+        passed: wrote.isEmpty,
+        actual: '$wrote',
+        expected: '[]',
+      ),
+      Assertion(
+        description: 'update_card_insight was NOT called',
+        passed: !updated,
+        actual: 'updated_insight=$updated',
+        expected: 'updated_insight=false',
+      ),
+    ];
+  }
+}
+
+/// Verifies that when a relevant file already existed, the agent
+/// chose to read it before writing (i.e. did not blindly overwrite).
+class PkmReadBeforeWriteGrader extends CodeGrader {
+  @override
+  String get name => 'read_before_write';
+
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async {
+    int firstWriteAt = -1;
+    int firstReadAt = -1;
+    for (var i = 0; i < transcript.toolCalls.length; i++) {
+      final n = transcript.toolCalls[i].toolName;
+      if (n == 'read_file' && firstReadAt < 0) firstReadAt = i;
+      if (n == 'write_file' && firstWriteAt < 0) firstWriteAt = i;
+    }
+    final ok =
+        firstReadAt >= 0 && (firstWriteAt < 0 || firstReadAt < firstWriteAt);
+    return [
+      Assertion(
+        description:
+            'agent called read_file before its first write_file (when '
+            'a fixture file existed)',
+        passed: ok,
+        actual: 'read_at=$firstReadAt write_at=$firstWriteAt',
+        expected: 'read_at < write_at (or no write at all)',
+      ),
+    ];
+  }
+}

--- a/example/eval_demo/pkm_agent/harness.dart
+++ b/example/eval_demo/pkm_agent/harness.dart
@@ -1,0 +1,105 @@
+import 'dart:io';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dart_agent_core/eval.dart';
+
+import '../_shared/agent_harness.dart';
+import 'agent.dart';
+
+class PkmAgentHarnessFactory implements AgentHarnessFactory {
+  final ModelConfig modelConfig;
+  const PkmAgentHarnessFactory({required this.modelConfig});
+
+  @override
+  Future<AgentHarnessSession> create({
+    required EvalTask task,
+    required Trial trial,
+    required EvalContext context,
+  }) async {
+    return GenericAgentSession(
+      task: task,
+      trial: trial,
+      context: context,
+      modelConfig: modelConfig,
+      agentName: 'pkm_agent_demo',
+      systemPrompt: pkmAgentSystemPrompt,
+      buildTools: buildPkmAgentTools,
+      captureOutcome: _capturePkmOutcome,
+    );
+  }
+}
+
+Outcome _capturePkmOutcome(Directory ws, SessionState state) {
+  final pkmRoot = Directory('${ws.path}/PKM');
+  final created = <String>[];
+  final modifiedSnippets = <String, String>{};
+  final allWritten = <String>[];
+
+  for (final tc in state.toolCalls) {
+    if (tc.toolName == 'write_file' && !tc.isError) {
+      final path = tc.arguments['path'];
+      if (path is String) allWritten.add(path);
+    }
+  }
+
+  if (pkmRoot.existsSync()) {
+    for (final entry in pkmRoot.listSync(recursive: true)) {
+      if (entry is! File) continue;
+      final rel = entry.path.replaceFirst('${pkmRoot.path}/', '');
+      created.add(rel);
+      final content = entry.readAsStringSync();
+      modifiedSnippets[rel] = content.length > 4096
+          ? content.substring(0, 4096)
+          : content;
+    }
+  }
+
+  // Insight & skipped sentinels.
+  String? insight;
+  final insightsDir = Directory('${ws.path}/insights');
+  String? insightForFactId;
+  if (insightsDir.existsSync()) {
+    for (final f in insightsDir.listSync()) {
+      if (f is! File) continue;
+      insightForFactId = f.uri.pathSegments.last.replaceAll(
+        RegExp(r'\.txt$'),
+        '',
+      );
+      insight = f.readAsStringSync().trim();
+      break;
+    }
+  }
+
+  String? skippedReason;
+  final skippedFile = File('${ws.path}/skipped.txt');
+  if (skippedFile.existsSync()) {
+    skippedReason = skippedFile.readAsStringSync().trim();
+  }
+
+  // Did any written file's body include the fact_id?
+  final factIdInFiles = <String>{};
+  modifiedSnippets.forEach((_, body) {
+    final m = RegExp(r'fact_id\s*:\s*(\S+)').firstMatch(body);
+    if (m != null) factIdInFiles.add(m.group(1)!);
+  });
+
+  return Outcome(
+    environmentState: {
+      'wrote_files': allWritten,
+      'pkm_files_created': created,
+      'fact_ids_in_files': factIdInFiles.toList(),
+      'insight': ?insight,
+      'insight_for_fact_id': ?insightForFactId,
+      'updated_insight': insight != null,
+      'skipped': skippedReason != null,
+      'skipped_reason': ?skippedReason,
+    },
+    workspaceDiff: WorkspaceDiff(
+      created: created.map((p) => 'PKM/$p').toList(),
+      contentSnippets: {
+        for (final entry in modifiedSnippets.entries)
+          'PKM/${entry.key}': entry.value,
+      },
+    ),
+  );
+}

--- a/example/eval_demo/pkm_agent/suites/pkm_capability/suite.json
+++ b/example/eval_demo/pkm_agent/suites/pkm_capability/suite.json
@@ -1,0 +1,7 @@
+{
+  "name": "pkm_agent_demo",
+  "agent_name": "pkm_agent_demo",
+  "kind": "mixed",
+  "requireReferenceSolution": true,
+  "taskPassThreshold": 1.0
+}

--- a/example/eval_demo/pkm_agent/suites/pkm_capability/tasks/negative/pkm_skip_trivial.json
+++ b/example/eval_demo/pkm_agent/suites/pkm_capability/tasks/negative/pkm_skip_trivial.json
@@ -1,0 +1,23 @@
+{
+  "id": "pkm_skip_trivial",
+  "description": "Trivial \"good morning\" input: should be skipped, not persisted.",
+  "trials_per_run": 2,
+  "timeout_seconds": 120,
+  "metadata": {
+    "failure_bucket": "skip_trivial",
+    "difficulty": "easy"
+  },
+  "input": {
+    "prompt": "Process the following user fact for PKM organization.\n\nfact_id: fact_pkm_004\n\ntext:\ngood morning ☀\n"
+  },
+  "reference_solution": {
+    "expected_outcome": {
+      "updated_insight": false,
+      "skipped": true
+    },
+    "source": "manual"
+  },
+  "graders": [
+    {"name": "pkm_skipped"}
+  ]
+}

--- a/example/eval_demo/pkm_agent/suites/pkm_capability/tasks/positive/pkm_append_to_existing.json
+++ b/example/eval_demo/pkm_agent/suites/pkm_capability/tasks/positive/pkm_append_to_existing.json
@@ -1,0 +1,34 @@
+{
+  "id": "pkm_append_to_existing",
+  "description": "Existing Areas/Sleep.md: should read THEN append, not overwrite.",
+  "trials_per_run": 2,
+  "timeout_seconds": 180,
+  "metadata": {
+    "failure_bucket": "append_to_existing",
+    "difficulty": "hard"
+  },
+  "input": {
+    "prompt": "Process the following user fact for PKM organization.\n\nfact_id: fact_pkm_003\n\ntext:\nSlept ~6.5h again. Energy crashed at 3pm. Need to get to bed earlier this week.\n",
+    "fixture_files": {
+      "Areas/Sleep.md": "# Sleep\n\nA running log of my sleep quality and what affects it.\n\nfact_id: fact_pkm_baseline\n- 2025-08-01: 7.5h, no caffeine after 2pm — felt good.\n- 2025-08-15: 5h, late call with EU team — terrible day after.\n"
+    }
+  },
+  "reference_solution": {
+    "expected_outcome": {
+      "updated_insight": true,
+      "skipped": false
+    },
+    "source": "manual"
+  },
+  "graders": [
+    {
+      "name": "pkm_organized",
+      "config": {
+        "fact_id": "fact_pkm_003",
+        "buckets": ["Areas/"],
+        "must_contain": ["fact_pkm_baseline", "6.5"]
+      }
+    },
+    {"name": "read_before_write"}
+  ]
+}

--- a/example/eval_demo/pkm_agent/suites/pkm_capability/tasks/positive/pkm_area_health.json
+++ b/example/eval_demo/pkm_agent/suites/pkm_capability/tasks/positive/pkm_area_health.json
@@ -1,0 +1,30 @@
+{
+  "id": "pkm_area_health",
+  "description": "Long-term health habit: should write under Areas/.",
+  "trials_per_run": 2,
+  "timeout_seconds": 180,
+  "metadata": {
+    "failure_bucket": "route_to_areas",
+    "difficulty": "easy"
+  },
+  "input": {
+    "prompt": "Process the following user fact for PKM organization.\n\nfact_id: fact_pkm_001\n\ntext:\nStarted doing 10 minutes of daily mobility work after noticing my back tightness. Want to make this a habit.\n"
+  },
+  "reference_solution": {
+    "expected_outcome": {
+      "updated_insight": true,
+      "skipped": false
+    },
+    "source": "manual"
+  },
+  "graders": [
+    {
+      "name": "pkm_organized",
+      "config": {
+        "fact_id": "fact_pkm_001",
+        "buckets": ["Areas/"],
+        "must_contain": ["mobility"]
+      }
+    }
+  ]
+}

--- a/example/eval_demo/pkm_agent/suites/pkm_capability/tasks/positive/pkm_resource_reading.json
+++ b/example/eval_demo/pkm_agent/suites/pkm_capability/tasks/positive/pkm_resource_reading.json
@@ -1,0 +1,30 @@
+{
+  "id": "pkm_resource_reading",
+  "description": "Reading note: should write under Resources/.",
+  "trials_per_run": 2,
+  "timeout_seconds": 180,
+  "metadata": {
+    "failure_bucket": "route_to_resources",
+    "difficulty": "medium"
+  },
+  "input": {
+    "prompt": "Process the following user fact for PKM organization.\n\nfact_id: fact_pkm_002\n\ntext:\nFrom \"Designing Data-Intensive Applications\" — log-structured storage engines optimize writes by sequencing them, but pay later in compaction.\n"
+  },
+  "reference_solution": {
+    "expected_outcome": {
+      "updated_insight": true,
+      "skipped": false
+    },
+    "source": "manual"
+  },
+  "graders": [
+    {
+      "name": "pkm_organized",
+      "config": {
+        "fact_id": "fact_pkm_002",
+        "buckets": ["Resources/"],
+        "must_contain": ["log-structured"]
+      }
+    }
+  ]
+}

--- a/example/eval_demo/pkm_agent/tasks.dart
+++ b/example/eval_demo/pkm_agent/tasks.dart
@@ -1,0 +1,38 @@
+import 'dart:io';
+
+import 'package:dart_agent_core/eval.dart';
+
+import 'graders.dart';
+
+/// Registers the three PKM-agent graders so the loader can resolve
+/// them from JSON `{"name": "...", "config": {...}}` entries.
+GraderRegistry buildPkmGraderRegistry() {
+  final reg = GraderRegistry();
+
+  reg.register(
+    'pkm_organized',
+    (cfg) => PkmOrganizedGrader(
+      expectedFactId: cfg['fact_id'] as String,
+      expectedBuckets: (cfg['buckets'] as List).cast<String>(),
+      mustContainSubstrings:
+          (cfg['must_contain'] as List?)?.cast<String>() ?? const [],
+    ),
+  );
+
+  reg.register('pkm_skipped', (_) => PkmSkippedGrader());
+  reg.register('read_before_write', (_) => PkmReadBeforeWriteGrader());
+
+  return reg;
+}
+
+/// Default suite path under `example/eval_demo/`. Resolves relative to
+/// the repo root when run via `dart run example/eval_demo/main.dart`.
+String defaultPkmSuiteDir() =>
+    'example/eval_demo/pkm_agent/suites/pkm_capability';
+
+/// Loads the demo suite from disk. Code path stays a single function so
+/// callers can override the directory via env var or CLI flag.
+EvalSuite buildPkmAgentDemoSuite({String? suiteDir}) {
+  final dir = Directory(suiteDir ?? defaultPkmSuiteDir());
+  return loadEvalSuiteFromDir(dir, graderRegistry: buildPkmGraderRegistry());
+}

--- a/example/min_eval/main.dart
+++ b/example/min_eval/main.dart
@@ -1,0 +1,193 @@
+import 'dart:io';
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dart_agent_core/eval.dart';
+
+// ─── 1. 写一个最小的 Agent（只会用 echo 工具回话） ──────────────────────
+const _systemPrompt = '''
+You echo what the user says back through the `echo` tool exactly once.
+Then your turn ends. Do not produce any free-form text.
+''';
+
+List<Tool> _buildTools(Directory ws) => [
+  Tool(
+    name: 'echo',
+    description: 'Echo the input text. Call this exactly once.',
+    parameters: const {
+      'type': 'object',
+      'properties': {
+        'text': {'type': 'string'},
+      },
+      'required': ['text'],
+    },
+    executable: (String text) async {
+      File('${ws.path}/echo.txt').writeAsStringSync(text);
+      return AgentToolResult(content: TextPart('echoed'), stopFlag: true);
+    },
+  ),
+];
+
+// ─── 2. EvalEnvironment：给每个 trial 一个临时工作目录 ──────────────────
+class EchoEnv implements EvalEnvironment {
+  final OpenAIClient Function() clientFactory;
+  EchoEnv(this.clientFactory);
+
+  @override
+  Future<EvalContext> prepare({
+    required Trial trial,
+    required EvalTask task,
+  }) async {
+    final dir = await Directory.systemTemp.createTemp('echo_eval_');
+    return EvalContext(
+      workspaceDir: dir,
+      clock: const SystemEvalClock(),
+      llmClient: clientFactory(),
+      controller: AgentController(),
+    );
+  }
+
+  @override
+  Future<void> dispose(EvalContext ctx) async {
+    final d = ctx.workspaceDir;
+    if (d != null && await d.exists()) await d.delete(recursive: true);
+    ctx.controller.close();
+  }
+}
+
+// ─── 3. AgentHarnessFactory：把模型包装成一个会调工具的 Agent ────────────
+class EchoHarness implements AgentHarnessFactory {
+  final ModelConfig modelConfig;
+  EchoHarness(this.modelConfig);
+
+  @override
+  Future<AgentHarnessSession> create({
+    required EvalTask task,
+    required Trial trial,
+    required EvalContext context,
+  }) async => _EchoSession(task: task, ctx: context, modelConfig: modelConfig);
+}
+
+class _EchoSession implements AgentHarnessSession {
+  final EvalTask task;
+  final EvalContext ctx;
+  final ModelConfig modelConfig;
+  _EchoSession({
+    required this.task,
+    required this.ctx,
+    required this.modelConfig,
+  });
+
+  @override
+  Future<({Transcript transcript, Outcome outcome})> run() async {
+    final agent = StatefulAgent(
+      name: 'echo_agent',
+      client: ctx.llmClient,
+      modelConfig: modelConfig,
+      state: AgentState(sessionId: task.id),
+      tools: _buildTools(ctx.workspaceDir!),
+      systemPrompts: [_systemPrompt],
+      controller: ctx.controller,
+      withGeneralPrinciples: false,
+      planMode: PlanMode.none,
+      disableSubAgents: true,
+      autoSaveStateFunc: (_) async {},
+    );
+    await agent.run([
+      UserMessage([TextPart(task.input['prompt'] as String)]),
+    ], useStream: false);
+
+    final f = File('${ctx.workspaceDir!.path}/echo.txt');
+    final echoed = f.existsSync() ? f.readAsStringSync() : null;
+
+    return (
+      transcript: Transcript(
+        messages: List.unmodifiable(agent.state.history.messages),
+        toolCalls: const [],
+        metrics: const TranscriptMetrics(
+          nTurns: 0,
+          nToolCalls: 0,
+          nTotalTokens: 0,
+        ),
+      ),
+      outcome: Outcome(environmentState: {'echoed': ?echoed}),
+    );
+  }
+
+  @override
+  Future<void> dispose() async {}
+}
+
+// ─── 4. Grader：echoed == 期望的文本 ─────────────────────────────────────
+class _EchoMatchesGrader extends CodeGrader {
+  final String expected;
+  _EchoMatchesGrader(this.expected);
+  @override
+  String get name => 'echo_matches';
+
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async => [
+    Assertion(
+      description: 'echoed text matches expected',
+      passed: outcome.environmentState['echoed'] == expected,
+      actual: '${outcome.environmentState['echoed']}',
+      expected: expected,
+    ),
+  ];
+}
+
+// ─── 5. EvalTask + EvalSuite ─────────────────────────────────────────────
+class _EchoTask implements EvalTask {
+  @override
+  String get id => 'echo_hi';
+  @override
+  String get description => 'agent must echo "hi" verbatim';
+  @override
+  Map<String, dynamic> get input => {'prompt': 'echo this back: hi'};
+  @override
+  Map<String, String> get metadata => const {};
+  @override
+  ReferenceSolution? get referenceSolution => null;
+  @override
+  List<Grader> get graders => [_EchoMatchesGrader('hi')];
+  @override
+  int get trialsPerRun => 2;
+  @override
+  Duration? get timeout => const Duration(minutes: 1);
+}
+
+// ─── 6. main：拼起来跑 ────────────────────────────────────────────────────
+Future<void> main() async {
+  final env = Platform.environment;
+  OpenAIClient client() => OpenAIClient(
+    apiKey: env['OPENAI_API_KEY']!,
+    baseUrl: env['OPENAI_BASE_URL'] ?? 'https://api.openai.com/v1',
+  );
+
+  final runner = EvalRunner(
+    environment: EchoEnv(client),
+    harnessFactory: EchoHarness(
+      ModelConfig(model: env['OPENAI_MODEL'] ?? 'gpt-4o-mini'),
+    ),
+    exporters: [JsonlTraceExporter(File('.eval_traces/echo.jsonl'))],
+    reportStore: FileReportStore(Directory('.eval_reports')),
+  );
+
+  final report = await runner.runSuite(
+    runName: 'echo_${DateTime.now().millisecondsSinceEpoch}',
+    suite: EvalSuite(
+      name: 'echo_capability',
+      agentName: 'echo_agent',
+      kind: SuiteKind.capability,
+      tasks: [_EchoTask()],
+    ),
+    concurrency: 2,
+  );
+
+  stdout.writeln(report.toMarkdownSummary());
+  exit(report.taskPassRate >= 1.0 ? 0 : 1);
+}

--- a/lib/eval.dart
+++ b/lib/eval.dart
@@ -1,0 +1,73 @@
+/// Eval subsystem for `dart_agent_core`.
+///
+/// See [Anthropic — Demystifying evals for AI agents](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents)
+/// for the underlying methodology, and `doc/eval-guide.zh-CN.md` for the
+/// usage guide.
+///
+/// This entry point is intentionally separate from `dart_agent_core.dart`:
+/// applications that don't need eval primitives should not pay the
+/// import cost. Backward compatibility is preserved.
+library;
+
+// Core types
+export 'src/eval/core/reference_solution.dart';
+export 'src/eval/core/transcript.dart';
+export 'src/eval/core/outcome.dart';
+export 'src/eval/core/trial.dart';
+export 'src/eval/core/trial_result.dart';
+export 'src/eval/core/eval_task.dart';
+export 'src/eval/core/eval_suite.dart';
+export 'src/eval/core/eval_context.dart';
+export 'src/eval/core/eval_environment.dart';
+export 'src/eval/core/agent_harness_factory.dart';
+export 'src/eval/core/eval_runner.dart';
+export 'src/eval/core/eval_run_report.dart';
+export 'src/eval/core/eval_run_config.dart';
+
+// Graders
+export 'src/eval/graders/grader.dart';
+export 'src/eval/graders/score.dart';
+export 'src/eval/graders/code_grader.dart';
+export 'src/eval/graders/model_grader.dart';
+export 'src/eval/graders/human_grader.dart';
+
+// LLM (recording / replay / rate limit)
+export 'src/eval/llm/llm_request_hash.dart';
+export 'src/eval/llm/recording_store.dart';
+export 'src/eval/llm/recording_llm_client.dart';
+export 'src/eval/llm/replay_llm_client.dart';
+export 'src/eval/llm/rate_limit_gate.dart';
+
+// Observability
+export 'src/eval/observability/trace_exporter.dart';
+export 'src/eval/observability/jsonl_trace_exporter.dart';
+export 'src/eval/observability/composite_trace_exporter.dart';
+export 'src/eval/observability/transcript_viewer.dart';
+export 'src/eval/observability/langfuse/langfuse_config.dart';
+export 'src/eval/observability/langfuse/langfuse_event.dart';
+export 'src/eval/observability/langfuse/langfuse_client.dart';
+export 'src/eval/observability/langfuse/langfuse_trace_exporter.dart';
+
+// Metrics
+export 'src/eval/metrics/pass_at_k.dart';
+export 'src/eval/metrics/pass_caret_k.dart';
+export 'src/eval/metrics/classification_metrics.dart';
+
+// Suite Health (Anthropic Step 7)
+export 'src/eval/suite_health/saturation_status.dart';
+export 'src/eval/suite_health/suite_health_report.dart';
+export 'src/eval/suite_health/suite_health_analyzer.dart';
+
+// Calibration (Anthropic Step 5)
+export 'src/eval/calibration/calibration_report.dart';
+export 'src/eval/calibration/judge_calibrator.dart';
+
+// Reporting
+export 'src/eval/reporting/report_store.dart';
+export 'src/eval/reporting/report_generator.dart';
+export 'src/eval/reporting/diff_reporter.dart';
+
+// Loaders (data-driven suites)
+export 'src/eval/loaders/grader_registry.dart';
+export 'src/eval/loaders/json_eval_task.dart';
+export 'src/eval/loaders/suite_loader.dart';

--- a/lib/src/eval/calibration/calibration_report.dart
+++ b/lib/src/eval/calibration/calibration_report.dart
@@ -1,0 +1,102 @@
+import '../core/trial.dart';
+
+/// 一个被人工标过的 trial。用于校准 LLM judge。
+class HumanLabeledTrial {
+  /// trial 的标识符，便于关联回原始数据。
+  final TrialId trialId;
+
+  /// 人工给出的"正确"分值（与 judge 同一刻度）。
+  final double humanScore;
+
+  /// 人工评注（可选，便于后续审视）。
+  final String? humanRationale;
+
+  /// 评估对象的输入摘要（让 judge 复跑用的最小信息）。
+  final Map<String, dynamic> input;
+
+  /// 被评估的输出（judge 判分的对象）。
+  final String output;
+
+  const HumanLabeledTrial({
+    required this.trialId,
+    required this.humanScore,
+    this.humanRationale,
+    required this.input,
+    required this.output,
+  });
+}
+
+/// LLM judge 与人工评分的相关性。
+class CalibrationReport {
+  /// Spearman 等级相关系数 ∈ [-1, 1]。Anthropic 推荐 ≥ 0.7 才上线。
+  final double spearmanCorrelation;
+
+  /// Pearson 线性相关系数 ∈ [-1, 1]。
+  final double pearsonCorrelation;
+
+  /// "judge 与人工差 ≤ tolerance"的样本占比 ∈ [0, 1]。
+  final double agreementRate;
+
+  /// 平均绝对误差（MAE）。
+  final double meanAbsoluteError;
+
+  final int samples;
+  final int agreementCount;
+  final int disagreementCount;
+
+  /// 不一致最严重的 trial，由 judge - human 绝对差降序排列，前 N 个。
+  final List<TrialDisagreement> disagreements;
+
+  const CalibrationReport({
+    required this.spearmanCorrelation,
+    required this.pearsonCorrelation,
+    required this.agreementRate,
+    required this.meanAbsoluteError,
+    required this.samples,
+    required this.agreementCount,
+    required this.disagreementCount,
+    required this.disagreements,
+  });
+
+  /// Anthropic Step 5 的"上线门槛"：Spearman ≥ 0.7。
+  bool get meetsAnthropicBar => spearmanCorrelation >= 0.7;
+
+  Map<String, dynamic> toJson() => {
+    'spearmanCorrelation': spearmanCorrelation,
+    'pearsonCorrelation': pearsonCorrelation,
+    'agreementRate': agreementRate,
+    'meanAbsoluteError': meanAbsoluteError,
+    'samples': samples,
+    'agreementCount': agreementCount,
+    'disagreementCount': disagreementCount,
+    'meetsAnthropicBar': meetsAnthropicBar,
+    'disagreements': disagreements.map((d) => d.toJson()).toList(),
+  };
+}
+
+class TrialDisagreement {
+  final TrialId trialId;
+  final double humanScore;
+  final double judgeScore;
+  final double absoluteDelta;
+  final String? humanRationale;
+  final String? judgeRationale;
+
+  const TrialDisagreement({
+    required this.trialId,
+    required this.humanScore,
+    required this.judgeScore,
+    required this.absoluteDelta,
+    this.humanRationale,
+    this.judgeRationale,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'trialId': trialId.toJson(),
+    'humanScore': humanScore,
+    'judgeScore': judgeScore,
+    'absoluteDelta': absoluteDelta,
+    'humanRationale': humanRationale,
+    'judgeRationale': judgeRationale,
+  };
+}

--- a/lib/src/eval/calibration/judge_calibrator.dart
+++ b/lib/src/eval/calibration/judge_calibrator.dart
@@ -1,0 +1,213 @@
+import 'calibration_report.dart';
+
+/// 业务方提供的 judge 评分回调。
+///
+/// 输入是 [HumanLabeledTrial.input] + [HumanLabeledTrial.output]，输出
+/// 是 judge 给出的分值（与人工同刻度）和可选解释。如果 judge 无法判断，
+/// 返回 null（被排除在相关性计算之外，但会单独统计）。
+typedef JudgeScorer = Future<JudgeScore?> Function(HumanLabeledTrial labeled);
+
+class JudgeScore {
+  final double value;
+  final String? rationale;
+  const JudgeScore({required this.value, this.rationale});
+}
+
+/// 默认配置：超过 0.15 的差距视为"不同意"，并报告 top 20 个最严重的偏差。
+class CalibrationConfig {
+  /// |humanScore - judgeScore| 在此阈值内视为"同意"。
+  final double agreementTolerance;
+
+  /// 报告中显示前 N 个偏差最大的 trial。
+  final int topDisagreements;
+
+  const CalibrationConfig({
+    this.agreementTolerance = 0.15,
+    this.topDisagreements = 20,
+  });
+}
+
+/// 度量 LLM judge 与人工评分的一致性。
+///
+/// 用法：
+/// ```dart
+/// final calibrator = JudgeCalibrator();
+/// final report = await calibrator.calibrate(
+///   goldenSet: humanLabeledTrials,
+///   judgeScorer: (labeled) async {
+///     final r = await myLLMJudge.grade(labeled.input, labeled.output);
+///     return JudgeScore(value: r.score, rationale: r.reasoning);
+///   },
+/// );
+/// if (!report.meetsAnthropicBar) {
+///   throw StateError('judge correlation too low: ${report.spearmanCorrelation}');
+/// }
+/// ```
+class JudgeCalibrator {
+  final CalibrationConfig config;
+
+  const JudgeCalibrator({this.config = const CalibrationConfig()});
+}
+
+extension JudgeCalibratorOps on JudgeCalibrator {
+  Future<CalibrationReport> calibrate({
+    required List<HumanLabeledTrial> goldenSet,
+    required JudgeScorer judgeScorer,
+    int concurrency = 4,
+  }) async {
+    if (goldenSet.isEmpty) {
+      throw ArgumentError('goldenSet must not be empty');
+    }
+
+    // 并发拉 judge 分数（每个 trial 最多一次 judge 调用）。
+    final results = List<_PairedScore?>.filled(goldenSet.length, null);
+    final iterator = goldenSet.asMap().entries.iterator;
+
+    Future<void> worker() async {
+      while (iterator.moveNext()) {
+        final entry = iterator.current;
+        final i = entry.key;
+        final labeled = entry.value;
+        try {
+          final js = await judgeScorer(labeled);
+          if (js != null) {
+            results[i] = _PairedScore(
+              labeled: labeled,
+              judgeValue: js.value,
+              judgeRationale: js.rationale,
+            );
+          }
+        } catch (e, st) {
+          // 失败的样本被忽略（不计入相关性）。
+          // 业务方可在 scorer 内做容错或返回 null。
+          assert(() {
+            print('judge scorer failed for ${labeled.trialId}: $e\n$st');
+            return true;
+          }());
+        }
+      }
+    }
+
+    await Future.wait(List.generate(concurrency, (_) => worker()));
+
+    final valid = results.whereType<_PairedScore>().toList();
+    if (valid.length < 2) {
+      throw StateError(
+        'Need at least 2 valid (judge, human) pairs to compute correlation. '
+        'Got ${valid.length}.',
+      );
+    }
+
+    final humanValues = valid.map((p) => p.labeled.humanScore).toList();
+    final judgeValues = valid.map((p) => p.judgeValue).toList();
+
+    final spearman = _spearman(humanValues, judgeValues);
+    final pearson = _pearson(humanValues, judgeValues);
+
+    final tolerance = config.agreementTolerance;
+    final agreementCount = valid
+        .where((p) => (p.labeled.humanScore - p.judgeValue).abs() <= tolerance)
+        .length;
+    final mae =
+        valid
+            .map((p) => (p.labeled.humanScore - p.judgeValue).abs())
+            .fold<double>(0, (a, b) => a + b) /
+        valid.length;
+
+    final disagreements =
+        valid
+            .map(
+              (p) => TrialDisagreement(
+                trialId: p.labeled.trialId,
+                humanScore: p.labeled.humanScore,
+                judgeScore: p.judgeValue,
+                absoluteDelta: (p.labeled.humanScore - p.judgeValue).abs(),
+                humanRationale: p.labeled.humanRationale,
+                judgeRationale: p.judgeRationale,
+              ),
+            )
+            .toList()
+          ..sort((a, b) => b.absoluteDelta.compareTo(a.absoluteDelta));
+
+    final topDisagreements = disagreements
+        .take(config.topDisagreements)
+        .toList();
+
+    return CalibrationReport(
+      spearmanCorrelation: spearman,
+      pearsonCorrelation: pearson,
+      agreementRate: agreementCount / valid.length,
+      meanAbsoluteError: mae,
+      samples: valid.length,
+      agreementCount: agreementCount,
+      disagreementCount: valid.length - agreementCount,
+      disagreements: topDisagreements,
+    );
+  }
+}
+
+class _PairedScore {
+  final HumanLabeledTrial labeled;
+  final double judgeValue;
+  final String? judgeRationale;
+  const _PairedScore({
+    required this.labeled,
+    required this.judgeValue,
+    this.judgeRationale,
+  });
+}
+
+double _pearson(List<double> xs, List<double> ys) {
+  assert(xs.length == ys.length);
+  final n = xs.length;
+  if (n < 2) return 0.0;
+  final meanX = xs.reduce((a, b) => a + b) / n;
+  final meanY = ys.reduce((a, b) => a + b) / n;
+  double num = 0, denX = 0, denY = 0;
+  for (var i = 0; i < n; i++) {
+    final dx = xs[i] - meanX;
+    final dy = ys[i] - meanY;
+    num += dx * dy;
+    denX += dx * dx;
+    denY += dy * dy;
+  }
+  if (denX == 0 || denY == 0) return 0.0;
+  return num / _sqrt(denX * denY);
+}
+
+/// Spearman = Pearson on the rank-transformed values. 用平均秩处理并列。
+double _spearman(List<double> xs, List<double> ys) {
+  return _pearson(_ranks(xs), _ranks(ys));
+}
+
+/// 平均秩：[3, 1, 1, 2] → [4, 1.5, 1.5, 3]
+List<double> _ranks(List<double> values) {
+  final indexed = List.generate(values.length, (i) => MapEntry(i, values[i]));
+  indexed.sort((a, b) => a.value.compareTo(b.value));
+  final ranks = List<double>.filled(values.length, 0);
+  var i = 0;
+  while (i < indexed.length) {
+    var j = i;
+    while (j + 1 < indexed.length && indexed[j + 1].value == indexed[i].value) {
+      j++;
+    }
+    // 索引区间 [i, j] 同分，平均秩 = (i + j) / 2 + 1
+    final avgRank = (i + j) / 2.0 + 1.0;
+    for (var k = i; k <= j; k++) {
+      ranks[indexed[k].key] = avgRank;
+    }
+    i = j + 1;
+  }
+  return ranks;
+}
+
+double _sqrt(double v) {
+  // dart:math 的 sqrt 在很多场景已经导入；这里我们只需要一个稳的开方。
+  // 使用牛顿迭代避免拉额外 import 仅为 sqrt。
+  if (v <= 0) return 0;
+  var x = v;
+  for (var i = 0; i < 32; i++) {
+    x = 0.5 * (x + v / x);
+  }
+  return x;
+}

--- a/lib/src/eval/core/agent_harness_factory.dart
+++ b/lib/src/eval/core/agent_harness_factory.dart
@@ -1,0 +1,31 @@
+import 'eval_context.dart';
+import 'eval_task.dart';
+import 'outcome.dart';
+import 'transcript.dart';
+import 'trial.dart';
+
+/// Anthropic: an *agent harness* is the system that lets a model act as
+/// an agent. The framework does not assume any specific implementation —
+/// applications provide their own factory.
+abstract class AgentHarnessFactory {
+  /// Build a session for one trial. Implementations are responsible for:
+  /// - Instantiating the agent (e.g. a StatefulAgent)
+  /// - Wiring tools / skills
+  /// - Subscribing to controller events for transcript collection
+  Future<AgentHarnessSession> create({
+    required EvalTask task,
+    required Trial trial,
+    required EvalContext context,
+  });
+}
+
+/// One trial worth of agent execution. Always created via the factory.
+abstract class AgentHarnessSession {
+  /// Run the agent for this trial and produce both a transcript and an
+  /// outcome.
+  Future<({Transcript transcript, Outcome outcome})> run();
+
+  /// Called after [run] regardless of outcome. Free any per-session
+  /// resources (file handles, subscriptions, etc.).
+  Future<void> dispose();
+}

--- a/lib/src/eval/core/eval_context.dart
+++ b/lib/src/eval/core/eval_context.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import '../../agent/controller.dart';
+import '../../core/llm_client.dart';
+
+/// Per-trial context provided by an [EvalEnvironment].
+///
+/// The context groups everything the [AgentHarnessFactory] needs to build
+/// and run an agent under test: filesystem root, clock, LLM client (which
+/// may be a recording/replay wrapper), application services, and a
+/// preconfigured [AgentController] with trace exporters already attached.
+class EvalContext {
+  /// Workspace root (when the agent reads/writes files). May be null for
+  /// agents that don't touch the filesystem.
+  final Directory? workspaceDir;
+
+  /// Time source. Use `clock.now()` instead of `DateTime.now()` so trials
+  /// can be made deterministic. Implementations may wire this up via
+  /// `package:clock` zones if they wish.
+  final EvalClock clock;
+
+  /// LLM client to use during the trial. May be a [RecordingLLMClient] or
+  /// [ReplayLLMClient] depending on the run mode.
+  final LLMClient llmClient;
+
+  /// Controller pre-attached with trace exporters and listeners. The
+  /// harness should reuse this controller, not create its own.
+  final AgentController controller;
+
+  /// Application services keyed by Type. Use [services] for typed lookup.
+  final Map<Type, Object> servicesMap;
+
+  /// Free-form metadata that flows into transcripts and reports.
+  final Map<String, dynamic> metadata;
+
+  EvalContext({
+    this.workspaceDir,
+    required this.clock,
+    required this.llmClient,
+    required this.controller,
+    this.servicesMap = const {},
+    this.metadata = const {},
+  });
+
+  T services<T>() => servicesMap[T] as T;
+}
+
+/// Time source abstraction. Production agents call `clock.now()` instead of
+/// `DateTime.now()` so the eval runner can lock time per trial.
+abstract class EvalClock {
+  DateTime now();
+}
+
+/// Real clock — delegates to [DateTime.now].
+class SystemEvalClock implements EvalClock {
+  const SystemEvalClock();
+
+  @override
+  DateTime now() => DateTime.now();
+}
+
+/// Fixed clock — always returns [reference]. Useful for deterministic trials.
+class FixedEvalClock implements EvalClock {
+  final DateTime reference;
+
+  const FixedEvalClock(this.reference);
+
+  @override
+  DateTime now() => reference;
+}

--- a/lib/src/eval/core/eval_environment.dart
+++ b/lib/src/eval/core/eval_environment.dart
@@ -1,0 +1,16 @@
+import 'eval_context.dart';
+import 'eval_task.dart';
+import 'trial.dart';
+
+/// Anthropic Step 4: each trial must run in an isolated, clean environment.
+///
+/// Applications implement this to set up workspaces, in-memory databases,
+/// time, and any other per-trial resources. The runner calls [prepare]
+/// before each trial and [dispose] after, regardless of outcome.
+abstract class EvalEnvironment {
+  /// Prepare a fresh context for one trial.
+  Future<EvalContext> prepare({required Trial trial, required EvalTask task});
+
+  /// Tear down. Called after the trial completes (success or failure).
+  Future<void> dispose(EvalContext context);
+}

--- a/lib/src/eval/core/eval_run_config.dart
+++ b/lib/src/eval/core/eval_run_config.dart
@@ -1,0 +1,171 @@
+import '../core/eval_suite.dart';
+import '../core/eval_task.dart';
+
+/// Run mode controlled by CLI / env.
+enum EvalRunMode { record, replay, live }
+
+/// Filter applied to suites and tasks at runtime.
+///
+/// `agents` filters at the **suite** level (a suite belongs to one agent
+/// — see [EvalSuite.agentName]). `buckets` and `taskIds` filter at the
+/// **task** level inside an already-selected suite.
+class TaskFilter {
+  final Set<String>? agents;
+  final Set<String>? buckets;
+  final Set<String>? taskIds;
+
+  const TaskFilter({this.agents, this.buckets, this.taskIds});
+
+  /// Whether the given suite passes the agent filter.
+  bool matchesSuite(EvalSuite suite) {
+    if (agents != null && !agents!.contains(suite.agentName)) return false;
+    return true;
+  }
+
+  /// Whether the given task passes the task-level filters.
+  ///
+  /// Note: this does NOT check the agent filter — see [matchesSuite].
+  /// Callers that want a single predicate for [EvalRunner.runSuite]
+  /// should pre-check the suite once and then use [matchesTask] for
+  /// each task.
+  bool matchesTask(EvalTask task) {
+    if (taskIds != null && !taskIds!.contains(task.id)) return false;
+    if (buckets != null) {
+      final b = task.metadata['failure_bucket'];
+      if (b == null || !buckets!.contains(b)) return false;
+    }
+    return true;
+  }
+
+  bool get isEmpty => agents == null && buckets == null && taskIds == null;
+}
+
+/// Parsed L2 (runner-level) configuration. Sources: CLI args, env vars.
+/// Applications instantiate one in `main()` and pass fields to the runner.
+class EvalRunConfig {
+  final String runName;
+  final int concurrency;
+  final int? trialsOverride;
+  final EvalRunMode mode;
+  final TaskFilter filter;
+  final int? rpm;
+  final int? tpm;
+  final String? recordingDir;
+  final bool langfuseEnabled;
+  final String? langfuseHost;
+
+  const EvalRunConfig({
+    required this.runName,
+    this.concurrency = 8,
+    this.trialsOverride,
+    this.mode = EvalRunMode.replay,
+    this.filter = const TaskFilter(),
+    this.rpm,
+    this.tpm,
+    this.recordingDir,
+    this.langfuseEnabled = true,
+    this.langfuseHost,
+  });
+}
+
+/// Tiny CLI parser. Avoids pulling in `package:args` to keep deps lean.
+///
+/// Supported flags:
+/// ```
+/// --run-name NAME
+/// --concurrency N
+/// --trials-override N
+/// --mode (record|replay|live)
+/// --filter-agent A,B,C
+/// --filter-bucket A,B,C
+/// --filter-task-id A,B,C
+/// --rpm N
+/// --tpm N
+/// --recording-dir PATH
+/// --no-langfuse
+/// --langfuse-host URL
+/// ```
+EvalRunConfig parseEvalRunArgs(
+  List<String> args, {
+  Map<String, String>? env,
+  String? defaultRunName,
+}) {
+  String? runName = defaultRunName;
+  var concurrency = 8;
+  int? trials;
+  var mode = EvalRunMode.replay;
+  Set<String>? agents;
+  Set<String>? buckets;
+  Set<String>? taskIds;
+  int? rpm;
+  int? tpm;
+  String? recordingDir;
+  var langfuseEnabled = true;
+  String? langfuseHost = env?['LANGFUSE_HOST'];
+
+  for (var i = 0; i < args.length; i++) {
+    final a = args[i];
+    String next() {
+      if (i + 1 >= args.length) {
+        throw ArgumentError('flag $a requires a value');
+      }
+      return args[++i];
+    }
+
+    switch (a) {
+      case '--run-name':
+        runName = next();
+        break;
+      case '--concurrency':
+        concurrency = int.parse(next());
+        break;
+      case '--trials-override':
+        trials = int.parse(next());
+        break;
+      case '--mode':
+        final v = next();
+        mode = EvalRunMode.values.firstWhere((m) => m.name == v);
+        break;
+      case '--filter-agent':
+        agents = next().split(',').map((s) => s.trim()).toSet();
+        break;
+      case '--filter-bucket':
+        buckets = next().split(',').map((s) => s.trim()).toSet();
+        break;
+      case '--filter-task-id':
+        taskIds = next().split(',').map((s) => s.trim()).toSet();
+        break;
+      case '--rpm':
+        rpm = int.parse(next());
+        break;
+      case '--tpm':
+        tpm = int.parse(next());
+        break;
+      case '--recording-dir':
+        recordingDir = next();
+        break;
+      case '--no-langfuse':
+        langfuseEnabled = false;
+        break;
+      case '--langfuse-host':
+        langfuseHost = next();
+        break;
+      default:
+        // Unknown flags are tolerated to allow downstream apps to extend.
+        break;
+    }
+  }
+
+  return EvalRunConfig(
+    runName: runName ?? 'run_${DateTime.now().millisecondsSinceEpoch}',
+    concurrency: concurrency,
+    trialsOverride: trials,
+    mode: mode,
+    filter: TaskFilter(agents: agents, buckets: buckets, taskIds: taskIds),
+    rpm: rpm,
+    tpm: tpm,
+    recordingDir: recordingDir,
+    langfuseEnabled: langfuseEnabled,
+    langfuseHost: langfuseHost,
+  );
+}

--- a/lib/src/eval/core/eval_run_report.dart
+++ b/lib/src/eval/core/eval_run_report.dart
@@ -1,0 +1,145 @@
+import '../core/eval_suite.dart';
+import '../core/trial_result.dart';
+import '../metrics/pass_at_k.dart';
+import '../metrics/pass_caret_k.dart';
+import '../suite_health/saturation_status.dart';
+
+/// Aggregated outcome of one [EvalRunner.runSuite] invocation.
+class EvalRunReport {
+  final String runName;
+  final EvalSuite suite;
+  final List<TrialResult> trials;
+  final DateTime startedAt;
+  final DateTime endedAt;
+
+  EvalRunReport({
+    required this.runName,
+    required this.suite,
+    required this.trials,
+    required this.startedAt,
+    required this.endedAt,
+  });
+
+  Duration get duration => endedAt.difference(startedAt);
+
+  /// Trials grouped by task id.
+  Map<String, List<TrialResult>> trialsByTask() {
+    final out = <String, List<TrialResult>>{};
+    for (final t in trials) {
+      out.putIfAbsent(t.trial.taskId, () => []).add(t);
+    }
+    return out;
+  }
+
+  /// pass@k for each task, computed from its actual trial count.
+  /// Returns map of taskId -> {k -> pass@k}.
+  Map<String, Map<int, double>> passAtKByTask({List<int> ks = const [1]}) {
+    final byTask = trialsByTask();
+    final out = <String, Map<int, double>>{};
+    for (final entry in byTask.entries) {
+      final passes = entry.value.map((tr) => tr.allGradersPassed).toList();
+      out[entry.key] = {for (final k in ks) k: passAtK(passes, k)};
+    }
+    return out;
+  }
+
+  /// pass^k for each task.
+  Map<String, Map<int, double>> passCaretKByTask({List<int> ks = const [1]}) {
+    final byTask = trialsByTask();
+    final out = <String, Map<int, double>>{};
+    for (final entry in byTask.entries) {
+      final passes = entry.value.map((tr) => tr.allGradersPassed).toList();
+      out[entry.key] = {for (final k in ks) k: passCaretK(passes, k)};
+    }
+    return out;
+  }
+
+  /// Overall fraction of trials that passed.
+  double get trialPassRate {
+    if (trials.isEmpty) return 0.0;
+    final passed = trials.where((t) => t.allGradersPassed).length;
+    return passed / trials.length;
+  }
+
+  /// Overall task pass rate. Definition depends on suite kind:
+  ///   - regression: task passes only if every trial passes (pass^N where N=trialsPerRun)
+  ///   - capability: task passes if at least one trial passes (pass@N)
+  ///   - mixed: same as regression
+  double get taskPassRate {
+    final byTask = trialsByTask();
+    if (byTask.isEmpty) return 0.0;
+    final passing = byTask.values.where((trs) {
+      if (suite.kind == SuiteKind.capability) {
+        return trs.any((t) => t.allGradersPassed);
+      }
+      return trs.every((t) => t.allGradersPassed);
+    }).length;
+    return passing / byTask.length;
+  }
+
+  /// Mean of each grader's score across all trials (null-valued scores
+  /// are excluded). Useful for tracking title_quality, etc.
+  Map<String, double> get graderMeans {
+    final accum = <String, List<double>>{};
+    for (final tr in trials) {
+      for (final s in tr.scores) {
+        if (s.value == null) continue;
+        accum.putIfAbsent(s.graderName, () => []).add(s.value!);
+      }
+    }
+    return {
+      for (final e in accum.entries)
+        e.key: e.value.reduce((a, b) => a + b) / e.value.length,
+    };
+  }
+
+  /// Per-bucket pass rate using metadata['failure_bucket'] on the source
+  /// task. The Runner attaches the bucket to each TrialResult via
+  /// `Trial`'s `taskId` lookup.
+  Map<String, double> bucketPassRates(Map<String, String> taskBucketMap) {
+    final byBucket = <String, List<bool>>{};
+    for (final tr in trials) {
+      final b = taskBucketMap[tr.trial.taskId];
+      if (b == null) continue;
+      byBucket.putIfAbsent(b, () => []).add(tr.allGradersPassed);
+    }
+    return {
+      for (final e in byBucket.entries)
+        e.key: e.value.where((v) => v).length / e.value.length,
+    };
+  }
+
+  /// Saturation snapshot for THIS run. See Anthropic Step 7. Capability
+  /// suites that come back with a high `saturatedTaskRatio` are signaling
+  /// that easy tasks should graduate to a regression suite and harder
+  /// tasks should be added.
+  ///
+  /// This is a single-run computation; for cross-run analysis (graduation
+  /// candidates that have been mature in N consecutive runs, broken-task
+  /// detection across runs) use `SuiteHealthAnalyzer`.
+  SaturationStatus saturationStatus({
+    SaturationThresholds thresholds = const SaturationThresholds(),
+  }) {
+    final byTask = trialsByTask();
+    final mature = <String>[];
+    final stragglers = <String>[];
+    for (final entry in byTask.entries) {
+      final passes = entry.value.where((tr) => tr.allGradersPassed).length;
+      final total = entry.value.length;
+      final passRate = total == 0 ? 0.0 : passes / total;
+      if (passRate >= thresholds.matureTaskPassRate) {
+        mature.add(entry.key);
+      } else if (passRate <= thresholds.brokenTaskPassRate &&
+          total >= thresholds.minTrialsForBrokenJudgment) {
+        stragglers.add(entry.key);
+      }
+    }
+    final ratio = byTask.isEmpty ? 0.0 : mature.length / byTask.length;
+    return SaturationStatus(
+      saturatedTaskRatio: ratio,
+      suiteSaturated: ratio >= thresholds.saturatedSuiteRatio,
+      matureTasks: mature,
+      stragglerTasks: stragglers,
+    );
+  }
+}

--- a/lib/src/eval/core/eval_runner.dart
+++ b/lib/src/eval/core/eval_runner.dart
@@ -1,0 +1,341 @@
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+
+import '../graders/score.dart';
+import '../llm/rate_limit_gate.dart';
+import '../llm/recording_store.dart';
+import '../observability/composite_trace_exporter.dart';
+import '../observability/trace_exporter.dart';
+import '../reporting/report_store.dart';
+import 'agent_harness_factory.dart';
+import 'eval_environment.dart';
+import 'eval_run_report.dart';
+import 'eval_suite.dart';
+import 'eval_task.dart';
+import 'outcome.dart';
+import 'transcript.dart';
+import 'trial.dart';
+import 'trial_result.dart';
+
+final _logger = Logger('EvalRunner');
+
+/// Runs evaluation suites with bounded concurrency and optional rate
+/// limiting. See RFC §6.8 and §6.15.
+class EvalRunner {
+  final EvalEnvironment environment;
+  final AgentHarnessFactory harnessFactory;
+  final TraceExporter exporter;
+
+  /// Optional. If set, the runner exposes the store to the harness via
+  /// the EvalContext (the harness chooses to wrap its LLMClient or not).
+  final RecordingStore? recordingStore;
+
+  /// Optional persistent store for run reports. When set, [runSuite]
+  /// automatically saves the final [EvalRunReport] for cross-run analysis
+  /// (saturation, graduation, diff).
+  final ReportStore? reportStore;
+
+  /// Optional. The harness can pull this from EvalContext too.
+  final RateLimitGate rateLimitGate;
+
+  /// Default per-trial timeout. Tasks may override via [EvalTask.timeout].
+  final Duration defaultTimeout;
+
+  EvalRunner({
+    required this.environment,
+    required this.harnessFactory,
+    List<TraceExporter> exporters = const [],
+    this.recordingStore,
+    this.reportStore,
+    RateLimitGate? rateLimitGate,
+    this.defaultTimeout = const Duration(minutes: 5),
+  }) : exporter = exporters.length == 1
+           ? exporters.first
+           : CompositeTraceExporter(exporters),
+       rateLimitGate = rateLimitGate ?? const NoopRateLimitGate();
+}
+
+extension EvalRunnerOps on EvalRunner {
+  /// Run all tasks in [suite], honoring [concurrency] and per-task
+  /// trialsPerRun. Returns the aggregated report.
+  Future<EvalRunReport> runSuite({
+    required String runName,
+    required EvalSuite suite,
+    int concurrency = 8,
+    int? trialsOverride,
+    bool Function(EvalTask)? filter,
+  }) async {
+    final problems = suite.validate();
+    if (problems.isNotEmpty) {
+      throw StateError(
+        'Invalid suite "${suite.name}":\n${problems.join('\n')}',
+      );
+    }
+
+    final tasks = filter == null
+        ? suite.tasks
+        : suite.tasks.where(filter).toList();
+
+    // Build the work queue: (task, trialIndex) pairs.
+    final queue = <_PlannedTrial>[];
+    for (final task in tasks) {
+      final trialsPerRun = trialsOverride ?? task.trialsPerRun;
+      for (var i = 0; i < trialsPerRun; i++) {
+        queue.add(_PlannedTrial(task: task, trialIndex: i));
+      }
+    }
+
+    final results = <TrialResult>[];
+    final startedAt = DateTime.now();
+
+    // Bounded concurrency via a simple semaphore over an async queue.
+    final iterator = queue.iterator;
+    final pool = List<Future<void>>.generate(
+      concurrency,
+      (_) => _worker(
+        iterator: iterator,
+        suite: suite,
+        runName: runName,
+        results: results,
+      ),
+    );
+    await Future.wait(pool);
+
+    final endedAt = DateTime.now();
+
+    // Run-level aggregate scores: report top-line metrics.
+    final report = EvalRunReport(
+      runName: runName,
+      suite: suite,
+      trials: results,
+      startedAt: startedAt,
+      endedAt: endedAt,
+    );
+
+    final aggregateScores = <String, double>{
+      'task_pass_rate': report.taskPassRate,
+      'trial_pass_rate': report.trialPassRate,
+      ...report.graderMeans.map((k, v) => MapEntry('grader_mean.$k', v)),
+    };
+
+    await exporter.onRunEnd(
+      runName: runName,
+      suiteName: suite.name,
+      aggregateScores: aggregateScores,
+    );
+    await exporter.dispose();
+    if (recordingStore != null) await recordingStore!.flush();
+    if (reportStore != null) await reportStore!.save(report);
+
+    return report;
+  }
+
+  /// Convenience: run a single task. Useful for ad-hoc debugging or for
+  /// rerunning a flaky task with extra trials.
+  ///
+  /// Internally wraps the task in a one-off [EvalSuite] of kind
+  /// [SuiteKind.mixed]. The synthetic suite is **not** persisted to the
+  /// report store (the run is for diagnosis, not for cross-run analysis).
+  Future<List<TrialResult>> runTask({
+    required String runName,
+    required EvalTask task,
+    required String agentName,
+    int? trialsOverride,
+  }) async {
+    final tempSuite = EvalSuite(
+      name: '_one_off/${task.id}',
+      agentName: agentName,
+      kind: SuiteKind.mixed,
+      tasks: [task],
+    );
+    // Use a one-off runner that skips the persistent report store but
+    // keeps every other behavior (exporters, recording, rate gate).
+    final scopedRunner = EvalRunner(
+      environment: environment,
+      harnessFactory: harnessFactory,
+      exporters: exporter is CompositeTraceExporter
+          ? (exporter as CompositeTraceExporter).exporters
+          : [exporter],
+      recordingStore: recordingStore,
+      // Intentionally null: this is a debug run, don't pollute history.
+      // reportStore: null,
+      rateLimitGate: rateLimitGate,
+      defaultTimeout: defaultTimeout,
+    );
+    final report = await scopedRunner.runSuite(
+      runName: runName,
+      suite: tempSuite,
+      concurrency: 1,
+      trialsOverride: trialsOverride,
+    );
+    return report.trials;
+  }
+}
+
+class _PlannedTrial {
+  final EvalTask task;
+  final int trialIndex;
+  _PlannedTrial({required this.task, required this.trialIndex});
+}
+
+extension on EvalRunner {
+  Future<void> _worker({
+    required Iterator<_PlannedTrial> iterator,
+    required EvalSuite suite,
+    required String runName,
+    required List<TrialResult> results,
+  }) async {
+    while (true) {
+      _PlannedTrial planned;
+      // The dart Iterator on List is single-thread safe within one isolate
+      // because moveNext()/current are synchronous; we just need a critical
+      // section that's atomic in the cooperative-scheduling sense.
+      if (!iterator.moveNext()) return;
+      planned = iterator.current;
+
+      final result = await _runOneTrial(
+        planned: planned,
+        suite: suite,
+        runName: runName,
+      );
+      results.add(result);
+    }
+  }
+
+  Future<TrialResult> _runOneTrial({
+    required _PlannedTrial planned,
+    required EvalSuite suite,
+    required String runName,
+  }) async {
+    final task = planned.task;
+    final trialIndex = planned.trialIndex;
+
+    final startedAt = DateTime.now();
+    Trial trial = Trial(
+      runName: runName,
+      suiteName: suite.name,
+      taskId: task.id,
+      trialIndex: trialIndex,
+      startedAt: startedAt,
+      endedAt: startedAt, // updated below
+      status: TrialStatus.errored,
+    );
+
+    try {
+      await exporter.onTrialStart(trial, task);
+    } catch (e, st) {
+      _logger.warning('exporter.onTrialStart failed', e, st);
+    }
+
+    final timeout = task.timeout ?? defaultTimeout;
+    Transcript? transcript;
+    Outcome? outcome;
+    var status = TrialStatus.errored;
+    String? failureReason;
+
+    final context = await environment.prepare(trial: trial, task: task);
+    try {
+      final session = await harnessFactory.create(
+        task: task,
+        trial: trial,
+        context: context,
+      );
+      try {
+        final r = await session.run().timeout(timeout);
+        transcript = r.transcript;
+        outcome = r.outcome;
+        status = TrialStatus.passed; // tentative; graders decide below
+      } on TimeoutException catch (e) {
+        status = TrialStatus.timedOut;
+        failureReason = 'Trial timed out after $timeout: $e';
+      } catch (e, st) {
+        status = TrialStatus.errored;
+        failureReason = '$e';
+        _logger.warning('trial run threw', e, st);
+      } finally {
+        await session.dispose();
+      }
+    } finally {
+      await environment.dispose(context);
+    }
+
+    final endedAt = DateTime.now();
+
+    // If the harness produced no transcript/outcome (timeout/error), make
+    // empty placeholders so graders can still decide what to do.
+    transcript ??= Transcript(
+      messages: const [],
+      toolCalls: const [],
+      metrics: const TranscriptMetrics(
+        nTurns: 0,
+        nToolCalls: 0,
+        nTotalTokens: 0,
+      ),
+    );
+    outcome ??= const Outcome(environmentState: {});
+
+    // Run graders. Each grader returns a Score; runner does not enforce
+    // pass/fail above the grader's own threshold.
+    final scores = <Score>[];
+    for (final grader in task.graders) {
+      try {
+        final score = await grader.grade(
+          trial: trial,
+          transcript: transcript,
+          outcome: outcome,
+          context: context,
+          referenceSolution: task.referenceSolution,
+        );
+        scores.add(score);
+      } catch (e, st) {
+        _logger.warning('grader ${grader.name} threw', e, st);
+        scores.add(
+          Score(
+            graderName: grader.name,
+            value: null,
+            passed: null,
+            rationale: 'grader exception: $e',
+          ),
+        );
+      }
+    }
+
+    // Final trial status reflects graders.
+    final passed = scores
+        .where((s) => s.passed != null)
+        .every((s) => s.passed == true);
+    if (status == TrialStatus.passed && !passed) status = TrialStatus.failed;
+
+    trial = Trial(
+      runName: trial.runName,
+      suiteName: trial.suiteName,
+      taskId: trial.taskId,
+      trialIndex: trial.trialIndex,
+      startedAt: startedAt,
+      endedAt: endedAt,
+      status: status,
+      failureReason: failureReason,
+    );
+
+    final result = TrialResult(
+      trial: trial,
+      transcript: transcript,
+      outcome: outcome,
+      scores: scores,
+    );
+
+    try {
+      await exporter.onTrialEnd(
+        trial: trial,
+        transcript: transcript,
+        outcome: outcome,
+        scores: scores,
+      );
+    } catch (e, st) {
+      _logger.warning('exporter.onTrialEnd failed', e, st);
+    }
+
+    return result;
+  }
+}

--- a/lib/src/eval/core/eval_suite.dart
+++ b/lib/src/eval/core/eval_suite.dart
@@ -1,0 +1,76 @@
+import 'eval_task.dart';
+
+/// Anthropic: capability evals start at low pass rates and improve over
+/// time; regression evals stay near 100% and any decline is a red flag.
+enum SuiteKind {
+  /// "What can this agent do well?" Saturation triggers a graduation
+  /// suggestion (move stable tasks into a regression suite).
+  capability,
+
+  /// "Does the agent still handle all the tasks it used to?"
+  regression,
+
+  /// Mixed-purpose suite without a strong type contract.
+  mixed,
+}
+
+/// Anthropic: a collection of tasks measuring specific capabilities or
+/// behaviors. Tasks in a suite typically share a broad goal.
+class EvalSuite {
+  final String name;
+
+  /// The agent these tasks are aimed at, e.g. `card_agent` /
+  /// `pkm_agent`. Drives routing to the right [AgentHarnessFactory] and
+  /// is the natural unit for filtering across multi-suite runs.
+  ///
+  /// In rare "cross-agent pipeline" suites where different tasks would
+  /// hit different agents, leave this as the pipeline name (e.g.
+  /// `card_to_pkm_pipeline`) and let your harness factory dispatch
+  /// internally based on `task.metadata`.
+  final String agentName;
+
+  final SuiteKind kind;
+  final List<EvalTask> tasks;
+
+  /// If true, every task must declare a [referenceSolution]. Strongly
+  /// recommended for capability suites.
+  final bool requireReferenceSolution;
+
+  /// If a task's mean score across its non-null graders meets or exceeds
+  /// this threshold, the task is considered "passed" for this suite. The
+  /// default is 1.0 (binary). Lower values let suites accept partial
+  /// credit when grading multi-component tasks.
+  final double taskPassThreshold;
+
+  const EvalSuite({
+    required this.name,
+    required this.agentName,
+    required this.kind,
+    required this.tasks,
+    this.requireReferenceSolution = false,
+    this.taskPassThreshold = 1.0,
+  });
+
+  /// Validates the suite at construction time: ids unique, reference
+  /// solutions present if required. Returns the list of problems (empty
+  /// if valid).
+  List<String> validate() {
+    final problems = <String>[];
+    final seen = <String>{};
+    for (final t in tasks) {
+      if (!seen.add(t.id)) {
+        problems.add('duplicate task id "${t.id}"');
+      }
+      if (t.graders.isEmpty) {
+        problems.add('task "${t.id}" has no graders');
+      }
+      if (requireReferenceSolution && t.referenceSolution == null) {
+        problems.add('task "${t.id}" missing referenceSolution');
+      }
+      if (t.trialsPerRun <= 0) {
+        problems.add('task "${t.id}" has trialsPerRun <= 0');
+      }
+    }
+    return problems;
+  }
+}

--- a/lib/src/eval/core/eval_task.dart
+++ b/lib/src/eval/core/eval_task.dart
@@ -1,0 +1,49 @@
+import '../graders/grader.dart';
+import 'reference_solution.dart';
+
+/// Anthropic: a task is a single test with defined inputs and success
+/// criteria. Implementations are pure data — they do not run the agent.
+///
+/// Note on what's intentionally **not** here:
+///   - There is no `successCriteria` map. The success contract lives
+///     entirely inside [graders]; a description-only mirror of it on
+///     the task would drift from the actual graders. If you want a
+///     human-readable summary of what a task tests, use [description]
+///     plus [metadata].
+///   - There is no `expectedBehavior` enum (`positive` / `negative`).
+///     Use [metadata]['failure_bucket'] or a similar tag to mark
+///     positive vs negative tasks if you need to filter by it.
+abstract class EvalTask {
+  /// Stable id. **Immutable after creation.**
+  ///
+  /// If the task changes meaningfully (input, graders, reference
+  /// solution), create a new task with a new id (convention:
+  /// `card_001` → `card_001_v2`). Historical reports stay associated
+  /// with the old id. See RFC §6.16 / §13.2.
+  String get id;
+
+  /// One-line human description.
+  String get description;
+
+  /// Input handed to the agent harness. Schema is application-defined.
+  Map<String, dynamic> get input;
+
+  /// Anthropic Step 2: a known working solution that passes all graders.
+  /// Strongly recommended — proves the task is solvable and graders are
+  /// configured correctly. May be required by the parent suite.
+  ReferenceSolution? get referenceSolution => null;
+
+  /// Free-form labels for filtering and bucketing. Conventional keys:
+  /// `failure_bucket`, `fixture`, `difficulty`, `language`, `expected`.
+  Map<String, String> get metadata => const {};
+
+  /// Graders attached to this task. At least one is required.
+  List<Grader> get graders;
+
+  /// Anthropic non-determinism: how many trials to run per dataset run.
+  /// Defaults to 1. Set ≥3 for tasks where stability matters (pass^k).
+  int get trialsPerRun => 1;
+
+  /// Optional per-task timeout. Falls back to the runner default if null.
+  Duration? get timeout => null;
+}

--- a/lib/src/eval/core/outcome.dart
+++ b/lib/src/eval/core/outcome.dart
@@ -1,0 +1,82 @@
+/// Anthropic: the final state of the environment at the end of a trial.
+///
+/// IMPORTANT: this is intentionally **separate** from a [Transcript].
+/// The transcript is "what the agent did/said"; the outcome is "what state
+/// the environment is in afterwards". Graders should default to inspecting
+/// the outcome (Anthropic Step 5: "grade what the agent produced, not the
+/// path it took").
+class Outcome {
+  /// Application-defined environment state. Schema is decided by the
+  /// application's outcome extractor.
+  ///
+  /// Examples:
+  ///   - Card agent:    {card_file, card_status, card_template, ...}
+  ///   - PKM agent:     {workspace_diff, fact_id_recorded, insight_updated}
+  ///   - Schedule agent:{aggregation_yaml, dirty_state, ...}
+  final Map<String, dynamic> environmentState;
+
+  /// Optional structural diff of a workspace. Many graders need this.
+  final WorkspaceDiff? workspaceDiff;
+
+  const Outcome({required this.environmentState, this.workspaceDiff});
+
+  Map<String, dynamic> toJson() => {
+    'environmentState': environmentState,
+    if (workspaceDiff != null) 'workspaceDiff': workspaceDiff!.toJson(),
+  };
+
+  factory Outcome.fromJson(Map<String, dynamic> json) {
+    return Outcome(
+      environmentState: (json['environmentState'] as Map)
+          .cast<String, dynamic>(),
+      workspaceDiff: json['workspaceDiff'] == null
+          ? null
+          : WorkspaceDiff.fromJson(
+              json['workspaceDiff'] as Map<String, dynamic>,
+            ),
+    );
+  }
+}
+
+/// Captures filesystem-level changes between fixture setup and trial end.
+class WorkspaceDiff {
+  /// Absolute paths (relative to workspace root) created during the trial.
+  final List<String> created;
+
+  /// Paths modified.
+  final List<String> modified;
+
+  /// Paths deleted.
+  final List<String> deleted;
+
+  /// Optional content snippets for created/modified files. Keys are paths.
+  /// Values are utf-8 text content (trimmed if > 4 KiB).
+  final Map<String, String> contentSnippets;
+
+  const WorkspaceDiff({
+    this.created = const [],
+    this.modified = const [],
+    this.deleted = const [],
+    this.contentSnippets = const {},
+  });
+
+  bool get isEmpty => created.isEmpty && modified.isEmpty && deleted.isEmpty;
+
+  Map<String, dynamic> toJson() => {
+    'created': created,
+    'modified': modified,
+    'deleted': deleted,
+    if (contentSnippets.isNotEmpty) 'contentSnippets': contentSnippets,
+  };
+
+  factory WorkspaceDiff.fromJson(Map<String, dynamic> json) {
+    return WorkspaceDiff(
+      created: ((json['created'] as List?) ?? []).cast<String>(),
+      modified: ((json['modified'] as List?) ?? []).cast<String>(),
+      deleted: ((json['deleted'] as List?) ?? []).cast<String>(),
+      contentSnippets:
+          ((json['contentSnippets'] as Map?)?.cast<String, String>()) ??
+          const {},
+    );
+  }
+}

--- a/lib/src/eval/core/reference_solution.dart
+++ b/lib/src/eval/core/reference_solution.dart
@@ -1,0 +1,45 @@
+import 'transcript.dart';
+
+/// How the reference solution was produced.
+enum ReferenceSolutionSource { manual, captured, synthesized }
+
+/// Anthropic Step 2: a known working solution that passes all graders.
+/// Useful for proving a task is solvable and that graders are configured
+/// correctly.
+class ReferenceSolution {
+  /// Expected environment state. Schema mirrors [Outcome.environmentState].
+  final Map<String, dynamic>? expectedOutcome;
+
+  /// Optional sample transcript captured from a known-good run.
+  final Transcript? sampleTranscript;
+
+  /// Provenance of this reference solution.
+  final ReferenceSolutionSource source;
+
+  const ReferenceSolution({
+    this.expectedOutcome,
+    this.sampleTranscript,
+    required this.source,
+  });
+
+  Map<String, dynamic> toJson() => {
+    if (expectedOutcome != null) 'expectedOutcome': expectedOutcome,
+    if (sampleTranscript != null)
+      'sampleTranscript': sampleTranscript!.toJson(),
+    'source': source.name,
+  };
+
+  factory ReferenceSolution.fromJson(Map<String, dynamic> json) {
+    return ReferenceSolution(
+      expectedOutcome: json['expectedOutcome'] as Map<String, dynamic>?,
+      sampleTranscript: json['sampleTranscript'] == null
+          ? null
+          : Transcript.fromJson(
+              json['sampleTranscript'] as Map<String, dynamic>,
+            ),
+      source: ReferenceSolutionSource.values.firstWhere(
+        (e) => e.name == json['source'],
+      ),
+    );
+  }
+}

--- a/lib/src/eval/core/transcript.dart
+++ b/lib/src/eval/core/transcript.dart
@@ -1,0 +1,193 @@
+import 'dart:convert';
+
+import '../../core/message.dart';
+
+/// Anthropic: a transcript is the complete record of a trial — messages,
+/// tool calls, reasoning, intermediate results, etc.
+class Transcript {
+  /// Full LLM message sequence in order.
+  final List<LLMMessage> messages;
+
+  /// Tool calls in order.
+  final List<ToolCallRecord> toolCalls;
+
+  /// Reasoning chunks, if the model emits them.
+  final List<String> reasoningSteps;
+
+  /// Streaming events, retries, errors.
+  final List<TranscriptEvent> events;
+
+  /// Quantitative metrics.
+  final TranscriptMetrics metrics;
+
+  Transcript({
+    required this.messages,
+    required this.toolCalls,
+    this.reasoningSteps = const [],
+    this.events = const [],
+    required this.metrics,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'messages': messages.map((m) => m.toJson()).toList(),
+    'toolCalls': toolCalls.map((t) => t.toJson()).toList(),
+    'reasoningSteps': reasoningSteps,
+    'events': events.map((e) => e.toJson()).toList(),
+    'metrics': metrics.toJson(),
+  };
+
+  factory Transcript.fromJson(Map<String, dynamic> json) {
+    return Transcript(
+      messages: (json['messages'] as List)
+          .map((m) => LLMMessage.fromJson(m as Map<String, dynamic>))
+          .toList(),
+      toolCalls: (json['toolCalls'] as List)
+          .map((t) => ToolCallRecord.fromJson(t as Map<String, dynamic>))
+          .toList(),
+      reasoningSteps: ((json['reasoningSteps'] as List?) ?? []).cast<String>(),
+      events: ((json['events'] as List?) ?? [])
+          .map((e) => TranscriptEvent.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      metrics: TranscriptMetrics.fromJson(
+        json['metrics'] as Map<String, dynamic>,
+      ),
+    );
+  }
+
+  String toJsonString() => jsonEncode(toJson());
+}
+
+/// Record of a single tool invocation during a trial.
+class ToolCallRecord {
+  final String callId;
+  final String toolName;
+  final Map<String, dynamic> arguments;
+
+  /// Strongly-typed execution result. May be null when the tool errored
+  /// before producing one; details should still appear in [errorMessage]
+  /// in that case.
+  final FunctionExecutionResult? result;
+
+  final DateTime startedAt;
+  final DateTime endedAt;
+  final bool isError;
+  final String? errorMessage;
+
+  ToolCallRecord({
+    required this.callId,
+    required this.toolName,
+    required this.arguments,
+    this.result,
+    required this.startedAt,
+    required this.endedAt,
+    this.isError = false,
+    this.errorMessage,
+  });
+
+  Duration get duration => endedAt.difference(startedAt);
+
+  Map<String, dynamic> toJson() => {
+    'callId': callId,
+    'toolName': toolName,
+    'arguments': arguments,
+    if (result != null) 'result': result!.toJson(),
+    'startedAt': startedAt.toIso8601String(),
+    'endedAt': endedAt.toIso8601String(),
+    'isError': isError,
+    if (errorMessage != null) 'errorMessage': errorMessage,
+  };
+
+  factory ToolCallRecord.fromJson(Map<String, dynamic> json) {
+    return ToolCallRecord(
+      callId: json['callId'] as String,
+      toolName: json['toolName'] as String,
+      arguments: (json['arguments'] as Map).cast<String, dynamic>(),
+      result: json['result'] == null
+          ? null
+          : FunctionExecutionResult.fromJson(
+              (json['result'] as Map).cast<String, dynamic>(),
+            ),
+      startedAt: DateTime.parse(json['startedAt'] as String),
+      endedAt: DateTime.parse(json['endedAt'] as String),
+      isError: json['isError'] as bool? ?? false,
+      errorMessage: json['errorMessage'] as String?,
+    );
+  }
+}
+
+/// Lightweight log of additional events that don't fit neatly into messages
+/// or tool calls (e.g. retries, plan changes, exceptions).
+class TranscriptEvent {
+  final DateTime at;
+  final String kind; // e.g. 'llm_retry', 'plan_changed', 'exception'
+  final String message;
+  final Map<String, dynamic> details;
+
+  TranscriptEvent({
+    required this.at,
+    required this.kind,
+    required this.message,
+    this.details = const {},
+  });
+
+  Map<String, dynamic> toJson() => {
+    'at': at.toIso8601String(),
+    'kind': kind,
+    'message': message,
+    if (details.isNotEmpty) 'details': details,
+  };
+
+  factory TranscriptEvent.fromJson(Map<String, dynamic> json) {
+    return TranscriptEvent(
+      at: DateTime.parse(json['at'] as String),
+      kind: json['kind'] as String,
+      message: json['message'] as String,
+      details: ((json['details'] as Map?)?.cast<String, dynamic>()) ?? const {},
+    );
+  }
+}
+
+/// Quantitative metrics about a trial.
+class TranscriptMetrics {
+  final int nTurns;
+  final int nToolCalls;
+  final int nTotalTokens;
+  final Duration? timeToFirstToken;
+  final Duration? timeToLastToken;
+  final double? outputTokensPerSec;
+
+  const TranscriptMetrics({
+    required this.nTurns,
+    required this.nToolCalls,
+    required this.nTotalTokens,
+    this.timeToFirstToken,
+    this.timeToLastToken,
+    this.outputTokensPerSec,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'nTurns': nTurns,
+    'nToolCalls': nToolCalls,
+    'nTotalTokens': nTotalTokens,
+    if (timeToFirstToken != null)
+      'timeToFirstTokenMs': timeToFirstToken!.inMilliseconds,
+    if (timeToLastToken != null)
+      'timeToLastTokenMs': timeToLastToken!.inMilliseconds,
+    if (outputTokensPerSec != null) 'outputTokensPerSec': outputTokensPerSec,
+  };
+
+  factory TranscriptMetrics.fromJson(Map<String, dynamic> json) {
+    return TranscriptMetrics(
+      nTurns: json['nTurns'] as int? ?? 0,
+      nToolCalls: json['nToolCalls'] as int? ?? 0,
+      nTotalTokens: json['nTotalTokens'] as int? ?? 0,
+      timeToFirstToken: json['timeToFirstTokenMs'] == null
+          ? null
+          : Duration(milliseconds: json['timeToFirstTokenMs'] as int),
+      timeToLastToken: json['timeToLastTokenMs'] == null
+          ? null
+          : Duration(milliseconds: json['timeToLastTokenMs'] as int),
+      outputTokensPerSec: (json['outputTokensPerSec'] as num?)?.toDouble(),
+    );
+  }
+}

--- a/lib/src/eval/core/trial.dart
+++ b/lib/src/eval/core/trial.dart
@@ -1,0 +1,109 @@
+/// Identifies one trial uniquely across runs.
+class TrialId {
+  final String runName;
+  final String taskId;
+  final int trialIndex;
+
+  const TrialId({
+    required this.runName,
+    required this.taskId,
+    required this.trialIndex,
+  });
+
+  @override
+  String toString() => '$runName/$taskId#$trialIndex';
+
+  Map<String, dynamic> toJson() => {
+    'runName': runName,
+    'taskId': taskId,
+    'trialIndex': trialIndex,
+  };
+
+  factory TrialId.fromJson(Map<String, dynamic> json) {
+    return TrialId(
+      runName: json['runName'] as String,
+      taskId: json['taskId'] as String,
+      trialIndex: json['trialIndex'] as int,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is TrialId &&
+      other.runName == runName &&
+      other.taskId == taskId &&
+      other.trialIndex == trialIndex;
+
+  @override
+  int get hashCode => Object.hash(runName, taskId, trialIndex);
+}
+
+/// Final status of a trial.
+enum TrialStatus { passed, failed, errored, timedOut, skipped }
+
+/// Metadata about one attempt at a task.
+class Trial {
+  final String runName;
+  final String suiteName;
+  final String taskId;
+  final int trialIndex;
+
+  final DateTime startedAt;
+  final DateTime endedAt;
+  final TrialStatus status;
+
+  /// Reason set when [status] is [TrialStatus.errored] or [TrialStatus.timedOut].
+  final String? failureReason;
+
+  Trial({
+    required this.runName,
+    required this.suiteName,
+    required this.taskId,
+    required this.trialIndex,
+    required this.startedAt,
+    required this.endedAt,
+    required this.status,
+    this.failureReason,
+  });
+
+  TrialId get id =>
+      TrialId(runName: runName, taskId: taskId, trialIndex: trialIndex);
+
+  /// Stable salt for record/replay caching, scoped per task+trial but
+  /// **independent of run name** so that recordings made in run A can
+  /// be replayed by run B. Format: `taskId#trialIndex`.
+  ///
+  /// Pass this into `RecordingLLMClient` / `ReplayLLMClient`'s
+  /// `trialSalt` parameter from inside `EvalEnvironment.prepare()` to
+  /// give each trial its own cache slot. Without it, trials of the
+  /// same task collapse onto one cache entry and the framework
+  /// silently destroys the non-determinism that pass^k / pass@k are
+  /// supposed to measure.
+  String get cacheSalt => '$taskId#$trialIndex';
+
+  Duration get duration => endedAt.difference(startedAt);
+
+  Map<String, dynamic> toJson() => {
+    'runName': runName,
+    'suiteName': suiteName,
+    'taskId': taskId,
+    'trialIndex': trialIndex,
+    'startedAt': startedAt.toIso8601String(),
+    'endedAt': endedAt.toIso8601String(),
+    'status': status.name,
+    if (failureReason != null) 'failureReason': failureReason,
+  };
+
+  factory Trial.fromJson(Map<String, dynamic> json) {
+    return Trial(
+      runName: json['runName'] as String,
+      suiteName: json['suiteName'] as String,
+      taskId: json['taskId'] as String,
+      trialIndex: json['trialIndex'] as int,
+      startedAt: DateTime.parse(json['startedAt'] as String),
+      endedAt: DateTime.parse(json['endedAt'] as String),
+      status: TrialStatus.values.firstWhere((s) => s.name == json['status']),
+      failureReason: json['failureReason'] as String?,
+    );
+  }
+}

--- a/lib/src/eval/core/trial_result.dart
+++ b/lib/src/eval/core/trial_result.dart
@@ -1,0 +1,41 @@
+import '../graders/score.dart';
+import 'outcome.dart';
+import 'transcript.dart';
+import 'trial.dart';
+
+/// All artifacts produced by one trial.
+class TrialResult {
+  final Trial trial;
+  final Transcript transcript;
+  final Outcome outcome;
+  final List<Score> scores;
+
+  const TrialResult({
+    required this.trial,
+    required this.transcript,
+    required this.outcome,
+    required this.scores,
+  });
+
+  /// True if every score (excluding null-valued ones) reports passed=true.
+  /// Null-valued scores (e.g. judge returned Unknown) are ignored.
+  bool get allGradersPassed {
+    final passing = scores.where((s) => s.passed != null);
+    if (passing.isEmpty) return false;
+    return passing.every((s) => s.passed == true);
+  }
+
+  /// Mean of non-null score values. Returns null if all scores are null.
+  double? get meanScoreValue {
+    final values = scores.map((s) => s.value).whereType<double>().toList();
+    if (values.isEmpty) return null;
+    return values.reduce((a, b) => a + b) / values.length;
+  }
+
+  Map<String, dynamic> toJson() => {
+    'trial': trial.toJson(),
+    'transcript': transcript.toJson(),
+    'outcome': outcome.toJson(),
+    'scores': scores.map((s) => s.toJson()).toList(),
+  };
+}

--- a/lib/src/eval/graders/code_grader.dart
+++ b/lib/src/eval/graders/code_grader.dart
@@ -1,0 +1,62 @@
+import '../core/eval_context.dart';
+import '../core/outcome.dart';
+import '../core/reference_solution.dart';
+import '../core/transcript.dart';
+import '../core/trial.dart';
+import 'grader.dart';
+import 'score.dart';
+
+/// Convenience base for deterministic code-based graders.
+///
+/// Subclasses implement [computeAssertions] and the base composes them into
+/// a [Score]. The default [passThreshold] is 1.0 (all assertions must pass).
+abstract class CodeGrader implements Grader {
+  @override
+  GraderKind get kind => GraderKind.code;
+
+  @override
+  double get passThreshold => 1.0;
+
+  /// Subclasses produce a list of pass/fail assertions.
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  });
+
+  /// Subclasses may override to customize the rationale produced on
+  /// failure; default joins all failed assertion descriptions.
+  String? buildRationale(List<Assertion> assertions) {
+    final failed = assertions.where((a) => !a.passed).toList();
+    if (failed.isEmpty) return null;
+    return failed.map((a) => '- ${a.description}').join('\n');
+  }
+
+  @override
+  Future<Score> grade({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async {
+    final assertions = await computeAssertions(
+      trial: trial,
+      transcript: transcript,
+      outcome: outcome,
+      context: context,
+      referenceSolution: referenceSolution,
+    );
+    final passedCount = assertions.where((a) => a.passed).length;
+    final value = assertions.isEmpty ? 0.0 : passedCount / assertions.length;
+    return Score(
+      graderName: name,
+      value: value,
+      passed: value >= passThreshold,
+      assertions: assertions,
+      rationale: buildRationale(assertions),
+    );
+  }
+}

--- a/lib/src/eval/graders/grader.dart
+++ b/lib/src/eval/graders/grader.dart
@@ -1,0 +1,36 @@
+import '../core/eval_context.dart';
+import '../core/outcome.dart';
+import '../core/reference_solution.dart';
+import '../core/transcript.dart';
+import '../core/trial.dart';
+import 'score.dart';
+
+/// Anthropic identifies three kinds of graders.
+enum GraderKind { code, model, human }
+
+/// A grader scores some aspect of an agent's performance for one trial.
+///
+/// Implementations should default to inspecting the [Outcome] rather than
+/// the [Transcript] (Anthropic Step 5: grade what the agent produced, not
+/// the path it took).
+abstract class Grader {
+  /// Stable name. Used as score key in reports.
+  String get name;
+
+  /// Anthropic kind: code / model / human.
+  GraderKind get kind;
+
+  /// If a [Score.value] meets or exceeds this threshold, [Score.passed] is
+  /// `true`. Defaults to `1.0` (binary) but graders may override to support
+  /// partial credit thresholds.
+  double get passThreshold => 1.0;
+
+  /// Compute a score for one trial.
+  Future<Score> grade({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  });
+}

--- a/lib/src/eval/graders/human_grader.dart
+++ b/lib/src/eval/graders/human_grader.dart
@@ -1,0 +1,70 @@
+import '../core/eval_context.dart';
+import '../core/outcome.dart';
+import '../core/reference_solution.dart';
+import '../core/transcript.dart';
+import '../core/trial.dart';
+import 'grader.dart';
+import 'score.dart';
+
+/// 人工审阅队列。框架不拥有 UI，但提供一个抽象让应用层接到自己的审阅平台
+/// （Langfuse Annotation Queue、自建 Web、Slack 工作流等）。
+abstract class HumanReviewQueue {
+  /// 将一个 trial 推到队列等待人工审阅。
+  Future<void> enqueue({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    String? rubric,
+    Map<String, dynamic> metadata = const {},
+  });
+
+  /// 拉取已有的人工评分。如果尚未评（或已被丢弃），返回 null。
+  /// 实现应当是非阻塞的——eval runner 跑完一次后可以立即查队列状态，
+  /// 没结果就标记为 `Score(value: null)` + `rationale: "pending human review"`。
+  Future<Score?> fetchVerdict(Trial trial);
+}
+
+/// Anthropic Step 5 / 8: human graders are gold-standard for subjective
+/// dimensions, used both for direct scoring and for calibrating LLM judges.
+///
+/// Concrete implementations connect to an application-provided
+/// [HumanReviewQueue]. The default [grade] flow is:
+/// 1. Push the trial to the queue (non-blocking).
+/// 2. Poll for a verdict; if absent, return a pending `Score(value: null)`.
+abstract class HumanGrader implements Grader {
+  @override
+  GraderKind get kind => GraderKind.human;
+
+  /// Where to enqueue trials and where to read back human verdicts.
+  HumanReviewQueue get queue;
+
+  /// Optional rubric prompt shown to human reviewers in the UI.
+  String? get rubric => null;
+
+  @override
+  double get passThreshold => 1.0;
+
+  @override
+  Future<Score> grade({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async {
+    await queue.enqueue(
+      trial: trial,
+      transcript: transcript,
+      outcome: outcome,
+      rubric: rubric,
+    );
+    final existing = await queue.fetchVerdict(trial);
+    if (existing != null) return existing;
+    return Score(
+      graderName: name,
+      value: null,
+      passed: null,
+      rationale: 'pending human review',
+    );
+  }
+}

--- a/lib/src/eval/graders/model_grader.dart
+++ b/lib/src/eval/graders/model_grader.dart
@@ -1,0 +1,19 @@
+import '../../core/llm_client.dart';
+import 'grader.dart';
+
+/// Convenience base for LLM-as-judge graders.
+///
+/// Subclasses provide [judgeClient] (an LLM client to use as judge) and
+/// [rubric] (a prompt template). The rubric should include an explicit
+/// "Unknown" escape hatch (Anthropic Step 5) so the grader can return
+/// `Score(value: null)` instead of fabricating a score.
+abstract class ModelGrader implements Grader {
+  @override
+  GraderKind get kind => GraderKind.model;
+
+  /// LLM client used for judging.
+  LLMClient get judgeClient;
+
+  /// Rubric prompt template. Must include an "Unknown" escape hatch.
+  String get rubric;
+}

--- a/lib/src/eval/graders/score.dart
+++ b/lib/src/eval/graders/score.dart
@@ -1,0 +1,95 @@
+/// One specific check inside a [Score]. Holds enough detail that a human can
+/// understand why it passed or failed without re-running the trial.
+class Assertion {
+  final String description;
+  final bool passed;
+
+  /// Observed value (stringified for human readability).
+  final String? actual;
+
+  /// Expected value.
+  final String? expected;
+
+  const Assertion({
+    required this.description,
+    required this.passed,
+    this.actual,
+    this.expected,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'description': description,
+    'passed': passed,
+    if (actual != null) 'actual': actual,
+    if (expected != null) 'expected': expected,
+  };
+
+  factory Assertion.fromJson(Map<String, dynamic> json) {
+    return Assertion(
+      description: json['description'] as String,
+      passed: json['passed'] as bool,
+      actual: json['actual'] as String?,
+      expected: json['expected'] as String?,
+    );
+  }
+}
+
+/// The output of a [Grader] for one trial.
+///
+/// Anthropic Step 5: graders should support partial credit (`value` is a
+/// double in [0.0, 1.0]) and must explain failures clearly (`rationale`).
+class Score {
+  /// Stable name of the grader that produced this score.
+  final String graderName;
+
+  /// 0.0 .. 1.0 with partial credit. `null` means the grader could not
+  /// evaluate (e.g. an LLM judge returned "Unknown"). `null` scores are
+  /// reported separately and do not contribute to averages.
+  final double? value;
+
+  /// Whether [value] crosses the grader's pass threshold. `null` if [value]
+  /// is null. Aggregated by [EvalRunReport] into pass@k and pass^k.
+  final bool? passed;
+
+  /// Sub-checks that contributed to [value].
+  final List<Assertion> assertions;
+
+  /// Human-readable explanation. Required when `passed == false` or
+  /// `value == null`. Anthropic Step 5: "failures should seem fair".
+  final String? rationale;
+
+  /// Free-form metadata (e.g. judge response, diff details).
+  final Map<String, dynamic> metadata;
+
+  const Score({
+    required this.graderName,
+    required this.value,
+    this.passed,
+    this.assertions = const [],
+    this.rationale,
+    this.metadata = const {},
+  });
+
+  Map<String, dynamic> toJson() => {
+    'graderName': graderName,
+    'value': value,
+    if (passed != null) 'passed': passed,
+    'assertions': assertions.map((a) => a.toJson()).toList(),
+    if (rationale != null) 'rationale': rationale,
+    if (metadata.isNotEmpty) 'metadata': metadata,
+  };
+
+  factory Score.fromJson(Map<String, dynamic> json) {
+    return Score(
+      graderName: json['graderName'] as String,
+      value: (json['value'] as num?)?.toDouble(),
+      passed: json['passed'] as bool?,
+      assertions: ((json['assertions'] as List?) ?? [])
+          .map((a) => Assertion.fromJson(a as Map<String, dynamic>))
+          .toList(),
+      rationale: json['rationale'] as String?,
+      metadata:
+          ((json['metadata'] as Map?)?.cast<String, dynamic>()) ?? const {},
+    );
+  }
+}

--- a/lib/src/eval/llm/llm_request_hash.dart
+++ b/lib/src/eval/llm/llm_request_hash.dart
@@ -1,0 +1,120 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+
+import '../../core/llm_client.dart';
+import '../../core/message.dart';
+import '../../core/tool.dart';
+
+/// Computes a stable hash of an LLM request, used as the cache key for
+/// recording / replay.
+///
+/// Stability requirements:
+///   - The hash must be deterministic given the same logical request.
+///   - It must ignore non-deterministic fields (timestamps, UUIDs, ids).
+///   - It must be sensitive to anything that would change the model's
+///     output (messages, tools, model id, sampling parameters).
+///
+/// Non-determinism caveat: when `trialsPerRun > 1`, every trial sends
+/// the **same** request (same messages, same tools, same model). Without
+/// extra signal the hash collapses across trials and the cache forces
+/// every trial to receive an identical response — which silently
+/// destroys the non-determinism that pass^k / pass@k are supposed to
+/// measure (Anthropic Step 6).
+///
+/// To preserve per-trial variation, callers can pass [trialSalt] (a
+/// stable per-trial identifier such as `runName/taskId#trialIndex`).
+/// Each trial then computes a distinct hash and the recording store
+/// keeps a separate cache entry per trial. A null salt means "no
+/// per-trial axis" — appropriate for one-off requests, judges, or any
+/// other call that should be cached once across all trials.
+abstract class LLMRequestHash {
+  /// Compute the hash for a request.
+  String compute({
+    required List<LLMMessage> messages,
+    required List<Tool>? tools,
+    required ModelConfig modelConfig,
+    bool? jsonOutput,
+    String? trialSalt,
+  });
+}
+
+/// Default SHA-256 based implementation. Hashes the JSON-encoded
+/// `(messages, tools, modelConfig, jsonOutput, trialSalt)` tuple.
+/// `Tool.executable` closures are ignored (they're not in toJson).
+///
+/// **Default-stripped keys**: `timestamp` is always stripped from
+/// message JSON before hashing. UserMessage / ModelMessage /
+/// FunctionExecutionResultMessage all carry `DateTime.now()`-derived
+/// timestamps for tracing purposes, but those values are never
+/// semantically part of the LLM request — including them would make
+/// every hash unique per process invocation and defeat the cache.
+class Sha256LLMRequestHash implements LLMRequestHash {
+  /// Additional message-level keys to strip before hashing. `timestamp`
+  /// is always stripped — see class docstring. Pass extra keys here
+  /// when the application embeds non-deterministic fields in messages
+  /// (e.g. trace ids inside system reminders).
+  final Set<String> stripMessageKeys;
+
+  /// Total set of keys actually stripped: union of [stripMessageKeys]
+  /// and the framework defaults (`timestamp`).
+  Set<String> get _effectiveStrip => {'timestamp', ...stripMessageKeys};
+
+  const Sha256LLMRequestHash({this.stripMessageKeys = const {}});
+
+  @override
+  String compute({
+    required List<LLMMessage> messages,
+    required List<Tool>? tools,
+    required ModelConfig modelConfig,
+    bool? jsonOutput,
+    String? trialSalt,
+  }) {
+    final payload = {
+      'messages': messages.map((m) => _stripped(m.toJson())).toList(),
+      'tools': tools?.map((t) => t.toJson()).toList(),
+      'model': modelConfig.toJson(),
+      'jsonOutput': ?jsonOutput,
+      'trialSalt': ?trialSalt,
+    };
+    final encoded = utf8.encode(_canonicalJson(payload));
+    return sha256.convert(encoded).toString();
+  }
+
+  Map<String, dynamic> _stripped(Map<String, dynamic> json) {
+    final keys = _effectiveStrip;
+    return _strippedRecursive(json, keys) as Map<String, dynamic>;
+  }
+
+  Object? _strippedRecursive(Object? value, Set<String> keys) {
+    if (value is Map) {
+      final out = <String, dynamic>{};
+      for (final entry in value.entries) {
+        if (entry.key is String && keys.contains(entry.key as String)) {
+          continue;
+        }
+        out['${entry.key}'] = _strippedRecursive(entry.value, keys);
+      }
+      return out;
+    }
+    if (value is List) {
+      return value.map((e) => _strippedRecursive(e, keys)).toList();
+    }
+    return value;
+  }
+
+  /// Encode JSON with stable key ordering so hashes are deterministic.
+  String _canonicalJson(Object? value) {
+    if (value is Map) {
+      final keys = value.keys.cast<String>().toList()..sort();
+      final pairs = keys.map(
+        (k) => '${jsonEncode(k)}:${_canonicalJson(value[k])}',
+      );
+      return '{${pairs.join(',')}}';
+    }
+    if (value is List) {
+      return '[${value.map(_canonicalJson).join(',')}]';
+    }
+    return jsonEncode(value);
+  }
+}

--- a/lib/src/eval/llm/rate_limit_gate.dart
+++ b/lib/src/eval/llm/rate_limit_gate.dart
@@ -1,0 +1,139 @@
+import 'dart:async';
+import 'dart:collection';
+
+/// Throttles outgoing LLM calls. Independent from runner concurrency.
+///
+/// [acquire] suspends the caller until the call is allowed. Implementations
+/// must be safe to call concurrently from many trials.
+abstract class RateLimitGate {
+  Future<void> acquire({int estimatedTokens = 0});
+}
+
+/// Permits up to N requests per minute (token bucket, refill at +N/60s).
+class RpmRateLimitGate implements RateLimitGate {
+  final int requestsPerMinute;
+  final double _refillPerSec;
+  double _tokens;
+  DateTime _lastRefill;
+  final Queue<Completer<void>> _waiters = Queue();
+
+  RpmRateLimitGate({required this.requestsPerMinute})
+    : _refillPerSec = requestsPerMinute / 60.0,
+      _tokens = requestsPerMinute.toDouble(),
+      _lastRefill = DateTime.now();
+
+  @override
+  Future<void> acquire({int estimatedTokens = 0}) async {
+    _refill();
+    if (_tokens >= 1.0 && _waiters.isEmpty) {
+      _tokens -= 1.0;
+      return;
+    }
+    final c = Completer<void>();
+    _waiters.add(c);
+    _scheduleWake();
+    return c.future;
+  }
+
+  void _refill() {
+    final now = DateTime.now();
+    final elapsed = now.difference(_lastRefill).inMilliseconds / 1000.0;
+    if (elapsed <= 0) return;
+    _lastRefill = now;
+    _tokens = (_tokens + elapsed * _refillPerSec).clamp(
+      0,
+      requestsPerMinute.toDouble(),
+    );
+  }
+
+  void _scheduleWake() {
+    if (_waiters.isEmpty) return;
+    final missing = 1.0 - _tokens;
+    final waitMs = (missing / _refillPerSec * 1000).ceil().clamp(10, 60000);
+    Timer(Duration(milliseconds: waitMs), _wake);
+  }
+
+  void _wake() {
+    _refill();
+    while (_waiters.isNotEmpty && _tokens >= 1.0) {
+      _tokens -= 1.0;
+      _waiters.removeFirst().complete();
+    }
+    if (_waiters.isNotEmpty) _scheduleWake();
+  }
+}
+
+/// Permits up to N tokens per minute (token-aware, refills similarly).
+///
+/// Note: callers must pass a reasonable [estimatedTokens] to [acquire];
+/// underestimating leaks throughput, overestimating wastes capacity.
+class TpmRateLimitGate implements RateLimitGate {
+  final int tokensPerMinute;
+  final double _refillPerSec;
+  double _budget;
+  DateTime _lastRefill;
+  final Queue<_TpmWaiter> _waiters = Queue();
+
+  TpmRateLimitGate({required this.tokensPerMinute})
+    : _refillPerSec = tokensPerMinute / 60.0,
+      _budget = tokensPerMinute.toDouble(),
+      _lastRefill = DateTime.now();
+
+  @override
+  Future<void> acquire({int estimatedTokens = 0}) async {
+    final cost = estimatedTokens > 0 ? estimatedTokens.toDouble() : 1.0;
+    _refill();
+    if (_budget >= cost && _waiters.isEmpty) {
+      _budget -= cost;
+      return;
+    }
+    final c = Completer<void>();
+    _waiters.add(_TpmWaiter(cost, c));
+    _scheduleWake();
+    return c.future;
+  }
+
+  void _refill() {
+    final now = DateTime.now();
+    final elapsed = now.difference(_lastRefill).inMilliseconds / 1000.0;
+    if (elapsed <= 0) return;
+    _lastRefill = now;
+    _budget = (_budget + elapsed * _refillPerSec).clamp(
+      0,
+      tokensPerMinute.toDouble(),
+    );
+  }
+
+  void _scheduleWake() {
+    if (_waiters.isEmpty) return;
+    final next = _waiters.first.cost - _budget;
+    final waitMs = next <= 0
+        ? 10
+        : (next / _refillPerSec * 1000).ceil().clamp(10, 60000);
+    Timer(Duration(milliseconds: waitMs), _wake);
+  }
+
+  void _wake() {
+    _refill();
+    while (_waiters.isNotEmpty && _budget >= _waiters.first.cost) {
+      final w = _waiters.removeFirst();
+      _budget -= w.cost;
+      w.completer.complete();
+    }
+    if (_waiters.isNotEmpty) _scheduleWake();
+  }
+}
+
+class _TpmWaiter {
+  final double cost;
+  final Completer<void> completer;
+  _TpmWaiter(this.cost, this.completer);
+}
+
+/// No-op gate. Default when callers don't configure rate limiting.
+class NoopRateLimitGate implements RateLimitGate {
+  const NoopRateLimitGate();
+
+  @override
+  Future<void> acquire({int estimatedTokens = 0}) async {}
+}

--- a/lib/src/eval/llm/recording_llm_client.dart
+++ b/lib/src/eval/llm/recording_llm_client.dart
@@ -1,0 +1,109 @@
+import 'package:dio/dio.dart';
+import 'package:logging/logging.dart';
+
+import '../../core/llm_client.dart';
+import '../../core/message.dart';
+import '../../core/tool.dart';
+import 'llm_request_hash.dart';
+import 'rate_limit_gate.dart';
+import 'recording_store.dart';
+
+final _logger = Logger('RecordingLLMClient');
+
+/// Wraps an inner [LLMClient] and records every successful
+/// (request, response) pair into a [RecordingStore]. Reads still go
+/// through the inner client; the store is a write target only.
+///
+/// If a [RateLimitGate] is provided, every real upstream call awaits
+/// the gate first. This is the wiring point for RFC §6.15 (concurrency
+/// vs rate-limit decoupling).
+///
+/// **Per-trial salt**: when [trialSalt] is non-null, every recorded
+/// hash includes it. This preserves non-determinism across trials —
+/// trial #0 and trial #1 of the same task receive different cache
+/// keys, so the cache stores N different responses (one per trial)
+/// instead of overwriting to one. Construct one client per trial via
+/// [withTrialSalt] from inside [EvalEnvironment.prepare]. Leave it
+/// null for one-off requests (judges, ad-hoc analysis) where caching
+/// across trials is the desired behavior.
+class RecordingLLMClient implements LLMClient {
+  final LLMClient inner;
+  final RecordingStore store;
+  final LLMRequestHash hasher;
+  final RateLimitGate rateLimitGate;
+  final String? trialSalt;
+
+  RecordingLLMClient({
+    required this.inner,
+    required this.store,
+    LLMRequestHash? hasher,
+    RateLimitGate? rateLimitGate,
+    this.trialSalt,
+  }) : hasher = hasher ?? const Sha256LLMRequestHash(),
+       rateLimitGate = rateLimitGate ?? const NoopRateLimitGate();
+
+  /// Returns a copy of this client bound to [salt]. Convenience for
+  /// per-trial wrapping inside an environment's `prepare()`.
+  RecordingLLMClient withTrialSalt(String salt) => RecordingLLMClient(
+    inner: inner,
+    store: store,
+    hasher: hasher,
+    rateLimitGate: rateLimitGate,
+    trialSalt: salt,
+  );
+
+  @override
+  Future<ModelMessage> generate(
+    List<LLMMessage> messages, {
+    List<Tool>? tools,
+    ToolChoice? toolChoice,
+    required ModelConfig modelConfig,
+    bool? jsonOutput,
+    CancelToken? cancelToken,
+  }) async {
+    await rateLimitGate.acquire(estimatedTokens: modelConfig.maxTokens ?? 0);
+    final response = await inner.generate(
+      messages,
+      tools: tools,
+      toolChoice: toolChoice,
+      modelConfig: modelConfig,
+      jsonOutput: jsonOutput,
+      cancelToken: cancelToken,
+    );
+    final hash = hasher.compute(
+      messages: messages,
+      tools: tools,
+      modelConfig: modelConfig,
+      jsonOutput: jsonOutput,
+      trialSalt: trialSalt,
+    );
+    try {
+      await store.put(hash, response);
+    } catch (e, st) {
+      _logger.warning('failed to record response for $hash', e, st);
+    }
+    return response;
+  }
+
+  @override
+  Future<Stream<StreamingMessage>> stream(
+    List<LLMMessage> messages, {
+    List<Tool>? tools,
+    ToolChoice? toolChoice,
+    required ModelConfig modelConfig,
+    bool? jsonOutput,
+    CancelToken? cancelToken,
+  }) async {
+    await rateLimitGate.acquire(estimatedTokens: modelConfig.maxTokens ?? 0);
+    // NOTE: stream recording is deferred. Streamed runs that need
+    // replay should use generate() in eval mode.
+    return inner.stream(
+      messages,
+      tools: tools,
+      toolChoice: toolChoice,
+      modelConfig: modelConfig,
+      jsonOutput: jsonOutput,
+      cancelToken: cancelToken,
+    );
+  }
+}

--- a/lib/src/eval/llm/recording_store.dart
+++ b/lib/src/eval/llm/recording_store.dart
@@ -1,0 +1,126 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:logging/logging.dart';
+
+import '../../core/message.dart';
+
+final _logger = Logger('RecordingStore');
+
+/// Append-only key-value store for recorded LLM responses.
+///
+/// Per RFC §13.3 the store is intentionally append-only; it does not
+/// support compaction or deletion. Operators who need to archive old
+/// recordings should do so externally.
+abstract class RecordingStore {
+  /// Returns the recorded response for [hash], or null if no recording.
+  Future<ModelMessage?> get(String hash);
+
+  /// Stores a new recording under [hash]. If a recording already exists,
+  /// implementations may overwrite or no-op (FileRecordingStore overwrites
+  /// — useful when re-recording after a known-broken capture).
+  Future<void> put(String hash, ModelMessage response);
+
+  /// Force any buffered writes to flush. Called by the runner before
+  /// exiting.
+  Future<void> flush();
+}
+
+/// In-memory store; useful for tests of the eval subsystem itself and for
+/// short-lived runs.
+class InMemoryRecordingStore implements RecordingStore {
+  final Map<String, ModelMessage> _store = {};
+
+  @override
+  Future<ModelMessage?> get(String hash) async => _store[hash];
+
+  @override
+  Future<void> put(String hash, ModelMessage response) async {
+    _store[hash] = response;
+  }
+
+  @override
+  Future<void> flush() async {}
+}
+
+/// Filesystem-backed store. One JSON file per (hash) under [rootDir].
+///
+/// Layout:
+///   rootDir/
+///     ab/cd/abcdef…json
+///
+/// The two-level prefix avoids huge directories on filesystems that don't
+/// like 100k+ siblings.
+class FileRecordingStore implements RecordingStore {
+  final Directory rootDir;
+
+  /// Cached writes, flushed lazily. Keyed by hash. We always re-read from
+  /// disk on miss so multiple concurrent runs converge.
+  final Map<String, ModelMessage> _pendingWrites = {};
+
+  /// Pending future for a single in-flight flush. Subsequent calls await
+  /// the same future to serialize disk writes.
+  Future<void>? _inflightFlush;
+
+  FileRecordingStore(this.rootDir) {
+    if (!rootDir.existsSync()) {
+      rootDir.createSync(recursive: true);
+    }
+  }
+
+  File _fileFor(String hash) {
+    final p1 = hash.substring(0, 2);
+    final p2 = hash.substring(2, 4);
+    return File('${rootDir.path}/$p1/$p2/$hash.json');
+  }
+
+  @override
+  Future<ModelMessage?> get(String hash) async {
+    final pending = _pendingWrites[hash];
+    if (pending != null) return pending;
+    final f = _fileFor(hash);
+    if (!await f.exists()) return null;
+    try {
+      final json = jsonDecode(await f.readAsString()) as Map<String, dynamic>;
+      return ModelMessage.fromJson(json);
+    } catch (e, st) {
+      _logger.warning('failed to decode recording $hash', e, st);
+      return null;
+    }
+  }
+
+  @override
+  Future<void> put(String hash, ModelMessage response) async {
+    _pendingWrites[hash] = response;
+    // Trigger a background flush; callers don't need to await each put.
+    _scheduleFlush();
+  }
+
+  void _scheduleFlush() {
+    _inflightFlush ??= Future.microtask(() async {
+      try {
+        await _doFlush();
+      } finally {
+        _inflightFlush = null;
+      }
+    });
+  }
+
+  Future<void> _doFlush() async {
+    final batch = Map<String, ModelMessage>.from(_pendingWrites);
+    if (batch.isEmpty) return;
+    _pendingWrites.clear();
+    for (final entry in batch.entries) {
+      final f = _fileFor(entry.key);
+      await f.parent.create(recursive: true);
+      await f.writeAsString(jsonEncode(entry.value.toJson()));
+    }
+  }
+
+  @override
+  Future<void> flush() async {
+    final inflight = _inflightFlush;
+    if (inflight != null) await inflight;
+    if (_pendingWrites.isNotEmpty) await _doFlush();
+  }
+}

--- a/lib/src/eval/llm/replay_llm_client.dart
+++ b/lib/src/eval/llm/replay_llm_client.dart
@@ -1,0 +1,129 @@
+import 'package:dio/dio.dart';
+import 'package:logging/logging.dart';
+
+import '../../core/llm_client.dart';
+import '../../core/message.dart';
+import '../../core/tool.dart';
+import 'llm_request_hash.dart';
+import 'rate_limit_gate.dart';
+import 'recording_store.dart';
+
+final _logger = Logger('ReplayLLMClient');
+
+/// Thrown when a [ReplayLLMClient] cannot find a recorded response and
+/// has no fallback configured (or [strictReplay] is true).
+class RecordingNotFoundException implements Exception {
+  final String hash;
+  final String? requestSummary;
+
+  RecordingNotFoundException(this.hash, {this.requestSummary});
+
+  @override
+  String toString() =>
+      'No recording for hash=$hash. '
+      'Re-record with `--mode record` if the prompt or tools changed.'
+      '${requestSummary == null ? '' : '\nRequest summary: $requestSummary'}';
+}
+
+/// Replays from a [RecordingStore]; falls back to an inner client (or
+/// throws) on miss.
+///
+/// CI default: pass `strictReplay: true` and no `fallback` so any cache
+/// miss fails the build, forcing re-recording.
+///
+/// When a [fallback] is configured, every fallback (real upstream) call
+/// awaits the [RateLimitGate] first.
+///
+/// **Per-trial salt**: must match what was used during recording (see
+/// [RecordingLLMClient.trialSalt]). Use [withTrialSalt] to clone this
+/// client per trial inside [EvalEnvironment.prepare] so each trial
+/// looks up its own cache entry instead of collapsing onto one shared
+/// response.
+class ReplayLLMClient implements LLMClient {
+  final RecordingStore store;
+  final LLMClient? fallback;
+  final LLMRequestHash hasher;
+  final RateLimitGate rateLimitGate;
+  final String? trialSalt;
+
+  /// If true, throw on miss instead of falling back.
+  final bool strictReplay;
+
+  ReplayLLMClient({
+    required this.store,
+    this.fallback,
+    this.strictReplay = true,
+    LLMRequestHash? hasher,
+    RateLimitGate? rateLimitGate,
+    this.trialSalt,
+  }) : hasher = hasher ?? const Sha256LLMRequestHash(),
+       rateLimitGate = rateLimitGate ?? const NoopRateLimitGate();
+
+  /// Returns a copy of this client bound to [salt]. Convenience for
+  /// per-trial wrapping inside an environment's `prepare()`.
+  ReplayLLMClient withTrialSalt(String salt) => ReplayLLMClient(
+    store: store,
+    fallback: fallback,
+    strictReplay: strictReplay,
+    hasher: hasher,
+    rateLimitGate: rateLimitGate,
+    trialSalt: salt,
+  );
+
+  @override
+  Future<ModelMessage> generate(
+    List<LLMMessage> messages, {
+    List<Tool>? tools,
+    ToolChoice? toolChoice,
+    required ModelConfig modelConfig,
+    bool? jsonOutput,
+    CancelToken? cancelToken,
+  }) async {
+    final hash = hasher.compute(
+      messages: messages,
+      tools: tools,
+      modelConfig: modelConfig,
+      jsonOutput: jsonOutput,
+      trialSalt: trialSalt,
+    );
+    final cached = await store.get(hash);
+    if (cached != null) return cached;
+
+    _logger.fine('replay cache miss: $hash');
+    if (fallback != null && !strictReplay) {
+      await rateLimitGate.acquire(estimatedTokens: modelConfig.maxTokens ?? 0);
+      return fallback!.generate(
+        messages,
+        tools: tools,
+        toolChoice: toolChoice,
+        modelConfig: modelConfig,
+        jsonOutput: jsonOutput,
+        cancelToken: cancelToken,
+      );
+    }
+    throw RecordingNotFoundException(hash);
+  }
+
+  @override
+  Future<Stream<StreamingMessage>> stream(
+    List<LLMMessage> messages, {
+    List<Tool>? tools,
+    ToolChoice? toolChoice,
+    required ModelConfig modelConfig,
+    bool? jsonOutput,
+    CancelToken? cancelToken,
+  }) async {
+    // For replay we synthesize a one-chunk stream from the recorded message.
+    final response = await generate(
+      messages,
+      tools: tools,
+      toolChoice: toolChoice,
+      modelConfig: modelConfig,
+      jsonOutput: jsonOutput,
+      cancelToken: cancelToken,
+    );
+    return Stream<StreamingMessage>.fromIterable([
+      StreamingMessage(modelMessage: response),
+    ]);
+  }
+}

--- a/lib/src/eval/loaders/grader_registry.dart
+++ b/lib/src/eval/loaders/grader_registry.dart
@@ -1,0 +1,44 @@
+import '../graders/grader.dart';
+
+/// Builds a [Grader] instance from a JSON config blob. Each demo /
+/// application registers one factory per grader-name; the loader uses
+/// the registry to materialize graders referenced from data files.
+typedef GraderFactoryFunction = Grader Function(Map<String, dynamic> config);
+
+/// Maps a grader name (as it appears in JSONL/JSON files) to a factory
+/// that can construct an actual [Grader] from a config map.
+///
+/// Usage:
+/// ```dart
+/// final reg = GraderRegistry();
+/// reg.register('answer_correctness',
+///   (cfg) => AnswerCorrectnessGrader(expected: cfg['expected'] as num));
+/// ```
+class GraderRegistry {
+  final Map<String, GraderFactoryFunction> _factories = {};
+
+  /// Register a factory for [name]. Overwrites any prior registration
+  /// of the same name.
+  void register(String name, GraderFactoryFunction factory) {
+    _factories[name] = factory;
+  }
+
+  /// Build a grader by [name] using [config]. Throws if [name] is not
+  /// registered.
+  Grader build(String name, Map<String, dynamic> config) {
+    final f = _factories[name];
+    if (f == null) {
+      throw StateError(
+        'Grader "$name" is not registered. '
+        'Known graders: ${_factories.keys.toList()}',
+      );
+    }
+    return f(config);
+  }
+
+  /// Returns true if [name] has a registered factory.
+  bool contains(String name) => _factories.containsKey(name);
+
+  /// Returns all registered names. Order is insertion order.
+  Iterable<String> get registeredNames => _factories.keys;
+}

--- a/lib/src/eval/loaders/json_eval_task.dart
+++ b/lib/src/eval/loaders/json_eval_task.dart
@@ -1,0 +1,63 @@
+import '../core/eval_task.dart';
+import '../core/reference_solution.dart';
+import '../graders/grader.dart';
+
+/// Data-driven [EvalTask]. Constructed from a parsed JSON map plus a
+/// list of graders already resolved by the loader.
+///
+/// Schema of one task file:
+/// ```json
+/// {
+///   "id": "card_event_meeting",
+///   "description": "Calendar-style input → 'event' template.",
+///   "input": {
+///     "prompt": "..."
+///   },
+///   "metadata": {
+///     "failure_bucket": "template_event"
+///   },
+///   "trials_per_run": 2,
+///   "timeout_seconds": 120,
+///   "reference_solution": {
+///     "expected_outcome": {"card_saved": true},
+///     "source": "manual"
+///   },
+///   "graders": [
+///     {"name": "card_saved", "config": {"fact_id": "fact_001",
+///                                        "templates": ["event"]}},
+///     {"name": "called_get_card_metadata"}
+///   ]
+/// }
+/// ```
+///
+/// The `agent_name` lives in `suite.json`, not here — every task in a
+/// suite shares the same target agent. See [EvalSuite].
+class JsonEvalTask implements EvalTask {
+  @override
+  final String id;
+  @override
+  final String description;
+  @override
+  final Map<String, dynamic> input;
+  @override
+  final ReferenceSolution? referenceSolution;
+  @override
+  final Map<String, String> metadata;
+  @override
+  final List<Grader> graders;
+  @override
+  final int trialsPerRun;
+  @override
+  final Duration? timeout;
+
+  JsonEvalTask({
+    required this.id,
+    required this.description,
+    required this.input,
+    required this.graders,
+    this.referenceSolution,
+    this.metadata = const {},
+    this.trialsPerRun = 1,
+    this.timeout,
+  });
+}

--- a/lib/src/eval/loaders/suite_loader.dart
+++ b/lib/src/eval/loaders/suite_loader.dart
@@ -1,0 +1,208 @@
+import 'dart:convert';
+import 'dart:io';
+
+import '../core/eval_suite.dart';
+import '../core/eval_task.dart';
+import '../core/reference_solution.dart';
+import '../graders/grader.dart';
+import 'grader_registry.dart';
+import 'json_eval_task.dart';
+
+/// Loads an [EvalSuite] from a directory laid out as:
+///
+/// ```
+/// suites/<suite_name>/
+///   suite.json                 ← suite metadata (incl. agent_name)
+///   tasks/                     ← one JSON file per task; sub-folders
+///     positive/                  are allowed for organization
+///       my_task.json
+///     negative/
+///       my_other_task.json
+/// ```
+///
+/// `suite.json` schema:
+/// ```json
+/// {
+///   "name": "card_agent_capability",
+///   "agent_name": "card_agent",
+///   "kind": "capability",
+///   "requireReferenceSolution": true,
+///   "taskPassThreshold": 1.0
+/// }
+/// ```
+///
+/// Each `<task>.json` follows the schema documented on [JsonEvalTask].
+/// Note that `agent_name` belongs on the suite, not on individual tasks
+/// — every task in a suite targets the same agent.
+///
+/// **Why a directory layout?** Big task sets quickly outgrow a single
+/// JSON blob. One file per task lets product owners review/PR a task
+/// at a time, lets git diffs be readable, and lets sub-folders group
+/// tasks by failure bucket / source / difficulty.
+EvalSuite loadEvalSuiteFromDir(
+  Directory root, {
+  required GraderRegistry graderRegistry,
+}) {
+  if (!root.existsSync()) {
+    throw ArgumentError('Suite directory does not exist: ${root.path}');
+  }
+
+  // 1. Suite metadata.
+  final suiteFile = File('${root.path}/suite.json');
+  if (!suiteFile.existsSync()) {
+    throw StateError(
+      'Missing suite.json at ${suiteFile.path}. '
+      'Every suite directory must declare its name + kind.',
+    );
+  }
+  final suiteJson =
+      jsonDecode(suiteFile.readAsStringSync()) as Map<String, dynamic>;
+  final name = (suiteJson['name'] as String?)?.trim();
+  if (name == null || name.isEmpty) {
+    throw StateError('${suiteFile.path}: "name" is required and non-empty.');
+  }
+  final agentName = (suiteJson['agent_name'] as String?)?.trim();
+  if (agentName == null || agentName.isEmpty) {
+    throw StateError(
+      '${suiteFile.path}: "agent_name" is required and non-empty.',
+    );
+  }
+  final kindStr = (suiteJson['kind'] as String?)?.trim() ?? 'mixed';
+  final kind = SuiteKind.values.firstWhere(
+    (k) => k.name == kindStr,
+    orElse: () => throw StateError(
+      '${suiteFile.path}: invalid kind "$kindStr". '
+      'Use one of ${SuiteKind.values.map((k) => k.name).toList()}',
+    ),
+  );
+  final requireReferenceSolution =
+      suiteJson['requireReferenceSolution'] as bool? ?? false;
+  final taskPassThreshold =
+      (suiteJson['taskPassThreshold'] as num?)?.toDouble() ?? 1.0;
+
+  // 2. Task files (recursive, alphabetical within each folder).
+  final tasksDir = Directory('${root.path}/tasks');
+  if (!tasksDir.existsSync()) {
+    throw StateError(
+      'Missing tasks/ directory at ${tasksDir.path}. '
+      'Place one task JSON file per test under tasks/.',
+    );
+  }
+  final taskFiles = <File>[];
+  for (final entity in tasksDir.listSync(recursive: true)) {
+    if (entity is File && entity.path.toLowerCase().endsWith('.json')) {
+      taskFiles.add(entity);
+    }
+  }
+  if (taskFiles.isEmpty) {
+    throw StateError(
+      'No task files found under ${tasksDir.path}. '
+      'Add at least one task JSON before loading the suite.',
+    );
+  }
+  // Stable order: alphabetical by full path. Same task, same position
+  // across runs — important for diff/saturation reports.
+  taskFiles.sort((a, b) => a.path.compareTo(b.path));
+
+  final tasks = <EvalTask>[
+    for (final f in taskFiles)
+      _decodeTask(f, rootDir: root, graderRegistry: graderRegistry),
+  ];
+
+  return EvalSuite(
+    name: name,
+    agentName: agentName,
+    kind: kind,
+    tasks: tasks,
+    requireReferenceSolution: requireReferenceSolution,
+    taskPassThreshold: taskPassThreshold,
+  );
+}
+
+JsonEvalTask _decodeTask(
+  File file, {
+  required Directory rootDir,
+  required GraderRegistry graderRegistry,
+}) {
+  final relPath = file.path.replaceFirst('${rootDir.path}/', '');
+  Map<String, dynamic> json;
+  try {
+    json = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+  } catch (e) {
+    throw StateError('$relPath: failed to parse JSON — $e');
+  }
+
+  String require(String key) {
+    final v = json[key];
+    if (v is! String || v.trim().isEmpty) {
+      throw StateError('$relPath: "$key" is required and must be a string.');
+    }
+    return v;
+  }
+
+  final id = require('id');
+  final description = require('description');
+
+  final input = (json['input'] as Map?)?.cast<String, dynamic>() ?? const {};
+  final metadata =
+      (json['metadata'] as Map?)?.map((k, v) => MapEntry('$k', '$v')) ??
+      const <String, String>{};
+
+  final trialsPerRun = (json['trials_per_run'] as num?)?.toInt() ?? 1;
+  final timeoutSecs = (json['timeout_seconds'] as num?)?.toInt();
+
+  ReferenceSolution? ref;
+  final refJson = json['reference_solution'];
+  if (refJson is Map) {
+    final refMap = refJson.cast<String, dynamic>();
+    final sourceStr = (refMap['source'] as String?) ?? 'manual';
+    final source = ReferenceSolutionSource.values.firstWhere(
+      (s) => s.name == sourceStr,
+      orElse: () => ReferenceSolutionSource.manual,
+    );
+    ref = ReferenceSolution(
+      expectedOutcome: (refMap['expected_outcome'] as Map?)
+          ?.cast<String, dynamic>(),
+      source: source,
+    );
+  }
+
+  // 3. Resolve graders by name through the registry.
+  final gradersJson = json['graders'];
+  if (gradersJson is! List || gradersJson.isEmpty) {
+    throw StateError('$relPath: "graders" must be a non-empty list.');
+  }
+  final graders = <Grader>[];
+  for (final raw in gradersJson) {
+    if (raw is! Map) {
+      throw StateError(
+        '$relPath: every grader must be an object, got ${raw.runtimeType}',
+      );
+    }
+    final entry = raw.cast<String, dynamic>();
+    final name = entry['name'];
+    if (name is! String || name.trim().isEmpty) {
+      throw StateError('$relPath: grader entry missing "name".');
+    }
+    final config =
+        (entry['config'] as Map?)?.cast<String, dynamic>() ?? const {};
+    if (!graderRegistry.contains(name)) {
+      throw StateError(
+        '$relPath: grader "$name" is not registered. '
+        'Known graders: ${graderRegistry.registeredNames.toList()}',
+      );
+    }
+    graders.add(graderRegistry.build(name, config));
+  }
+
+  return JsonEvalTask(
+    id: id,
+    description: description,
+    input: input,
+    referenceSolution: ref,
+    metadata: metadata,
+    graders: graders,
+    trialsPerRun: trialsPerRun,
+    timeout: timeoutSecs == null ? null : Duration(seconds: timeoutSecs),
+  );
+}

--- a/lib/src/eval/metrics/classification_metrics.dart
+++ b/lib/src/eval/metrics/classification_metrics.dart
@@ -1,0 +1,51 @@
+/// Precision/Recall/F1 for binary classification tasks (e.g. Memory Agent).
+class ClassificationMetrics {
+  final int truePositives;
+  final int falsePositives;
+  final int trueNegatives;
+  final int falseNegatives;
+
+  const ClassificationMetrics({
+    required this.truePositives,
+    required this.falsePositives,
+    required this.trueNegatives,
+    required this.falseNegatives,
+  });
+
+  double get precision {
+    final denom = truePositives + falsePositives;
+    if (denom == 0) return 0.0;
+    return truePositives / denom;
+  }
+
+  double get recall {
+    final denom = truePositives + falseNegatives;
+    if (denom == 0) return 0.0;
+    return truePositives / denom;
+  }
+
+  double get f1 {
+    final p = precision;
+    final r = recall;
+    if (p + r == 0) return 0.0;
+    return 2 * p * r / (p + r);
+  }
+
+  double get accuracy {
+    final total =
+        truePositives + falsePositives + trueNegatives + falseNegatives;
+    if (total == 0) return 0.0;
+    return (truePositives + trueNegatives) / total;
+  }
+
+  Map<String, dynamic> toJson() => {
+    'truePositives': truePositives,
+    'falsePositives': falsePositives,
+    'trueNegatives': trueNegatives,
+    'falseNegatives': falseNegatives,
+    'precision': precision,
+    'recall': recall,
+    'f1': f1,
+    'accuracy': accuracy,
+  };
+}

--- a/lib/src/eval/metrics/pass_at_k.dart
+++ b/lib/src/eval/metrics/pass_at_k.dart
@@ -1,0 +1,24 @@
+/// Anthropic: probability of at least one success in [k] independent trials.
+///
+/// Uses the unbiased combinatorial formula from Codex paper:
+///
+///   pass@k = 1 − C(n − c, k) / C(n, k)
+///
+/// where n = total trials, c = successes among them, k ≤ n.
+///
+/// Returns 0.0 when k > trialPasses.length (cannot evaluate that many).
+double passAtK(List<bool> trialPasses, int k) {
+  final n = trialPasses.length;
+  if (k <= 0 || n == 0) return 0.0;
+  if (k > n) return 0.0;
+  final c = trialPasses.where((p) => p).length;
+  if (n - c < k) return 1.0;
+
+  // log-domain product to avoid overflow on big n.
+  // 1 - prod_{i=0..k-1} (n - c - i) / (n - i)
+  var prob = 1.0;
+  for (var i = 0; i < k; i++) {
+    prob *= (n - c - i) / (n - i);
+  }
+  return 1.0 - prob;
+}

--- a/lib/src/eval/metrics/pass_caret_k.dart
+++ b/lib/src/eval/metrics/pass_caret_k.dart
@@ -1,0 +1,24 @@
+/// Anthropic: probability that *all* k trials pass.
+///
+/// pass^k = (c / n)^k for the empirical estimator. Some references use the
+/// unbiased combinatorial form C(c, k) / C(n, k). We provide the empirical
+/// version because it's intuitive and consistent with how teams report
+/// "X out of Y trials passed" in CI reports.
+///
+/// Returns 0.0 when k <= 0 or n == 0.
+double passCaretK(List<bool> trialPasses, int k) {
+  final n = trialPasses.length;
+  if (k <= 0 || n == 0) return 0.0;
+  final c = trialPasses.where((p) => p).length;
+  if (c == 0) return 0.0;
+  // (c/n)^k
+  return _pow(c / n, k);
+}
+
+double _pow(double base, int exp) {
+  var result = 1.0;
+  for (var i = 0; i < exp; i++) {
+    result *= base;
+  }
+  return result;
+}

--- a/lib/src/eval/observability/composite_trace_exporter.dart
+++ b/lib/src/eval/observability/composite_trace_exporter.dart
@@ -1,0 +1,80 @@
+import '../../core/llm_client.dart';
+import '../../core/message.dart';
+import '../core/eval_task.dart';
+import '../core/outcome.dart';
+import '../core/transcript.dart';
+import '../core/trial.dart';
+import '../graders/score.dart';
+import 'trace_exporter.dart';
+
+/// Fans out events to multiple exporters. Order is preserved within each
+/// exporter; cross-exporter order is not guaranteed.
+class CompositeTraceExporter implements TraceExporter {
+  final List<TraceExporter> exporters;
+
+  CompositeTraceExporter(this.exporters);
+
+  Future<void> _broadcast(Future<void> Function(TraceExporter e) op) async {
+    await Future.wait(exporters.map(op));
+  }
+
+  @override
+  Future<void> onTrialStart(Trial trial, EvalTask task) =>
+      _broadcast((e) => e.onTrialStart(trial, task));
+
+  @override
+  Future<void> onLLMCall({
+    required Trial trial,
+    required List<LLMMessage> requestMessages,
+    required ModelConfig modelConfig,
+    required ModelMessage? response,
+    required Duration duration,
+    Object? error,
+  }) => _broadcast(
+    (e) => e.onLLMCall(
+      trial: trial,
+      requestMessages: requestMessages,
+      modelConfig: modelConfig,
+      response: response,
+      duration: duration,
+      error: error,
+    ),
+  );
+
+  @override
+  Future<void> onToolCall({
+    required Trial trial,
+    required ToolCallRecord record,
+  }) => _broadcast((e) => e.onToolCall(trial: trial, record: record));
+
+  @override
+  Future<void> onTrialEnd({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required List<Score> scores,
+  }) => _broadcast(
+    (e) => e.onTrialEnd(
+      trial: trial,
+      transcript: transcript,
+      outcome: outcome,
+      scores: scores,
+    ),
+  );
+
+  @override
+  Future<void> onRunEnd({
+    required String runName,
+    required String suiteName,
+    required Map<String, double> aggregateScores,
+  }) => _broadcast(
+    (e) => e.onRunEnd(
+      runName: runName,
+      suiteName: suiteName,
+      aggregateScores: aggregateScores,
+    ),
+  );
+
+  @override
+  Future<void> dispose() => _broadcast((e) => e.dispose());
+}

--- a/lib/src/eval/observability/jsonl_trace_exporter.dart
+++ b/lib/src/eval/observability/jsonl_trace_exporter.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+import 'dart:io';
+
+import '../../core/llm_client.dart';
+import '../../core/message.dart';
+import '../core/eval_task.dart';
+import '../core/outcome.dart';
+import '../core/transcript.dart';
+import '../core/trial.dart';
+import '../graders/score.dart';
+import 'trace_exporter.dart';
+
+/// Writes one JSON object per line to a file. Easy to grep, easy to
+/// import into other tools.
+///
+/// Event format (top-level keys):
+///   - `kind`: 'trial_start' | 'llm_call' | 'tool_call' | 'trial_end' | 'run_end'
+///   - `at`: ISO-8601 timestamp
+///   - all other keys are kind-specific
+///
+/// The exporter buffers writes; flush is called automatically on
+/// [dispose] but can also be called manually.
+class JsonlTraceExporter implements TraceExporter {
+  final IOSink _sink;
+  final File file;
+
+  JsonlTraceExporter._(this.file, this._sink);
+
+  factory JsonlTraceExporter(File file, {bool append = true}) {
+    file.parent.createSync(recursive: true);
+    final sink = file.openWrite(
+      mode: append ? FileMode.append : FileMode.write,
+    );
+    return JsonlTraceExporter._(file, sink);
+  }
+
+  void _write(Map<String, dynamic> obj) {
+    obj['at'] ??= DateTime.now().toIso8601String();
+    _sink.writeln(jsonEncode(obj));
+  }
+
+  @override
+  Future<void> onTrialStart(Trial trial, EvalTask task) async {
+    _write({
+      'kind': 'trial_start',
+      'trial': trial.toJson(),
+      'task': {
+        'id': task.id,
+        'description': task.description,
+        'metadata': task.metadata,
+      },
+    });
+  }
+
+  @override
+  Future<void> onLLMCall({
+    required Trial trial,
+    required List<LLMMessage> requestMessages,
+    required ModelConfig modelConfig,
+    required ModelMessage? response,
+    required Duration duration,
+    Object? error,
+  }) async {
+    _write({
+      'kind': 'llm_call',
+      'trialId': trial.id.toJson(),
+      'model': modelConfig.toJson(),
+      'durationMs': duration.inMilliseconds,
+      if (response != null) 'response': response.toJson(),
+      if (error != null) 'error': error.toString(),
+    });
+  }
+
+  @override
+  Future<void> onToolCall({
+    required Trial trial,
+    required ToolCallRecord record,
+  }) async {
+    _write({
+      'kind': 'tool_call',
+      'trialId': trial.id.toJson(),
+      'record': record.toJson(),
+    });
+  }
+
+  @override
+  Future<void> onTrialEnd({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required List<Score> scores,
+  }) async {
+    _write({
+      'kind': 'trial_end',
+      'trial': trial.toJson(),
+      'transcript': transcript.toJson(),
+      'outcome': outcome.toJson(),
+      'scores': scores.map((s) => s.toJson()).toList(),
+    });
+  }
+
+  @override
+  Future<void> onRunEnd({
+    required String runName,
+    required String suiteName,
+    required Map<String, double> aggregateScores,
+  }) async {
+    _write({
+      'kind': 'run_end',
+      'runName': runName,
+      'suiteName': suiteName,
+      'aggregateScores': aggregateScores,
+    });
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _sink.flush();
+    await _sink.close();
+  }
+}

--- a/lib/src/eval/observability/langfuse/langfuse_client.dart
+++ b/lib/src/eval/observability/langfuse/langfuse_client.dart
@@ -1,0 +1,189 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:logging/logging.dart';
+
+import 'langfuse_config.dart';
+import 'langfuse_event.dart';
+
+/// 把 [LangfuseEvent] 批量发到 `POST /api/public/ingestion`。
+///
+/// 行为对齐 Langfuse 官方 SDK：
+///   - 内部维护一个事件 queue
+///   - 满 [LangfuseConfig.flushAt] 条立刻 flush
+///   - 否则最长 [LangfuseConfig.flushInterval] flush 一次
+///   - HTTP 失败按指数退避重试，最多 [LangfuseConfig.maxRetries] 次
+///   - 关闭时 [shutdown] 强制 flush 完所有积压
+///
+/// 仅暴露 [enqueue] / [flush] / [shutdown] 三个口子，TraceExporter 不
+/// 需要关心 HTTP / 重试 / 批处理。
+class LangfuseClient {
+  static final _log = Logger('LangfuseClient');
+
+  final LangfuseConfig config;
+  final Dio _dio;
+
+  final List<LangfuseEvent> _queue = [];
+  Timer? _flushTimer;
+
+  /// 串行化 flush，避免并发请求重复发同一批 event。
+  Future<void>? _inFlight;
+  bool _closed = false;
+
+  LangfuseClient(this.config, {Dio? dio}) : _dio = dio ?? _defaultDio(config);
+
+  static Dio _defaultDio(LangfuseConfig config) {
+    final auth =
+        'Basic ${base64.encode(utf8.encode('${config.publicKey}:${config.secretKey}'))}';
+    return Dio(
+      BaseOptions(
+        connectTimeout: config.requestTimeout,
+        sendTimeout: config.requestTimeout,
+        receiveTimeout: config.requestTimeout,
+        headers: {'Content-Type': 'application/json', 'Authorization': auth},
+        // 4xx/5xx 自己处理，不要让 Dio 抛出
+        validateStatus: (_) => true,
+      ),
+    );
+  }
+
+  /// 把一条 event 放入队列。线程安全：只在 isolate-local 内调用。
+  void enqueue(LangfuseEvent event) {
+    if (_closed) return;
+    _queue.add(event);
+    if (_queue.length >= config.flushAt) {
+      // 立即触发；不 await，flush 自己串行化
+      unawaited(flush());
+    } else {
+      _scheduleFlush();
+    }
+  }
+
+  /// 多条版本，避免单条 enqueue 多次 schedule timer。
+  void enqueueAll(Iterable<LangfuseEvent> events) {
+    if (_closed) return;
+    _queue.addAll(events);
+    if (_queue.length >= config.flushAt) {
+      unawaited(flush());
+    } else {
+      _scheduleFlush();
+    }
+  }
+
+  void _scheduleFlush() {
+    _flushTimer ??= Timer(config.flushInterval, () {
+      _flushTimer = null;
+      unawaited(flush());
+    });
+  }
+
+  /// 把当前队列里的所有 event 发出去。**串行化**：同一时刻只有一个
+  /// 在飞的 flush，避免重复发送。
+  Future<void> flush() async {
+    if (_inFlight != null) {
+      await _inFlight;
+      // 等上一次完成后，如果队列里还有新的（在那期间 enqueue 的），递归
+      // flush 一次。但只递归一层，避免无限。
+      if (_queue.isNotEmpty) return _doFlushOnce();
+      return;
+    }
+    return _doFlushOnce();
+  }
+
+  Future<void> _doFlushOnce() async {
+    if (_queue.isEmpty) return;
+    final completer = Completer<void>();
+    _inFlight = completer.future;
+    try {
+      _flushTimer?.cancel();
+      _flushTimer = null;
+      final batch = List<LangfuseEvent>.from(_queue);
+      _queue.clear();
+      await _send(batch);
+    } finally {
+      _inFlight = null;
+      completer.complete();
+    }
+  }
+
+  Future<void> _send(List<LangfuseEvent> events) async {
+    if (events.isEmpty) return;
+    final body = {'batch': events.map((e) => e.toJson()).toList()};
+
+    var attempt = 0;
+    while (true) {
+      attempt++;
+      try {
+        final resp = await _dio.post<dynamic>(config.ingestionUrl, data: body);
+        // Langfuse 在部分 event 失败时会返回 207（Multi-Status）。
+        // 200 / 201 / 207 全算成功；只要有一部分被接收就放过。
+        final status = resp.statusCode ?? -1;
+        if (status >= 200 && status < 300) {
+          if (status == 207) {
+            _log.warning(
+              'Langfuse partial-success (207): ${_truncate(resp.data)}',
+            );
+          }
+          return;
+        }
+        // 4xx 不可恢复（鉴权 / schema 问题），扔出去
+        if (status >= 400 && status < 500) {
+          throw StateError(
+            'Langfuse rejected batch with $status: ${_truncate(resp.data)}',
+          );
+        }
+        // 5xx 才进入重试
+        throw _Retryable('Langfuse $status: ${_truncate(resp.data)}');
+      } on _Retryable catch (e) {
+        if (attempt > config.maxRetries) {
+          _log.severe(
+            'Langfuse flush failed after $attempt attempts (${events.length} events dropped): $e',
+          );
+          return; // 放弃，不让 eval run 因为可观测性挂掉
+        }
+        await Future.delayed(_backoff(attempt));
+      } on DioException catch (e) {
+        // 网络层失败也走重试
+        if (attempt > config.maxRetries) {
+          _log.severe(
+            'Langfuse flush failed after $attempt attempts (${events.length} events dropped): ${e.message}',
+          );
+          return;
+        }
+        await Future.delayed(_backoff(attempt));
+      } catch (e) {
+        _log.severe('Langfuse flush hit non-retryable error: $e');
+        return;
+      }
+    }
+  }
+
+  Duration _backoff(int attempt) {
+    // 100ms, 200ms, 400ms, 800ms, ...
+    final ms = 100 * (1 << (attempt - 1));
+    return Duration(milliseconds: ms.clamp(100, 5000));
+  }
+
+  /// flush 剩余事件 + 释放定时器。调用后 [enqueue] 静默 no-op。
+  Future<void> shutdown() async {
+    _closed = true;
+    _flushTimer?.cancel();
+    _flushTimer = null;
+    await flush();
+    if (_inFlight != null) await _inFlight;
+    _dio.close(force: true);
+  }
+
+  String _truncate(Object? data) {
+    final s = data?.toString() ?? '';
+    return s.length > 500 ? '${s.substring(0, 500)}...' : s;
+  }
+}
+
+class _Retryable implements Exception {
+  final String message;
+  _Retryable(this.message);
+  @override
+  String toString() => 'Retryable: $message';
+}

--- a/lib/src/eval/observability/langfuse/langfuse_config.dart
+++ b/lib/src/eval/observability/langfuse/langfuse_config.dart
@@ -1,0 +1,80 @@
+import 'dart:io';
+
+/// Langfuse 客户端配置。
+///
+/// 字段语义对齐 Langfuse 官方 SDK：
+///   - [host] 默认 `https://cloud.langfuse.com`，自托管时改成你的地址
+///   - [publicKey] / [secretKey] 用于 HTTP Basic auth
+///   - [environment] 透传到每个 trace/observation/score 的 `environment`
+///     字段（默认 `default`），用来在 dashboard 上区分 dev / staging / prod
+///   - [release] / [version] 可选标识，方便在 langfuse 上做 A/B 对比
+///
+/// 工厂方法 [LangfuseConfig.fromEnv] 从环境变量读取，方便 CI 接入。
+class LangfuseConfig {
+  /// 形如 `https://cloud.langfuse.com` 或 `https://langfuse.your-domain.com`。
+  /// 末尾不需要带 `/api/public/ingestion`。
+  final String host;
+  final String publicKey;
+  final String secretKey;
+
+  /// 默认 `default`。Langfuse 服务端会校验匹配 `^[a-z0-9-_]{1,40}$`。
+  final String environment;
+
+  final String? release;
+  final String? version;
+
+  /// 批量发送阈值：达到这么多 event 就立刻 flush。默认 50，对齐
+  /// 官方 SDK 的 `flushAt`。
+  final int flushAt;
+
+  /// 时间阈值：哪怕没攒够也最长等这么久就 flush。默认 1 秒，对齐
+  /// 官方 SDK 的 `flushInterval`。
+  final Duration flushInterval;
+
+  /// 单次 HTTP 失败的最大重试次数（指数退避）。默认 3。
+  final int maxRetries;
+
+  /// 单次请求超时。默认 10 秒。
+  final Duration requestTimeout;
+
+  const LangfuseConfig({
+    this.host = 'https://cloud.langfuse.com',
+    required this.publicKey,
+    required this.secretKey,
+    this.environment = 'default',
+    this.release,
+    this.version,
+    this.flushAt = 50,
+    this.flushInterval = const Duration(seconds: 1),
+    this.maxRetries = 3,
+    this.requestTimeout = const Duration(seconds: 10),
+  });
+
+  /// 从环境变量读取：
+  ///   - `LANGFUSE_HOST` (可选，默认 cloud)
+  ///   - `LANGFUSE_PUBLIC_KEY` (必需)
+  ///   - `LANGFUSE_SECRET_KEY` (必需)
+  ///   - `LANGFUSE_ENVIRONMENT` (可选，默认 `default`)
+  ///   - `LANGFUSE_RELEASE` / `LANGFUSE_VERSION` (可选)
+  factory LangfuseConfig.fromEnv([Map<String, String>? env]) {
+    final e = env ?? Platform.environment;
+    final pub = e['LANGFUSE_PUBLIC_KEY'];
+    final sec = e['LANGFUSE_SECRET_KEY'];
+    if (pub == null || pub.isEmpty || sec == null || sec.isEmpty) {
+      throw StateError(
+        'LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY are required in environment',
+      );
+    }
+    return LangfuseConfig(
+      host: e['LANGFUSE_HOST'] ?? 'https://cloud.langfuse.com',
+      publicKey: pub,
+      secretKey: sec,
+      environment: e['LANGFUSE_ENVIRONMENT'] ?? 'default',
+      release: e['LANGFUSE_RELEASE'],
+      version: e['LANGFUSE_VERSION'],
+    );
+  }
+
+  String get ingestionUrl =>
+      '${host.replaceAll(RegExp(r'/$'), '')}/api/public/ingestion';
+}

--- a/lib/src/eval/observability/langfuse/langfuse_event.dart
+++ b/lib/src/eval/observability/langfuse/langfuse_event.dart
@@ -1,0 +1,40 @@
+/// Langfuse `/api/public/ingestion` 上的 event 包装格式。
+///
+/// 一条 event 长这样：
+/// ```json
+/// {
+///   "id": "<uuid>",
+///   "type": "trace-create" | "generation-create" | ... ,
+///   "timestamp": "2026-05-22T...Z",
+///   "body": { ... }
+/// }
+/// ```
+///
+/// Body schema 参见 langfuse 仓库 `packages/shared/src/server/ingestion/types.ts`
+/// 的 `TraceBody` / `CreateGenerationBody` / `CreateSpanBody` / `ScoreBody`。
+class LangfuseEvent {
+  /// Event 自身的 UUID（不是 traceId）。Langfuse 用它做 dedup。
+  final String id;
+
+  /// `trace-create` / `generation-create` / `generation-update` /
+  /// `span-create` / `span-update` / `score-create` 等。
+  final String type;
+
+  final DateTime timestamp;
+
+  final Map<String, dynamic> body;
+
+  const LangfuseEvent({
+    required this.id,
+    required this.type,
+    required this.timestamp,
+    required this.body,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'type': type,
+    'timestamp': timestamp.toUtc().toIso8601String(),
+    'body': body,
+  };
+}

--- a/lib/src/eval/observability/langfuse/langfuse_trace_exporter.dart
+++ b/lib/src/eval/observability/langfuse/langfuse_trace_exporter.dart
@@ -1,0 +1,297 @@
+import 'package:uuid/uuid.dart';
+
+import '../../../core/llm_client.dart';
+import '../../../core/message.dart';
+import '../../core/eval_task.dart';
+import '../../core/outcome.dart';
+import '../../core/transcript.dart';
+import '../../core/trial.dart';
+import '../../graders/score.dart';
+import '../trace_exporter.dart';
+import 'langfuse_client.dart';
+import 'langfuse_config.dart';
+import 'langfuse_event.dart';
+
+/// Streams trial events to Langfuse via `/api/public/ingestion`.
+///
+/// 映射方式（一个 trial = 一棵 langfuse trace）：
+///
+/// | dart_agent_core | Langfuse |
+/// |---|---|
+/// | [Trial] | `trace-create`：traceId = `<runName>:<taskId>:<trialIndex>` |
+/// | LLM call | `generation-create`：observationId = uuid，parent = trace |
+/// | Tool call | `span-create`：observationId = uuid，parent = trace |
+/// | [Score] | `score-create`：traceId 关联到 trial 的 trace，dataType=NUMERIC |
+/// | run-level aggregate | trace 上挂一个 `run-summary` trace + score |
+///
+/// 配置从 [LangfuseConfig.fromEnv] 或显式构造，支持云端 / 自托管：
+/// ```dart
+/// final exporter = LangfuseTraceExporter(LangfuseConfig.fromEnv());
+/// final runner = EvalRunner(
+///   environment: env,
+///   harnessFactory: harness,
+///   exporters: [JsonlTraceExporter(file), exporter],
+///   ...
+/// );
+/// ```
+///
+/// 所有 HTTP 都跑在后台 queue 里。即使 langfuse server 临时挂了或网络
+/// 抖动，也不会拖慢 eval run（最多丢几条 event）。
+class LangfuseTraceExporter implements TraceExporter {
+  final LangfuseConfig config;
+  final LangfuseClient _client;
+  final _uuid = const Uuid();
+
+  /// runName + taskId + trialIndex → 当前 trace id（自己生成的稳定 id）。
+  /// 之所以不直接用 trial id 字符串拼一拼，是因为 langfuse 服务端要求
+  /// id 长这个样子 `^[a-zA-Z0-9_\-:.@/]+$`，而 trial 字符串里可能含 `#`。
+  final Map<String, String> _traceIds = {};
+
+  LangfuseTraceExporter(this.config, {LangfuseClient? client})
+    : _client = client ?? LangfuseClient(config);
+
+  String _traceIdFor(Trial trial) {
+    final key = trial.id.toString();
+    return _traceIds.putIfAbsent(key, () => _uuid.v4());
+  }
+
+  // ── TraceExporter callbacks ───────────────────────────────────────
+
+  @override
+  Future<void> onTrialStart(Trial trial, EvalTask task) async {
+    final traceId = _traceIdFor(trial);
+    _client.enqueue(
+      LangfuseEvent(
+        id: _uuid.v4(),
+        type: 'trace-create',
+        timestamp: trial.startedAt,
+        body: {
+          'id': traceId,
+          'timestamp': trial.startedAt.toUtc().toIso8601String(),
+          'name': '${trial.suiteName}/${trial.taskId}#${trial.trialIndex}',
+          'environment': config.environment,
+          'userId': trial.runName, // 在 dashboard 上按 run 过滤
+          'sessionId': trial.suiteName,
+          'tags': [
+            'suite:${trial.suiteName}',
+            'task:${trial.taskId}',
+            'run:${trial.runName}',
+            'trial:${trial.trialIndex}',
+          ],
+          'input': {
+            'taskId': task.id,
+            'description': task.description,
+            'input': task.input,
+          },
+          'metadata': {
+            'taskMetadata': task.metadata,
+            'trialIndex': trial.trialIndex,
+          },
+          if (config.release != null) 'release': config.release,
+          if (config.version != null) 'version': config.version,
+        },
+      ),
+    );
+  }
+
+  @override
+  Future<void> onLLMCall({
+    required Trial trial,
+    required List<LLMMessage> requestMessages,
+    required ModelConfig modelConfig,
+    required ModelMessage? response,
+    required Duration duration,
+    Object? error,
+  }) async {
+    final traceId = _traceIdFor(trial);
+    final endTime = DateTime.now();
+    final startTime = endTime.subtract(duration);
+    final usage = response?.usage;
+
+    _client.enqueue(
+      LangfuseEvent(
+        id: _uuid.v4(),
+        type: 'generation-create',
+        timestamp: startTime,
+        body: {
+          'id': _uuid.v4(),
+          'traceId': traceId,
+          'environment': config.environment,
+          'name': 'llm.${modelConfig.model}',
+          'startTime': startTime.toUtc().toIso8601String(),
+          'endTime': endTime.toUtc().toIso8601String(),
+          'model': modelConfig.model,
+          'modelParameters': _modelParameters(modelConfig),
+          'input': requestMessages.map((m) => m.toJson()).toList(),
+          if (response != null) 'output': response.toJson(),
+          if (usage != null)
+            'usage': {
+              'input': usage.promptTokens,
+              'output': usage.completionTokens,
+              'total': usage.totalTokens,
+              'unit': 'TOKENS',
+            },
+          if (error != null) ...{
+            'level': 'ERROR',
+            'statusMessage': error.toString(),
+          },
+        },
+      ),
+    );
+  }
+
+  Map<String, dynamic> _modelParameters(ModelConfig c) {
+    final out = <String, dynamic>{};
+    if (c.temperature != null) out['temperature'] = c.temperature;
+    if (c.maxTokens != null) out['maxTokens'] = c.maxTokens;
+    if (c.topP != null) out['topP'] = c.topP;
+    if (c.topK != null) out['topK'] = c.topK;
+    return out;
+  }
+
+  @override
+  Future<void> onToolCall({
+    required Trial trial,
+    required ToolCallRecord record,
+  }) async {
+    final traceId = _traceIdFor(trial);
+    _client.enqueue(
+      LangfuseEvent(
+        id: _uuid.v4(),
+        type: 'span-create',
+        timestamp: record.startedAt,
+        body: {
+          'id': _uuid.v4(),
+          'traceId': traceId,
+          'environment': config.environment,
+          'name': 'tool.${record.toolName}',
+          'startTime': record.startedAt.toUtc().toIso8601String(),
+          'endTime': record.endedAt.toUtc().toIso8601String(),
+          'input': {
+            'callId': record.callId,
+            'toolName': record.toolName,
+            'arguments': record.arguments,
+          },
+          if (record.result != null) 'output': record.result!.toJson(),
+          if (record.isError) ...{
+            'level': 'ERROR',
+            'statusMessage': record.errorMessage ?? 'tool error',
+          },
+        },
+      ),
+    );
+  }
+
+  @override
+  Future<void> onTrialEnd({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required List<Score> scores,
+  }) async {
+    final traceId = _traceIdFor(trial);
+
+    // 用 trace-create 再写一次同 id 的 trace 来 merge：补 endTime / output /
+    // 终态 metadata（30 天内 langfuse 服务端会按 id 合并）。
+    _client.enqueue(
+      LangfuseEvent(
+        id: _uuid.v4(),
+        type: 'trace-create',
+        timestamp: trial.endedAt,
+        body: {
+          'id': traceId,
+          'timestamp': trial.startedAt.toUtc().toIso8601String(),
+          'name': '${trial.suiteName}/${trial.taskId}#${trial.trialIndex}',
+          'environment': config.environment,
+          'userId': trial.runName,
+          'sessionId': trial.suiteName,
+          'output': outcome.toJson(),
+          'metadata': {
+            'status': trial.status.name,
+            if (trial.failureReason != null)
+              'failureReason': trial.failureReason,
+            'durationMs': trial.duration.inMilliseconds,
+            'transcriptMetrics': transcript.metrics.toJson(),
+          },
+        },
+      ),
+    );
+
+    // 每个 grader 一条 score-create。
+    for (final s in scores) {
+      if (s.value == null) continue; // null score 不上传（langfuse 不支持）
+      _client.enqueue(
+        LangfuseEvent(
+          id: _uuid.v4(),
+          type: 'score-create',
+          timestamp: trial.endedAt,
+          body: {
+            'id': _uuid.v4(),
+            'traceId': traceId,
+            'environment': config.environment,
+            'name': s.graderName,
+            'value': s.value,
+            'dataType': 'NUMERIC',
+            if (s.rationale != null) 'comment': s.rationale,
+            'metadata': {
+              if (s.passed != null) 'passed': s.passed,
+              'assertions': s.assertions.map((a) => a.toJson()).toList(),
+              ...s.metadata,
+            },
+          },
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<void> onRunEnd({
+    required String runName,
+    required String suiteName,
+    required Map<String, double> aggregateScores,
+  }) async {
+    // 给 run 整体建一个 summary trace，把所有 aggregate score 挂上去。
+    // 这样在 langfuse dashboard 可以按 userId=runName 筛出整次跑的概览。
+    final summaryTraceId = _uuid.v4();
+    final now = DateTime.now();
+    _client.enqueue(
+      LangfuseEvent(
+        id: _uuid.v4(),
+        type: 'trace-create',
+        timestamp: now,
+        body: {
+          'id': summaryTraceId,
+          'timestamp': now.toUtc().toIso8601String(),
+          'name': 'run-summary:$suiteName',
+          'environment': config.environment,
+          'userId': runName,
+          'sessionId': suiteName,
+          'tags': ['summary', 'run:$runName', 'suite:$suiteName'],
+          'metadata': {'aggregateScores': aggregateScores},
+        },
+      ),
+    );
+    for (final entry in aggregateScores.entries) {
+      _client.enqueue(
+        LangfuseEvent(
+          id: _uuid.v4(),
+          type: 'score-create',
+          timestamp: now,
+          body: {
+            'id': _uuid.v4(),
+            'traceId': summaryTraceId,
+            'environment': config.environment,
+            'name': entry.key,
+            'value': entry.value,
+            'dataType': 'NUMERIC',
+          },
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _client.shutdown();
+  }
+}

--- a/lib/src/eval/observability/trace_exporter.dart
+++ b/lib/src/eval/observability/trace_exporter.dart
@@ -1,0 +1,58 @@
+import '../../core/llm_client.dart';
+import '../../core/message.dart';
+import '../core/eval_task.dart';
+import '../core/outcome.dart';
+import '../core/transcript.dart';
+import '../core/trial.dart';
+import '../graders/score.dart';
+
+/// Streams trial events to an external observability backend.
+///
+/// "Trace" here is OTel-style (a tree of spans for one trial), distinct
+/// from [Transcript] (the serialized record). A single trial produces:
+///   - one `onTrialStart` call
+///   - many `onLLMCall` and `onToolCall` interleaved
+///   - one `onTrialEnd` call
+///
+/// Implementations must be safe to call from concurrent trials. Each
+/// trial's events arrive in order but trials interleave with each other.
+abstract class TraceExporter {
+  /// Called when a trial starts.
+  Future<void> onTrialStart(Trial trial, EvalTask task);
+
+  /// Called for each LLM call. [response] is null on errors.
+  Future<void> onLLMCall({
+    required Trial trial,
+    required List<LLMMessage> requestMessages,
+    required ModelConfig modelConfig,
+    required ModelMessage? response,
+    required Duration duration,
+    Object? error,
+  });
+
+  /// Called for each tool call.
+  Future<void> onToolCall({
+    required Trial trial,
+    required ToolCallRecord record,
+  });
+
+  /// Called when trial finishes with the final transcript, outcome, and
+  /// scores. Implementations should attach all scores here.
+  Future<void> onTrialEnd({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required List<Score> scores,
+  });
+
+  /// Called when a dataset run completes. Implementations may use this
+  /// hook to record run-level aggregate scores (pass@k, F1 …).
+  Future<void> onRunEnd({
+    required String runName,
+    required String suiteName,
+    required Map<String, double> aggregateScores,
+  }) async {}
+
+  /// Flush + release resources. Called once at the end of the run.
+  Future<void> dispose();
+}

--- a/lib/src/eval/observability/transcript_viewer.dart
+++ b/lib/src/eval/observability/transcript_viewer.dart
@@ -1,0 +1,337 @@
+import 'dart:convert';
+import 'dart:io';
+
+import '../core/eval_suite.dart';
+import '../core/trial_result.dart';
+import '../graders/score.dart';
+import '../reporting/report_store.dart';
+
+/// 命令行帮助文档。
+const String transcriptViewerUsage = r'''
+Usage: transcripts <command> [options]
+
+Commands:
+  list                          List recent runs.
+    --suite NAME                Filter by suite.
+    --limit N                   Max rows (default 20).
+
+  show                          Show one trial.
+    --trial RUN/TASK#INDEX      e.g. card_v3/card_001#0
+    --format human|json         (default human)
+
+  diff                          Compare same task across two runs.
+    --task TASK_ID              Required.
+    --runs RUN_A,RUN_B          Required.
+
+  export                        Export run as one markdown blob.
+    --run RUN_NAME              Required.
+    --format markdown|json      (default markdown)
+
+Common options:
+  --store DIR                   Report store directory (default: ./reports)
+''';
+
+/// 命令行入口。`bin/transcripts.dart` 直接 `await runTranscriptViewer(args)`。
+Future<int> runTranscriptViewer(List<String> args) async {
+  if (args.isEmpty) {
+    stdout.writeln(transcriptViewerUsage);
+    return 0;
+  }
+
+  final cmd = args.first;
+  final opts = _parseOptions(args.sublist(1));
+  final store = FileReportStore(Directory(opts['store'] ?? './reports'));
+
+  switch (cmd) {
+    case 'list':
+      return _cmdList(store, opts);
+    case 'show':
+      return _cmdShow(store, opts);
+    case 'diff':
+      return _cmdDiff(store, opts);
+    case 'export':
+      return _cmdExport(store, opts);
+    case '-h':
+    case '--help':
+      stdout.writeln(transcriptViewerUsage);
+      return 0;
+    default:
+      stderr.writeln('unknown command: $cmd');
+      stdout.writeln(transcriptViewerUsage);
+      return 2;
+  }
+}
+
+Map<String, String> _parseOptions(List<String> args) {
+  final out = <String, String>{};
+  for (var i = 0; i < args.length; i++) {
+    final a = args[i];
+    if (a.startsWith('--')) {
+      final key = a.substring(2);
+      final value = (i + 1 < args.length && !args[i + 1].startsWith('--'))
+          ? args[++i]
+          : 'true';
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+Future<int> _cmdList(ReportStore store, Map<String, String> opts) async {
+  final suite = opts['suite'];
+  final limit = int.tryParse(opts['limit'] ?? '20') ?? 20;
+  if (suite == null) {
+    final names = await store.listRunNames(limit: limit);
+    if (names.isEmpty) {
+      stdout.writeln('No runs found.');
+      return 0;
+    }
+    for (final n in names) {
+      stdout.writeln(n);
+    }
+    return 0;
+  }
+  final entries = await store.listRecent(suiteName: suite, limit: limit);
+  if (entries.isEmpty) {
+    stdout.writeln('No runs found for suite "$suite".');
+    return 0;
+  }
+  stdout.writeln(
+    [
+      'Run',
+      'Suite',
+      'Kind',
+      'Started',
+      'Tasks pass',
+      'Trials pass',
+      '#trials',
+    ].join('\t'),
+  );
+  for (final e in entries) {
+    stdout.writeln(
+      [
+        e.runName,
+        e.suiteName,
+        e.suiteKind.name,
+        e.startedAt.toIso8601String(),
+        '${(e.taskPassRate * 100).toStringAsFixed(1)}%',
+        '${(e.trialPassRate * 100).toStringAsFixed(1)}%',
+        e.numTrials,
+      ].join('\t'),
+    );
+  }
+  return 0;
+}
+
+Future<int> _cmdShow(ReportStore store, Map<String, String> opts) async {
+  final spec = opts['trial'];
+  if (spec == null) {
+    stderr.writeln('--trial RUN/TASK#INDEX is required');
+    return 2;
+  }
+  final parsed = _parseTrialSpec(spec);
+  if (parsed == null) {
+    stderr.writeln('invalid --trial: $spec (expected RUN/TASK#INDEX)');
+    return 2;
+  }
+
+  final report = await store.load(parsed.runName);
+  if (report == null) {
+    stderr.writeln('run not found: ${parsed.runName}');
+    return 1;
+  }
+  final tr = report.trials.firstWhere(
+    (t) =>
+        t.trial.taskId == parsed.taskId &&
+        t.trial.trialIndex == parsed.trialIndex,
+    orElse: () => throw StateError('trial not found in run'),
+  );
+
+  if ((opts['format'] ?? 'human') == 'json') {
+    stdout.writeln(jsonEncode(tr.toJson()));
+    return 0;
+  }
+  _renderTrialHuman(tr, report.suite.kind);
+  return 0;
+}
+
+void _renderTrialHuman(TrialResult tr, SuiteKind kind) {
+  final t = tr.trial;
+  stdout.writeln('Trial: ${t.runName} / ${t.taskId} #${t.trialIndex}');
+  stdout.writeln('Status: ${t.status.name}');
+  stdout.writeln('Duration: ${t.duration}');
+  stdout.writeln('All graders passed: ${tr.allGradersPassed}');
+  if (t.failureReason != null) {
+    stdout.writeln('Failure reason: ${t.failureReason}');
+  }
+  stdout.writeln();
+  stdout.writeln('--- Scores ---');
+  for (final s in tr.scores) {
+    stdout.writeln(_scoreLine(s));
+  }
+  stdout.writeln();
+  stdout.writeln('--- Outcome ---');
+  stdout.writeln(
+    const JsonEncoder.withIndent('  ').convert(tr.outcome.environmentState),
+  );
+  stdout.writeln();
+  stdout.writeln('--- Transcript metrics ---');
+  final m = tr.transcript.metrics;
+  stdout.writeln(
+    'turns=${m.nTurns} tools=${m.nToolCalls} tokens=${m.nTotalTokens}',
+  );
+  stdout.writeln();
+  stdout.writeln('--- Messages ---');
+  for (final msg in tr.transcript.messages) {
+    final j = msg.toJson();
+    final role = j['role'];
+    final text = _previewText(j);
+    stdout.writeln('[$role] $text');
+  }
+  stdout.writeln();
+  stdout.writeln('--- Tool calls ---');
+  for (final c in tr.transcript.toolCalls) {
+    stdout.writeln(
+      '${c.toolName}(${jsonEncode(c.arguments)})'
+      '${c.isError ? " [ERROR]" : ""}',
+    );
+  }
+}
+
+String _scoreLine(Score s) {
+  final pass = s.passed == null ? '?' : (s.passed! ? '✓' : '✗');
+  final value = s.value?.toStringAsFixed(2) ?? '—';
+  final tail = s.rationale == null ? '' : ' — ${s.rationale}';
+  return '$pass ${s.graderName} ($value)$tail';
+}
+
+String _previewText(Map<String, dynamic> j) {
+  final c = j['content'];
+  if (c is String) return c.length > 200 ? '${c.substring(0, 200)}…' : c;
+  if (c is List) {
+    final parts = c
+        .map((p) {
+          if (p is Map && p['type'] == 'text')
+            return p['text']?.toString() ?? '';
+          if (p is Map && p['text'] is String) return p['text'];
+          return '<${(p as Map?)?['type'] ?? "?"}>';
+        })
+        .join(' ');
+    return parts.length > 200 ? '${parts.substring(0, 200)}…' : parts;
+  }
+  return jsonEncode(c);
+}
+
+class _TrialSpec {
+  final String runName;
+  final String taskId;
+  final int trialIndex;
+  const _TrialSpec(this.runName, this.taskId, this.trialIndex);
+}
+
+_TrialSpec? _parseTrialSpec(String s) {
+  final hashIdx = s.lastIndexOf('#');
+  final slashIdx = s.indexOf('/');
+  if (hashIdx <= 0 || slashIdx <= 0 || hashIdx <= slashIdx) return null;
+  final runName = s.substring(0, slashIdx);
+  final taskId = s.substring(slashIdx + 1, hashIdx);
+  final idx = int.tryParse(s.substring(hashIdx + 1));
+  if (idx == null) return null;
+  return _TrialSpec(runName, taskId, idx);
+}
+
+Future<int> _cmdDiff(ReportStore store, Map<String, String> opts) async {
+  final taskId = opts['task'];
+  final runs = (opts['runs'] ?? '')
+      .split(',')
+      .where((s) => s.isNotEmpty)
+      .toList();
+  if (taskId == null || runs.length != 2) {
+    stderr.writeln('--task TASK_ID and --runs RUN_A,RUN_B are required');
+    return 2;
+  }
+
+  final reports = <PersistedRunReport>[];
+  for (final r in runs) {
+    final report = await store.load(r);
+    if (report == null) {
+      stderr.writeln('run not found: $r');
+      return 1;
+    }
+    reports.add(report);
+  }
+
+  for (var i = 0; i < 2; i++) {
+    final r = reports[i];
+    stdout.writeln('=== ${r.runName} (${r.startedAt.toIso8601String()}) ===');
+    final trials = r.trials.where((t) => t.trial.taskId == taskId).toList();
+    if (trials.isEmpty) {
+      stdout.writeln('  no trials for task $taskId');
+      continue;
+    }
+    for (final t in trials) {
+      stdout.writeln(
+        '  trial #${t.trial.trialIndex}: '
+        '${t.allGradersPassed ? "PASS" : "FAIL"} '
+        '(scores=${t.scores.map((s) => "${s.graderName}=${s.value?.toStringAsFixed(2) ?? '?'}").join(", ")})',
+      );
+    }
+    stdout.writeln();
+  }
+  return 0;
+}
+
+Future<int> _cmdExport(ReportStore store, Map<String, String> opts) async {
+  final runName = opts['run'];
+  if (runName == null) {
+    stderr.writeln('--run RUN_NAME is required');
+    return 2;
+  }
+  final report = await store.load(runName);
+  if (report == null) {
+    stderr.writeln('run not found: $runName');
+    return 1;
+  }
+  final format = opts['format'] ?? 'markdown';
+  if (format == 'json') {
+    stdout.writeln(
+      jsonEncode({
+        'runName': report.runName,
+        'suite': report.suite.toJson(),
+        'startedAt': report.startedAt.toIso8601String(),
+        'endedAt': report.endedAt.toIso8601String(),
+        'trials': report.trials.map((t) => t.toJson()).toList(),
+      }),
+    );
+    return 0;
+  }
+  stdout.writeln(_exportMarkdown(report));
+  return 0;
+}
+
+String _exportMarkdown(PersistedRunReport report) {
+  final b = StringBuffer();
+  b.writeln('# Run `${report.runName}`');
+  b.writeln();
+  b.writeln('- Suite: ${report.suite.name} (${report.suite.kind.name})');
+  b.writeln('- Started: ${report.startedAt.toIso8601String()}');
+  b.writeln('- Trials: ${report.trials.length}');
+  b.writeln();
+  for (final t in report.trials) {
+    b.writeln('## ${t.trial.taskId} #${t.trial.trialIndex}');
+    b.writeln(
+      '- Status: ${t.trial.status.name}'
+      '${t.trial.failureReason == null ? '' : ' (${t.trial.failureReason})'}',
+    );
+    for (final s in t.scores) {
+      b.writeln('- ${_scoreLine(s)}');
+    }
+    b.writeln();
+    final m = t.transcript.metrics;
+    b.writeln(
+      'Metrics: turns=${m.nTurns} tools=${m.nToolCalls} tokens=${m.nTotalTokens}',
+    );
+    b.writeln();
+  }
+  return b.toString();
+}

--- a/lib/src/eval/reporting/diff_reporter.dart
+++ b/lib/src/eval/reporting/diff_reporter.dart
@@ -1,0 +1,258 @@
+import '../core/eval_run_report.dart';
+import '../core/eval_suite.dart';
+import '../core/trial_result.dart';
+
+/// 跨两个 [EvalRunReport] 的差分。
+class EvalRunDiff {
+  /// 当前 run（PR/staging）。
+  final EvalRunReport current;
+
+  /// 基线 run（main/production）。
+  final EvalRunReport baseline;
+
+  /// 在两个 run 中都存在但状态变化的任务。
+  final List<TaskTransition> transitions;
+
+  /// 仅在当前 run 中出现的 task id（新增）。
+  final List<String> addedTaskIds;
+
+  /// 仅在基线中出现的 task id（被移除/重命名）。
+  final List<String> removedTaskIds;
+
+  /// Top-line metric 变化。
+  final Map<String, double> metricDeltas;
+
+  const EvalRunDiff({
+    required this.current,
+    required this.baseline,
+    required this.transitions,
+    required this.addedTaskIds,
+    required this.removedTaskIds,
+    required this.metricDeltas,
+  });
+
+  /// 生成 PR comment 友好的 markdown。
+  String toMarkdown() {
+    final b = StringBuffer();
+    b.writeln('# Eval diff: `${current.runName}` vs `${baseline.runName}`');
+    b.writeln();
+    b.writeln(
+      '- Suite: **${current.suite.name}** (${_kindLabel(current.suite.kind)})',
+    );
+    b.writeln(
+      '- Tasks: ${current.trialsByTask().length} '
+      '(was ${baseline.trialsByTask().length})',
+    );
+    b.writeln();
+
+    b.writeln('## Top-line metrics');
+    b.writeln();
+    b.writeln('| Metric | This run | Baseline | Δ |');
+    b.writeln('|---|---|---|---|');
+    for (final entry in metricDeltas.entries) {
+      final deltaStr = _delta(entry.value);
+      final marker =
+          current.suite.kind == SuiteKind.regression &&
+              entry.value < 0 &&
+              entry.key.contains('pass_rate')
+          ? ' 🚨'
+          : '';
+      b.writeln(
+        '| ${entry.key} | '
+        '${_metricCurrent(entry.key)} | '
+        '${_metricBaseline(entry.key)} | '
+        '$deltaStr$marker |',
+      );
+    }
+    b.writeln();
+
+    final regressed = transitions
+        .where((t) => t.kind == TaskTransitionKind.regressed)
+        .toList();
+    if (regressed.isNotEmpty) {
+      b.writeln('## 🚨 Regressed tasks (${regressed.length})');
+      b.writeln();
+      for (final t in regressed) {
+        b.writeln(
+          '- `${t.taskId}`: '
+          'baseline ${_pct(t.baselinePassRate)} → '
+          'current ${_pct(t.currentPassRate)}',
+        );
+      }
+      b.writeln();
+    }
+
+    final improved = transitions
+        .where((t) => t.kind == TaskTransitionKind.improved)
+        .toList();
+    if (improved.isNotEmpty) {
+      b.writeln('## ⬆️ Improved tasks (${improved.length})');
+      b.writeln();
+      for (final t in improved) {
+        b.writeln(
+          '- `${t.taskId}`: '
+          '${_pct(t.baselinePassRate)} → ${_pct(t.currentPassRate)}',
+        );
+      }
+      b.writeln();
+    }
+
+    if (addedTaskIds.isNotEmpty) {
+      b.writeln('## ➕ Added tasks');
+      b.writeln();
+      for (final id in addedTaskIds) {
+        b.writeln('- `$id`');
+      }
+      b.writeln();
+    }
+
+    if (removedTaskIds.isNotEmpty) {
+      b.writeln('## ➖ Removed tasks');
+      b.writeln();
+      for (final id in removedTaskIds) {
+        b.writeln('- `$id`');
+      }
+      b.writeln();
+    }
+
+    return b.toString();
+  }
+
+  String _metricCurrent(String key) {
+    switch (key) {
+      case 'task_pass_rate':
+        return _pct(current.taskPassRate);
+      case 'trial_pass_rate':
+        return _pct(current.trialPassRate);
+      default:
+        final mean = current.graderMeans[key.replaceFirst('grader_mean.', '')];
+        return mean == null ? '—' : mean.toStringAsFixed(3);
+    }
+  }
+
+  String _metricBaseline(String key) {
+    switch (key) {
+      case 'task_pass_rate':
+        return _pct(baseline.taskPassRate);
+      case 'trial_pass_rate':
+        return _pct(baseline.trialPassRate);
+      default:
+        final mean = baseline.graderMeans[key.replaceFirst('grader_mean.', '')];
+        return mean == null ? '—' : mean.toStringAsFixed(3);
+    }
+  }
+}
+
+enum TaskTransitionKind { regressed, improved, unchanged }
+
+class TaskTransition {
+  final String taskId;
+  final double currentPassRate;
+  final double baselinePassRate;
+  final TaskTransitionKind kind;
+
+  const TaskTransition({
+    required this.taskId,
+    required this.currentPassRate,
+    required this.baselinePassRate,
+    required this.kind,
+  });
+
+  bool get regressed => kind == TaskTransitionKind.regressed;
+  bool get improved => kind == TaskTransitionKind.improved;
+  bool get unchanged => kind == TaskTransitionKind.unchanged;
+}
+
+/// 计算两份 run report 的 diff。
+EvalRunDiff diffRunReports({
+  required EvalRunReport current,
+  required EvalRunReport baseline,
+  double significanceThreshold = 0.05,
+}) {
+  final currByTask = current.trialsByTask();
+  final baseByTask = baseline.trialsByTask();
+
+  final shared = currByTask.keys.toSet().intersection(baseByTask.keys.toSet());
+  final transitions = <TaskTransition>[];
+  for (final id in shared) {
+    final cur = _passRate(currByTask[id]!);
+    final base = _passRate(baseByTask[id]!);
+    final delta = cur - base;
+    final t = delta.abs() < significanceThreshold
+        ? TaskTransitionKind.unchanged
+        : (delta > 0
+              ? TaskTransitionKind.improved
+              : TaskTransitionKind.regressed);
+    transitions.add(
+      TaskTransition(
+        taskId: id,
+        currentPassRate: cur,
+        baselinePassRate: base,
+        kind: t,
+      ),
+    );
+  }
+
+  final added = currByTask.keys.toSet().difference(baseByTask.keys.toSet());
+  final removed = baseByTask.keys.toSet().difference(currByTask.keys.toSet());
+
+  final deltas = <String, double>{
+    'task_pass_rate': current.taskPassRate - baseline.taskPassRate,
+    'trial_pass_rate': current.trialPassRate - baseline.trialPassRate,
+  };
+  for (final entry in current.graderMeans.entries) {
+    final baseValue = baseline.graderMeans[entry.key];
+    if (baseValue != null) {
+      deltas['grader_mean.${entry.key}'] = entry.value - baseValue;
+    }
+  }
+
+  return EvalRunDiff(
+    current: current,
+    baseline: baseline,
+    transitions: transitions,
+    addedTaskIds: added.toList()..sort(),
+    removedTaskIds: removed.toList()..sort(),
+    metricDeltas: deltas,
+  );
+}
+
+double _passRate(List<TrialResult> trs) {
+  if (trs.isEmpty) return 0.0;
+  return trs.where((t) => t.allGradersPassed).length / trs.length;
+}
+
+String _pct(double v) => '${(v * 100).toStringAsFixed(1)}%';
+
+String _delta(double v) {
+  final pct = '${(v * 100).toStringAsFixed(1)}%';
+  if (v > 0) return '+$pct ⬆';
+  if (v < 0) return '$pct ⬇';
+  return '0%';
+}
+
+String _kindLabel(SuiteKind kind) {
+  switch (kind) {
+    case SuiteKind.capability:
+      return 'capability';
+    case SuiteKind.regression:
+      return 'regression';
+    case SuiteKind.mixed:
+      return 'mixed';
+  }
+}
+
+/// Convenience: `current.diffWith(baseline)` reads more naturally than
+/// `diffRunReports(current: current, baseline: baseline)`.
+extension EvalRunReportDiff on EvalRunReport {
+  EvalRunDiff diffWith(
+    EvalRunReport baseline, {
+    double significanceThreshold = 0.05,
+  }) {
+    return diffRunReports(
+      current: this,
+      baseline: baseline,
+      significanceThreshold: significanceThreshold,
+    );
+  }
+}

--- a/lib/src/eval/reporting/report_generator.dart
+++ b/lib/src/eval/reporting/report_generator.dart
@@ -1,0 +1,185 @@
+import '../core/eval_run_report.dart';
+import '../core/eval_suite.dart';
+import '../graders/score.dart';
+import '../suite_health/suite_health_report.dart';
+
+/// 生成一次 [EvalRunReport] 的 Markdown 总结。
+String generateMarkdownReport(
+  EvalRunReport report, {
+  Map<String, String>? taskBucketMap,
+  SuiteHealthReport? health,
+  List<int> ksToReport = const [1, 3],
+}) {
+  final b = StringBuffer();
+  final byTask = report.trialsByTask();
+
+  b.writeln('# Eval Run: `${report.runName}`');
+  b.writeln();
+  b.writeln(
+    '- Suite: **${report.suite.name}** '
+    '(${_kindLabel(report.suite.kind)})',
+  );
+  b.writeln('- Started: ${report.startedAt.toIso8601String()}');
+  b.writeln('- Duration: ${_formatDuration(report.duration)}');
+  b.writeln('- Tasks: ${byTask.length} · Trials: ${report.trials.length}');
+  b.writeln();
+
+  // Top-line metrics
+  b.writeln('## Top-line metrics');
+  b.writeln();
+  b.writeln('| Metric | Value |');
+  b.writeln('|---|---|');
+  b.writeln('| Task pass rate | ${_pct(report.taskPassRate)} |');
+  b.writeln('| Trial pass rate | ${_pct(report.trialPassRate)} |');
+  for (final entry in report.graderMeans.entries) {
+    b.writeln(
+      '| Grader mean: `${entry.key}` | ${entry.value.toStringAsFixed(3)} |',
+    );
+  }
+  b.writeln();
+
+  // pass@k / pass^k
+  final passAtK = report.passAtKByTask(ks: ksToReport);
+  final passCK = report.passCaretKByTask(ks: ksToReport);
+  if (passAtK.isNotEmpty && ksToReport.isNotEmpty) {
+    b.writeln('## pass@k / pass^k by task');
+    b.writeln();
+    final headers = [
+      'Task',
+      ...ksToReport.expand((k) => ['pass@$k', 'pass^$k']),
+    ];
+    b.writeln('| ${headers.join(' | ')} |');
+    b.writeln('|${'---|' * headers.length}');
+    for (final taskId in passAtK.keys) {
+      final cells = <String>[
+        '`$taskId`',
+        for (final k in ksToReport) ...[
+          _pct(passAtK[taskId]?[k] ?? 0),
+          _pct(passCK[taskId]?[k] ?? 0),
+        ],
+      ];
+      b.writeln('| ${cells.join(' | ')} |');
+    }
+    b.writeln();
+  }
+
+  // Bucket pass rates
+  if (taskBucketMap != null) {
+    final bucketRates = report.bucketPassRates(taskBucketMap);
+    if (bucketRates.isNotEmpty) {
+      b.writeln('## Pass rate by failure bucket');
+      b.writeln();
+      b.writeln('| Bucket | Pass rate |');
+      b.writeln('|---|---|');
+      for (final entry in bucketRates.entries) {
+        b.writeln('| ${entry.key} | ${_pct(entry.value)} |');
+      }
+      b.writeln();
+    }
+  }
+
+  // Failed trials
+  final failed = report.trials.where((t) => !t.allGradersPassed).toList();
+  if (failed.isNotEmpty) {
+    b.writeln('## Failed trials (${failed.length})');
+    b.writeln();
+    for (final tr in failed) {
+      b.writeln('### `${tr.trial.taskId}` · trial #${tr.trial.trialIndex}');
+      b.writeln();
+      for (final s in tr.scores) {
+        b.writeln(_renderScore(s));
+      }
+      b.writeln();
+    }
+  }
+
+  // Health
+  if (health != null) {
+    b.writeln('## Suite health');
+    b.writeln();
+    b.writeln(
+      '- Saturation: ${_pct(health.currentSaturationRatio)} '
+      '${health.currentlySaturated ? "⚠️ saturated" : ""}',
+    );
+    if (health.graduationCandidates.isNotEmpty) {
+      b.writeln('- Graduation candidates:');
+      for (final c in health.graduationCandidates) {
+        b.writeln(
+          '  - `${c.taskId}` (mean ${_pct(c.recentMeanPassRate)}, '
+          '${c.consecutiveMatureRuns} consecutive mature runs)',
+        );
+      }
+    }
+    if (health.brokenTaskCandidates.isNotEmpty) {
+      b.writeln('- Broken task candidates (likely task/grader bugs):');
+      for (final c in health.brokenTaskCandidates) {
+        b.writeln(
+          '  - `${c.taskId}` (${c.passedTrials}/${c.totalTrials} '
+          'passed = ${_pct(c.passRate)})',
+        );
+      }
+    }
+    b.writeln();
+  }
+
+  return b.toString();
+}
+
+String _renderScore(Score s) {
+  final b = StringBuffer();
+  final pass = s.passed == null
+      ? '⚪ unknown'
+      : (s.passed! ? '✅ passed' : '❌ failed');
+  final value = s.value == null ? '—' : s.value!.toStringAsFixed(2);
+  b.writeln('- **${s.graderName}** — $pass · score=$value');
+  if (s.rationale != null && s.rationale!.isNotEmpty) {
+    final indented = s.rationale!.split('\n').map((l) => '  $l').join('\n');
+    b.writeln(indented);
+  }
+  if (s.assertions.isNotEmpty) {
+    for (final a in s.assertions.where((a) => !a.passed)) {
+      b.writeln(
+        '  - ❌ ${a.description}'
+        '${a.expected != null ? " · expected=`${a.expected}`" : ""}'
+        '${a.actual != null ? " · actual=`${a.actual}`" : ""}',
+      );
+    }
+  }
+  return b.toString();
+}
+
+String _pct(double v) => '${(v * 100).toStringAsFixed(1)}%';
+
+String _kindLabel(SuiteKind kind) {
+  switch (kind) {
+    case SuiteKind.capability:
+      return 'capability';
+    case SuiteKind.regression:
+      return 'regression';
+    case SuiteKind.mixed:
+      return 'mixed';
+  }
+}
+
+String _formatDuration(Duration d) {
+  if (d.inHours > 0) return '${d.inHours}h${d.inMinutes.remainder(60)}m';
+  if (d.inMinutes > 0) return '${d.inMinutes}m${d.inSeconds.remainder(60)}s';
+  return '${d.inSeconds}s';
+}
+
+/// Convenience methods on [EvalRunReport] that render Markdown / diff output.
+/// Implemented as extensions so the core `EvalRunReport` class doesn't have
+/// to import the reporting layer.
+extension EvalRunReportReporting on EvalRunReport {
+  /// Render this run as a Markdown summary (PR comments, console output).
+  String toMarkdownSummary({
+    Map<String, String>? taskBucketMap,
+    List<int> ksToReport = const [1, 3],
+  }) {
+    return generateMarkdownReport(
+      this,
+      taskBucketMap: taskBucketMap,
+      ksToReport: ksToReport,
+    );
+  }
+}

--- a/lib/src/eval/reporting/report_store.dart
+++ b/lib/src/eval/reporting/report_store.dart
@@ -1,0 +1,304 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:logging/logging.dart';
+
+import '../core/eval_run_report.dart';
+import '../core/eval_suite.dart';
+import '../core/outcome.dart';
+import '../core/transcript.dart';
+import '../core/trial.dart';
+import '../core/trial_result.dart';
+import '../graders/score.dart';
+
+final _logger = Logger('ReportStore');
+
+/// 当从持久化 store 加载历史 run 时返回的"快照"。
+/// trials 完整保留，但 [suite] 字段是 [SuiteSnapshot]——历史 run 中的真实
+/// EvalSuite 实例（含 grader / referenceSolution 等运行时对象）已经不可
+/// 重建。跨 run 分析（saturation / graduation / diff）只读元数据，够用。
+class PersistedRunReport {
+  final String runName;
+  final SuiteSnapshot suite;
+  final List<TrialResult> trials;
+  final DateTime startedAt;
+  final DateTime endedAt;
+
+  const PersistedRunReport({
+    required this.runName,
+    required this.suite,
+    required this.trials,
+    required this.startedAt,
+    required this.endedAt,
+  });
+
+  Duration get duration => endedAt.difference(startedAt);
+
+  Map<String, List<TrialResult>> trialsByTask() {
+    final out = <String, List<TrialResult>>{};
+    for (final t in trials) {
+      out.putIfAbsent(t.trial.taskId, () => []).add(t);
+    }
+    return out;
+  }
+}
+
+/// Suite 元数据的不可执行快照。只保留分析需要的字段。
+class SuiteSnapshot {
+  final String name;
+  final SuiteKind kind;
+  final List<String> taskIds;
+  final double taskPassThreshold;
+  final bool requireReferenceSolution;
+
+  const SuiteSnapshot({
+    required this.name,
+    required this.kind,
+    required this.taskIds,
+    required this.taskPassThreshold,
+    required this.requireReferenceSolution,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'name': name,
+    'kind': kind.name,
+    'taskIds': taskIds,
+    'taskPassThreshold': taskPassThreshold,
+    'requireReferenceSolution': requireReferenceSolution,
+  };
+
+  factory SuiteSnapshot.fromJson(Map<String, dynamic> json) {
+    return SuiteSnapshot(
+      name: json['name'] as String,
+      kind: SuiteKind.values.firstWhere((k) => k.name == json['kind']),
+      taskIds: ((json['taskIds'] as List?) ?? const []).cast<String>(),
+      taskPassThreshold: (json['taskPassThreshold'] as num?)?.toDouble() ?? 1.0,
+      requireReferenceSolution:
+          json['requireReferenceSolution'] as bool? ?? false,
+    );
+  }
+
+  factory SuiteSnapshot.from(EvalSuite suite) => SuiteSnapshot(
+    name: suite.name,
+    kind: suite.kind,
+    taskIds: suite.tasks.map((t) => t.id).toList(),
+    taskPassThreshold: suite.taskPassThreshold,
+    requireReferenceSolution: suite.requireReferenceSolution,
+  );
+}
+
+/// 索引文件中一行的轻量元数据。
+class RunIndexEntry {
+  final String runName;
+  final String suiteName;
+  final SuiteKind suiteKind;
+  final DateTime startedAt;
+  final DateTime endedAt;
+  final double taskPassRate;
+  final double trialPassRate;
+  final int numTrials;
+
+  const RunIndexEntry({
+    required this.runName,
+    required this.suiteName,
+    required this.suiteKind,
+    required this.startedAt,
+    required this.endedAt,
+    required this.taskPassRate,
+    required this.trialPassRate,
+    required this.numTrials,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'runName': runName,
+    'suiteName': suiteName,
+    'suiteKind': suiteKind.name,
+    'startedAt': startedAt.toIso8601String(),
+    'endedAt': endedAt.toIso8601String(),
+    'taskPassRate': taskPassRate,
+    'trialPassRate': trialPassRate,
+    'numTrials': numTrials,
+  };
+
+  factory RunIndexEntry.fromJson(Map<String, dynamic> json) {
+    return RunIndexEntry(
+      runName: json['runName'] as String,
+      suiteName: json['suiteName'] as String,
+      suiteKind: SuiteKind.values.firstWhere(
+        (k) => k.name == json['suiteKind'],
+      ),
+      startedAt: DateTime.parse(json['startedAt'] as String),
+      endedAt: DateTime.parse(json['endedAt'] as String),
+      taskPassRate: (json['taskPassRate'] as num).toDouble(),
+      trialPassRate: (json['trialPassRate'] as num).toDouble(),
+      numTrials: json['numTrials'] as int,
+    );
+  }
+}
+
+/// 持久化历史 run report。append-only。
+abstract class ReportStore {
+  Future<void> save(EvalRunReport report);
+
+  Future<PersistedRunReport?> load(String runName);
+
+  /// 列出某 suite 最近 N 次的索引条目（轻量），按时间倒序。
+  Future<List<RunIndexEntry>> listRecent({
+    required String suiteName,
+    int limit = 10,
+  });
+
+  /// 加载某 suite 最近 N 次完整快照，按时间倒序。
+  Future<List<PersistedRunReport>> loadRecent({
+    required String suiteName,
+    int limit = 10,
+  });
+
+  Future<List<String>> listRunNames({String? suiteFilter, int? limit});
+}
+
+/// 文件系统实现。
+///
+/// 布局：
+/// ```
+/// rootDir/
+///   index.jsonl         # 每行一个 run 索引
+///   reports/
+///     {safe_runName}.json
+/// ```
+class FileReportStore implements ReportStore {
+  final Directory rootDir;
+  final File indexFile;
+  final Directory reportsDir;
+
+  FileReportStore(this.rootDir)
+    : indexFile = File('${rootDir.path}/index.jsonl'),
+      reportsDir = Directory('${rootDir.path}/reports') {
+    rootDir.createSync(recursive: true);
+    reportsDir.createSync(recursive: true);
+    if (!indexFile.existsSync()) indexFile.createSync();
+  }
+
+  static String _safeName(String s) =>
+      s.replaceAll(RegExp(r'[^A-Za-z0-9_.\-]'), '_');
+
+  File _reportFile(String runName) =>
+      File('${reportsDir.path}/${_safeName(runName)}.json');
+
+  @override
+  Future<void> save(EvalRunReport report) async {
+    final entry = RunIndexEntry(
+      runName: report.runName,
+      suiteName: report.suite.name,
+      suiteKind: report.suite.kind,
+      startedAt: report.startedAt,
+      endedAt: report.endedAt,
+      taskPassRate: report.taskPassRate,
+      trialPassRate: report.trialPassRate,
+      numTrials: report.trials.length,
+    );
+    await indexFile.writeAsString(
+      '${jsonEncode(entry.toJson())}\n',
+      mode: FileMode.append,
+      flush: true,
+    );
+
+    final body = {
+      'runName': report.runName,
+      'suite': SuiteSnapshot.from(report.suite).toJson(),
+      'startedAt': report.startedAt.toIso8601String(),
+      'endedAt': report.endedAt.toIso8601String(),
+      'trials': report.trials.map((t) => t.toJson()).toList(),
+    };
+    await _reportFile(
+      report.runName,
+    ).writeAsString(jsonEncode(body), flush: true);
+  }
+
+  @override
+  Future<PersistedRunReport?> load(String runName) async {
+    final f = _reportFile(runName);
+    if (!await f.exists()) return null;
+    final body = jsonDecode(await f.readAsString()) as Map<String, dynamic>;
+    return _decode(body);
+  }
+
+  @override
+  Future<List<RunIndexEntry>> listRecent({
+    required String suiteName,
+    int limit = 10,
+  }) async {
+    final entries = await _readIndex();
+    final filtered = entries.where((e) => e.suiteName == suiteName).toList();
+    filtered.sort((a, b) => b.startedAt.compareTo(a.startedAt));
+    return filtered.take(limit).toList();
+  }
+
+  @override
+  Future<List<PersistedRunReport>> loadRecent({
+    required String suiteName,
+    int limit = 10,
+  }) async {
+    final indices = await listRecent(suiteName: suiteName, limit: limit);
+    final out = <PersistedRunReport>[];
+    for (final idx in indices) {
+      final r = await load(idx.runName);
+      if (r != null) out.add(r);
+    }
+    return out;
+  }
+
+  @override
+  Future<List<String>> listRunNames({String? suiteFilter, int? limit}) async {
+    final entries = await _readIndex();
+    var filtered = suiteFilter == null
+        ? entries
+        : entries.where((e) => e.suiteName == suiteFilter).toList();
+    filtered.sort((a, b) => b.startedAt.compareTo(a.startedAt));
+    if (limit != null) filtered = filtered.take(limit).toList();
+    return filtered.map((e) => e.runName).toList();
+  }
+
+  TrialResult _trialResultFromJson(Map<String, dynamic> json) {
+    return TrialResult(
+      trial: Trial.fromJson(json['trial'] as Map<String, dynamic>),
+      transcript: Transcript.fromJson(
+        json['transcript'] as Map<String, dynamic>,
+      ),
+      outcome: Outcome.fromJson(json['outcome'] as Map<String, dynamic>),
+      scores: ((json['scores'] as List?) ?? const [])
+          .map((s) => Score.fromJson(s as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  PersistedRunReport _decode(Map<String, dynamic> body) {
+    return PersistedRunReport(
+      runName: body['runName'] as String,
+      suite: SuiteSnapshot.fromJson(body['suite'] as Map<String, dynamic>),
+      startedAt: DateTime.parse(body['startedAt'] as String),
+      endedAt: DateTime.parse(body['endedAt'] as String),
+      trials: (body['trials'] as List)
+          .map((t) => _trialResultFromJson(t as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  Future<List<RunIndexEntry>> _readIndex() async {
+    if (!await indexFile.exists()) return const [];
+    final entries = <RunIndexEntry>[];
+    final lines = await indexFile.readAsLines();
+    for (final line in lines) {
+      if (line.trim().isEmpty) continue;
+      try {
+        entries.add(
+          RunIndexEntry.fromJson(jsonDecode(line) as Map<String, dynamic>),
+        );
+      } catch (e, st) {
+        _logger.warning('skipping malformed index line', e, st);
+      }
+    }
+    return entries;
+  }
+}

--- a/lib/src/eval/suite_health/saturation_status.dart
+++ b/lib/src/eval/suite_health/saturation_status.dart
@@ -1,0 +1,105 @@
+/// Saturation 评估的阈值和分桶决议。Anthropic Step 7：当 capability suite
+/// 上 task 普遍接近 100% 通过时，应当把它们"毕业"到 regression suite，
+/// 并往 capability suite 里补更难的 task。
+class SaturationThresholds {
+  /// pass@1 ≥ 该阈值视为"已成熟"。
+  final double matureTaskPassRate;
+
+  /// 连续多少次 dataset run 都达到 [matureTaskPassRate] 才算"建议毕业"。
+  final int consecutiveRunsForGraduation;
+
+  /// pass@1 ≤ 该阈值视为"几乎不能解"——往往是任务定义有 bug。
+  final double brokenTaskPassRate;
+
+  /// 在多少 trial 上都低于 [brokenTaskPassRate] 才算"破损候选"。
+  final int minTrialsForBrokenJudgment;
+
+  /// suite 中 mature task 占比 ≥ 该阈值视为"已饱和"。
+  final double saturatedSuiteRatio;
+
+  const SaturationThresholds({
+    this.matureTaskPassRate = 0.95,
+    this.consecutiveRunsForGraduation = 5,
+    this.brokenTaskPassRate = 0.0,
+    this.minTrialsForBrokenJudgment = 10,
+    this.saturatedSuiteRatio = 0.9,
+  });
+}
+
+/// 当一个 task 在最近 N 次 run 都达到成熟通过率，建议毕业到 regression suite。
+class GraduationCandidate {
+  final String taskId;
+  final double recentMeanPassRate;
+  final int consecutiveMatureRuns;
+  final List<String> contributingRuns;
+
+  const GraduationCandidate({
+    required this.taskId,
+    required this.recentMeanPassRate,
+    required this.consecutiveMatureRuns,
+    required this.contributingRuns,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'taskId': taskId,
+    'recentMeanPassRate': recentMeanPassRate,
+    'consecutiveMatureRuns': consecutiveMatureRuns,
+    'contributingRuns': contributingRuns,
+  };
+}
+
+/// 跨多次 run 都几乎全失败的任务——通常是任务定义/grader 配置有 bug，
+/// 而不是 agent 真的不会做（Anthropic Step 2 显式提醒）。
+class BrokenTaskCandidate {
+  final String taskId;
+  final int totalTrials;
+  final int passedTrials;
+  final List<String> contributingRuns;
+
+  const BrokenTaskCandidate({
+    required this.taskId,
+    required this.totalTrials,
+    required this.passedTrials,
+    required this.contributingRuns,
+  });
+
+  double get passRate => totalTrials == 0 ? 0.0 : passedTrials / totalTrials;
+
+  Map<String, dynamic> toJson() => {
+    'taskId': taskId,
+    'totalTrials': totalTrials,
+    'passedTrials': passedTrials,
+    'passRate': passRate,
+    'contributingRuns': contributingRuns,
+  };
+}
+
+/// 在单次 run 视角下评估 suite 的健康度（饱和率 + 候选清单的当下值）。
+class SaturationStatus {
+  /// 当前 run 中 pass@1 ≥ matureTaskPassRate 的任务数 / 总任务数。
+  final double saturatedTaskRatio;
+
+  /// 是否整个 suite 已"饱和"。
+  final bool suiteSaturated;
+
+  /// 在当前 run 中表现良好的任务（pass@1 ≥ 阈值）。仅基于当次数据，
+  /// 真正的"是否建议毕业"需要 [SuiteHealthAnalyzer] 跨多 run 判断。
+  final List<String> matureTasks;
+
+  /// 在当前 run 中表现极差的任务。
+  final List<String> stragglerTasks;
+
+  const SaturationStatus({
+    required this.saturatedTaskRatio,
+    required this.suiteSaturated,
+    required this.matureTasks,
+    required this.stragglerTasks,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'saturatedTaskRatio': saturatedTaskRatio,
+    'suiteSaturated': suiteSaturated,
+    'matureTasks': matureTasks,
+    'stragglerTasks': stragglerTasks,
+  };
+}

--- a/lib/src/eval/suite_health/suite_health_analyzer.dart
+++ b/lib/src/eval/suite_health/suite_health_analyzer.dart
@@ -1,0 +1,201 @@
+import '../core/eval_run_report.dart';
+import '../reporting/report_store.dart';
+import 'saturation_status.dart';
+import 'suite_health_report.dart';
+
+/// 跨多次 run 分析 suite 健康度。Anthropic Step 7 / 8 的工具支撑。
+class SuiteHealthAnalyzer {
+  final ReportStore store;
+  final SaturationThresholds thresholds;
+
+  const SuiteHealthAnalyzer(
+    this.store, {
+    this.thresholds = const SaturationThresholds(),
+  });
+
+  /// 检测当前 [report] 单次 run 的饱和度。
+  SaturationStatus computeSaturationStatus(EvalRunReport report) {
+    final byTask = report.trialsByTask();
+    final mature = <String>[];
+    final stragglers = <String>[];
+
+    for (final entry in byTask.entries) {
+      final passes = entry.value.where((tr) => tr.allGradersPassed).length;
+      final total = entry.value.length;
+      final passRate = total == 0 ? 0.0 : passes / total;
+      if (passRate >= thresholds.matureTaskPassRate) {
+        mature.add(entry.key);
+      } else if (passRate <= thresholds.brokenTaskPassRate &&
+          total >= thresholds.minTrialsForBrokenJudgment) {
+        stragglers.add(entry.key);
+      }
+    }
+
+    final ratio = byTask.isEmpty ? 0.0 : mature.length / byTask.length;
+    return SaturationStatus(
+      saturatedTaskRatio: ratio,
+      suiteSaturated: ratio >= thresholds.saturatedSuiteRatio,
+      matureTasks: mature,
+      stragglerTasks: stragglers,
+    );
+  }
+}
+
+extension SuiteHealthAnalyzerOps on SuiteHealthAnalyzer {
+  /// 跨多 run 分析。从 [store] 拉最近 [recentRunCount] 次 run 计算
+  /// graduation/broken 候选 + 难度分布。
+  Future<SuiteHealthReport> analyze({
+    required String suiteName,
+    int recentRunCount = 10,
+  }) async {
+    final runs = await store.loadRecent(
+      suiteName: suiteName,
+      limit: recentRunCount,
+    );
+    if (runs.isEmpty) {
+      throw StateError(
+        'No persisted runs found for suite "$suiteName". '
+        'Save at least one EvalRunReport to the store before analyzing.',
+      );
+    }
+
+    // 时间倒序保证 runs[0] 是最新的。
+    runs.sort((a, b) => b.startedAt.compareTo(a.startedAt));
+
+    // 收集每个 task 在每次 run 的通过率。
+    // taskId -> [{run, passRate, trialsCount, passedCount}, ...]
+    final perTaskPerRun = <String, List<_TaskRunStat>>{};
+    for (final run in runs) {
+      final byTask = run.trialsByTask();
+      for (final entry in byTask.entries) {
+        final passes = entry.value.where((tr) => tr.allGradersPassed).length;
+        final total = entry.value.length;
+        perTaskPerRun
+            .putIfAbsent(entry.key, () => [])
+            .add(
+              _TaskRunStat(
+                runName: run.runName,
+                startedAt: run.startedAt,
+                passes: passes,
+                trials: total,
+              ),
+            );
+      }
+    }
+
+    final graduates = <GraduationCandidate>[];
+    final brokens = <BrokenTaskCandidate>[];
+    final histogram = <String, int>{};
+
+    for (final entry in perTaskPerRun.entries) {
+      final stats = entry.value
+        ..sort((a, b) => b.startedAt.compareTo(a.startedAt));
+
+      // 跨 run 平均通过率 → 难度分布
+      final allTrials = stats.fold<int>(0, (a, b) => a + b.trials);
+      final allPasses = stats.fold<int>(0, (a, b) => a + b.passes);
+      final overallPassRate = allTrials == 0 ? 0.0 : allPasses / allTrials;
+      final bucket = _bucketFor(overallPassRate);
+      histogram[bucket] = (histogram[bucket] ?? 0) + 1;
+
+      // 毕业判定：连续多次 run 都达到 mature 阈值
+      var consecutiveMature = 0;
+      for (final s in stats) {
+        if (s.trials == 0) break;
+        if (s.passes / s.trials >= thresholds.matureTaskPassRate) {
+          consecutiveMature++;
+        } else {
+          break;
+        }
+      }
+      if (consecutiveMature >= thresholds.consecutiveRunsForGraduation) {
+        graduates.add(
+          GraduationCandidate(
+            taskId: entry.key,
+            recentMeanPassRate: overallPassRate,
+            consecutiveMatureRuns: consecutiveMature,
+            contributingRuns: stats
+                .take(consecutiveMature)
+                .map((s) => s.runName)
+                .toList(),
+          ),
+        );
+      }
+
+      // 破损候选：跨 run 几乎全失败
+      if (allTrials >= thresholds.minTrialsForBrokenJudgment &&
+          overallPassRate <= thresholds.brokenTaskPassRate) {
+        brokens.add(
+          BrokenTaskCandidate(
+            taskId: entry.key,
+            totalTrials: allTrials,
+            passedTrials: allPasses,
+            contributingRuns: stats.map((s) => s.runName).toList(),
+          ),
+        );
+      }
+    }
+
+    // 当前饱和度（基于最新一次 run）
+    final newest = runs.first;
+    final newestSat = _computeSaturationFor(newest);
+
+    return SuiteHealthReport(
+      suiteName: suiteName,
+      suiteKind: newest.suite.kind,
+      analyzedRunCount: runs.length,
+      thresholds: thresholds,
+      graduationCandidates: graduates,
+      brokenTaskCandidates: brokens,
+      currentSaturationRatio: newestSat.saturatedTaskRatio,
+      currentlySaturated: newestSat.suiteSaturated,
+      difficultyHistogram: histogram,
+    );
+  }
+
+  SaturationStatus _computeSaturationFor(PersistedRunReport report) {
+    final byTask = report.trialsByTask();
+    final mature = <String>[];
+    final stragglers = <String>[];
+    for (final entry in byTask.entries) {
+      final passes = entry.value.where((tr) => tr.allGradersPassed).length;
+      final total = entry.value.length;
+      final passRate = total == 0 ? 0.0 : passes / total;
+      if (passRate >= thresholds.matureTaskPassRate) {
+        mature.add(entry.key);
+      } else if (passRate <= thresholds.brokenTaskPassRate &&
+          total >= thresholds.minTrialsForBrokenJudgment) {
+        stragglers.add(entry.key);
+      }
+    }
+    final ratio = byTask.isEmpty ? 0.0 : mature.length / byTask.length;
+    return SaturationStatus(
+      saturatedTaskRatio: ratio,
+      suiteSaturated: ratio >= thresholds.saturatedSuiteRatio,
+      matureTasks: mature,
+      stragglerTasks: stragglers,
+    );
+  }
+}
+
+class _TaskRunStat {
+  final String runName;
+  final DateTime startedAt;
+  final int passes;
+  final int trials;
+  const _TaskRunStat({
+    required this.runName,
+    required this.startedAt,
+    required this.passes,
+    required this.trials,
+  });
+}
+
+String _bucketFor(double passRate) {
+  if (passRate < 0.2) return '[0.0, 0.2)';
+  if (passRate < 0.4) return '[0.2, 0.4)';
+  if (passRate < 0.6) return '[0.4, 0.6)';
+  if (passRate < 0.8) return '[0.6, 0.8)';
+  if (passRate < 0.95) return '[0.8, 0.95)';
+  return '[0.95, 1.0]';
+}

--- a/lib/src/eval/suite_health/suite_health_report.dart
+++ b/lib/src/eval/suite_health/suite_health_report.dart
@@ -1,0 +1,65 @@
+import '../core/eval_suite.dart';
+import 'saturation_status.dart';
+
+/// 跨多次 run 的 suite 健康分析。
+///
+/// 用法：
+/// ```dart
+/// final analyzer = SuiteHealthAnalyzer(reportStore);
+/// final report = await analyzer.analyze(
+///   suiteName: 'card_agent_capability',
+///   recentRunCount: 10,
+/// );
+/// for (final c in report.graduationCandidates) {
+///   print('graduate ${c.taskId}: ${c.recentMeanPassRate}');
+/// }
+/// ```
+class SuiteHealthReport {
+  final String suiteName;
+  final SuiteKind suiteKind;
+  final int analyzedRunCount;
+  final SaturationThresholds thresholds;
+
+  /// 在最近 N 次 run 都达到 matureTaskPassRate 的任务。
+  final List<GraduationCandidate> graduationCandidates;
+
+  /// 跨多次 run 都几乎全失败的任务（任务/grader 可能有 bug）。
+  final List<BrokenTaskCandidate> brokenTaskCandidates;
+
+  /// 当前最近一次 run 的饱和率。
+  final double currentSaturationRatio;
+
+  /// 是否当前已饱和。
+  final bool currentlySaturated;
+
+  /// 任务难度分布柱状图。key: `0.0-0.2` / `0.2-0.4` / ... / `0.8-1.0`，
+  /// value: 落入此通过率区间的任务数（基于跨 run 平均通过率）。
+  final Map<String, int> difficultyHistogram;
+
+  const SuiteHealthReport({
+    required this.suiteName,
+    required this.suiteKind,
+    required this.analyzedRunCount,
+    required this.thresholds,
+    required this.graduationCandidates,
+    required this.brokenTaskCandidates,
+    required this.currentSaturationRatio,
+    required this.currentlySaturated,
+    required this.difficultyHistogram,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'suiteName': suiteName,
+    'suiteKind': suiteKind.name,
+    'analyzedRunCount': analyzedRunCount,
+    'graduationCandidates': graduationCandidates
+        .map((g) => g.toJson())
+        .toList(),
+    'brokenTaskCandidates': brokenTaskCandidates
+        .map((b) => b.toJson())
+        .toList(),
+    'currentSaturationRatio': currentSaturationRatio,
+    'currentlySaturated': currentlySaturated,
+    'difficultyHistogram': difficultyHistogram,
+  };
+}

--- a/test/eval/_helpers.dart
+++ b/test/eval/_helpers.dart
@@ -1,0 +1,140 @@
+/// Shared test helpers for eval subsystem tests.
+library;
+
+import 'dart:async';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dart_agent_core/eval.dart';
+import 'package:dio/dio.dart';
+
+// ─── Fake LLM client ────────────────────────────────────────────────────────
+
+/// Returns a canned [ModelMessage] for each call. Cycles when out of canned.
+class FakeLLMClient extends LLMClient {
+  final List<ModelMessage> canned;
+  final List<int> tokensUsed;
+  int generateCalls = 0;
+  int streamCalls = 0;
+
+  FakeLLMClient(this.canned, {this.tokensUsed = const []});
+
+  ModelMessage _next() {
+    final m = canned[generateCalls % canned.length];
+    return m;
+  }
+
+  @override
+  Future<ModelMessage> generate(
+    List<LLMMessage> messages, {
+    List<Tool>? tools,
+    ToolChoice? toolChoice,
+    required ModelConfig modelConfig,
+    bool? jsonOutput,
+    CancelToken? cancelToken,
+  }) async {
+    final m = _next();
+    generateCalls++;
+    return m;
+  }
+
+  @override
+  Future<Stream<StreamingMessage>> stream(
+    List<LLMMessage> messages, {
+    List<Tool>? tools,
+    ToolChoice? toolChoice,
+    required ModelConfig modelConfig,
+    bool? jsonOutput,
+    CancelToken? cancelToken,
+  }) async {
+    streamCalls++;
+    final m = _next();
+    return Stream<StreamingMessage>.fromIterable([
+      StreamingMessage(modelMessage: m),
+    ]);
+  }
+}
+
+ModelMessage textReply(String text, {String model = 'fake-model'}) {
+  return ModelMessage(
+    textOutput: text,
+    model: model,
+    stopReason: 'stop',
+    usage: ModelUsage(
+      promptTokens: 10,
+      completionTokens: 5,
+      totalTokens: 15,
+      model: model,
+    ),
+  );
+}
+
+// ─── Trial / TrialResult builders ───────────────────────────────────────────
+
+Trial makeTrial({
+  required String runName,
+  required String suiteName,
+  required String taskId,
+  int trialIndex = 0,
+  TrialStatus status = TrialStatus.passed,
+  DateTime? startedAt,
+  DateTime? endedAt,
+}) {
+  final start = startedAt ?? DateTime(2025, 1, 1);
+  return Trial(
+    runName: runName,
+    suiteName: suiteName,
+    taskId: taskId,
+    trialIndex: trialIndex,
+    startedAt: start,
+    endedAt: endedAt ?? start.add(const Duration(seconds: 1)),
+    status: status,
+  );
+}
+
+Transcript emptyTranscript() => Transcript(
+  messages: const [],
+  toolCalls: const [],
+  metrics: const TranscriptMetrics(nTurns: 0, nToolCalls: 0, nTotalTokens: 0),
+);
+
+TrialResult makeTrialResult({
+  required String runName,
+  required String suiteName,
+  required String taskId,
+  int trialIndex = 0,
+  required List<Score> scores,
+  Outcome? outcome,
+  Transcript? transcript,
+  TrialStatus? status,
+  DateTime? startedAt,
+}) {
+  final passed = scores
+      .where((s) => s.passed != null)
+      .every((s) => s.passed == true);
+  return TrialResult(
+    trial: makeTrial(
+      runName: runName,
+      suiteName: suiteName,
+      taskId: taskId,
+      trialIndex: trialIndex,
+      status: status ?? (passed ? TrialStatus.passed : TrialStatus.failed),
+      startedAt: startedAt,
+    ),
+    transcript: transcript ?? emptyTranscript(),
+    outcome: outcome ?? const Outcome(environmentState: {}),
+    scores: scores,
+  );
+}
+
+Score okScore(String name, {double value = 1.0}) =>
+    Score(graderName: name, value: value, passed: true);
+
+Score failScore(String name, {double value = 0.0, String? rationale}) => Score(
+  graderName: name,
+  value: value,
+  passed: false,
+  rationale: rationale ?? 'failed',
+);
+
+Score nullScore(String name, {String rationale = 'unknown'}) =>
+    Score(graderName: name, value: null, passed: null, rationale: rationale);

--- a/test/eval/calibration_test.dart
+++ b/test/eval/calibration_test.dart
@@ -1,0 +1,119 @@
+import 'package:dart_agent_core/eval.dart';
+import 'package:test/test.dart';
+
+void main() {
+  HumanLabeledTrial labeled(double human, String id) => HumanLabeledTrial(
+    trialId: TrialId(runName: 'r', taskId: id, trialIndex: 0),
+    humanScore: human,
+    input: const {},
+    output: 'output for $id',
+  );
+
+  group('JudgeCalibrator', () {
+    test('perfect agreement → Spearman/Pearson = 1.0, MAE = 0', () async {
+      final golden = [
+        labeled(0.0, 't0'),
+        labeled(0.25, 't1'),
+        labeled(0.5, 't2'),
+        labeled(0.75, 't3'),
+        labeled(1.0, 't4'),
+      ];
+      const calibrator = JudgeCalibrator();
+      final report = await calibrator.calibrate(
+        goldenSet: golden,
+        judgeScorer: (l) async => JudgeScore(value: l.humanScore),
+      );
+      expect(report.spearmanCorrelation, closeTo(1.0, 1e-9));
+      expect(report.pearsonCorrelation, closeTo(1.0, 1e-9));
+      expect(report.meanAbsoluteError, closeTo(0.0, 1e-9));
+      expect(report.agreementRate, 1.0);
+      expect(report.samples, 5);
+      expect(report.disagreementCount, 0);
+      expect(report.meetsAnthropicBar, isTrue);
+    });
+
+    test('perfectly inverted → Spearman = -1.0, fails Anthropic bar', () async {
+      // judge always reports 1 - human
+      final golden = [
+        labeled(0.0, 't0'),
+        labeled(0.25, 't1'),
+        labeled(0.5, 't2'),
+        labeled(0.75, 't3'),
+        labeled(1.0, 't4'),
+      ];
+      const calibrator = JudgeCalibrator();
+      final report = await calibrator.calibrate(
+        goldenSet: golden,
+        judgeScorer: (l) async => JudgeScore(value: 1.0 - l.humanScore),
+      );
+      expect(report.spearmanCorrelation, closeTo(-1.0, 1e-9));
+      expect(report.meetsAnthropicBar, isFalse);
+    });
+
+    test(
+      'null judge scores are excluded from correlation but counted',
+      () async {
+        // 3 valid, 1 null
+        final golden = [
+          labeled(0.0, 't0'),
+          labeled(0.5, 't1'),
+          labeled(1.0, 't2'),
+          labeled(0.5, 't3'),
+        ];
+        const calibrator = JudgeCalibrator();
+        final report = await calibrator.calibrate(
+          goldenSet: golden,
+          judgeScorer: (l) async {
+            if (l.trialId.taskId == 't3') return null;
+            return JudgeScore(value: l.humanScore);
+          },
+        );
+        expect(report.samples, 3);
+        expect(report.spearmanCorrelation, closeTo(1.0, 1e-9));
+      },
+    );
+
+    test('throws if golden set empty', () async {
+      const calibrator = JudgeCalibrator();
+      await expectLater(
+        calibrator.calibrate(
+          goldenSet: const [],
+          judgeScorer: (l) async => null,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws if too few valid pairs (< 2)', () async {
+      const calibrator = JudgeCalibrator();
+      await expectLater(
+        calibrator.calibrate(
+          goldenSet: [labeled(0.5, 't0'), labeled(0.5, 't1')],
+          judgeScorer: (l) async => null, // both null → 0 valid
+        ),
+        throwsStateError,
+      );
+    });
+
+    test('disagreements are sorted by absolute delta descending', () async {
+      // Force big disagreement on one entry
+      final golden = [
+        labeled(0.0, 't0'),
+        labeled(0.25, 't1'),
+        labeled(0.5, 't2'),
+        labeled(0.75, 't3'),
+        labeled(1.0, 't4'),
+      ];
+      const calibrator = JudgeCalibrator();
+      final report = await calibrator.calibrate(
+        goldenSet: golden,
+        judgeScorer: (l) async {
+          if (l.trialId.taskId == 't0') return const JudgeScore(value: 1.0);
+          return JudgeScore(value: l.humanScore);
+        },
+      );
+      expect(report.disagreements.first.trialId.taskId, 't0');
+      expect(report.disagreements.first.absoluteDelta, closeTo(1.0, 1e-9));
+    });
+  });
+}

--- a/test/eval/diff_and_store_test.dart
+++ b/test/eval/diff_and_store_test.dart
@@ -1,0 +1,230 @@
+import 'dart:io';
+
+import 'package:dart_agent_core/eval.dart';
+import 'package:test/test.dart';
+
+import '_helpers.dart';
+
+class _StubTask implements EvalTask {
+  @override
+  final String id;
+  @override
+  final List<Grader> graders;
+  @override
+  final ReferenceSolution? referenceSolution = null;
+  @override
+  final int trialsPerRun = 1;
+  @override
+  final Map<String, String> metadata = const {};
+  @override
+  final Map<String, dynamic> input = const {};
+  @override
+  final String description = '';
+  @override
+  final Duration? timeout = null;
+  _StubTask({required this.id, required this.graders});
+}
+
+class _NoopGrader extends CodeGrader {
+  @override
+  String get name => 'noop';
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async => const [Assertion(description: 'always', passed: true)];
+}
+
+EvalRunReport _buildRun({
+  required String name,
+  required Map<String, double> taskPassRates,
+  int trialsPerTask = 4,
+}) {
+  final taskIds = taskPassRates.keys.toList();
+  final trials = <TrialResult>[];
+  for (final id in taskIds) {
+    final pr = taskPassRates[id]!;
+    final passing = (pr * trialsPerTask).round();
+    for (var i = 0; i < trialsPerTask; i++) {
+      trials.add(
+        makeTrialResult(
+          runName: name,
+          suiteName: 's',
+          taskId: id,
+          trialIndex: i,
+          scores: [
+            i < passing
+                ? okScore('quality', value: 1.0)
+                : failScore('quality', value: 0.0),
+          ],
+        ),
+      );
+    }
+  }
+  return EvalRunReport(
+    runName: name,
+    suite: EvalSuite(
+      name: 's',
+      agentName: 'agent_x',      kind: SuiteKind.regression,
+      tasks: [
+        for (final id in taskIds) _StubTask(id: id, graders: [_NoopGrader()]),
+      ],
+    ),
+    trials: trials,
+    startedAt: DateTime(2025),
+    endedAt: DateTime(2025),
+  );
+}
+
+void main() {
+  group('diffRunReports', () {
+    test('classifies regressed / improved / unchanged via threshold', () {
+      final baseline = _buildRun(
+        name: 'main',
+        taskPassRates: const {
+          'a': 1.0, // unchanged
+          'b': 1.0, // regress
+          'c': 0.0, // improve
+        },
+      );
+      final current = _buildRun(
+        name: 'pr',
+        taskPassRates: const {'a': 1.0, 'b': 0.0, 'c': 1.0},
+      );
+      final diff = current.diffWith(baseline, significanceThreshold: 0.05);
+
+      final regressed = diff.transitions
+          .where((t) => t.regressed)
+          .map((t) => t.taskId)
+          .toList();
+      final improved = diff.transitions
+          .where((t) => t.improved)
+          .map((t) => t.taskId)
+          .toList();
+      final unchanged = diff.transitions
+          .where((t) => t.unchanged)
+          .map((t) => t.taskId)
+          .toList();
+
+      expect(regressed, contains('b'));
+      expect(improved, contains('c'));
+      expect(unchanged, contains('a'));
+    });
+
+    test('reports added and removed task ids', () {
+      final baseline = _buildRun(
+        name: 'main',
+        taskPassRates: const {'a': 1.0, 'old': 1.0},
+      );
+      final current = _buildRun(
+        name: 'pr',
+        taskPassRates: const {'a': 1.0, 'new': 0.5},
+      );
+      final diff = current.diffWith(baseline);
+      expect(diff.addedTaskIds, ['new']);
+      expect(diff.removedTaskIds, ['old']);
+    });
+
+    test('metricDeltas reflects task and trial pass-rate change', () {
+      final baseline = _buildRun(name: 'main', taskPassRates: const {'a': 1.0});
+      final current = _buildRun(name: 'pr', taskPassRates: const {'a': 0.0});
+      final diff = current.diffWith(baseline);
+      expect(diff.metricDeltas['task_pass_rate'], closeTo(-1.0, 1e-9));
+      expect(diff.metricDeltas['trial_pass_rate'], closeTo(-1.0, 1e-9));
+    });
+
+    test('toMarkdown lists regressed tasks under a 🚨 header', () {
+      final baseline = _buildRun(name: 'main', taskPassRates: const {'a': 1.0});
+      final current = _buildRun(name: 'pr', taskPassRates: const {'a': 0.0});
+      final md = current.diffWith(baseline).toMarkdown();
+      expect(md, contains('Regressed tasks'));
+      expect(md, contains('`a`'));
+    });
+  });
+
+  group('FileReportStore round-trip', () {
+    late Directory tmp;
+    setUp(() async {
+      tmp = await Directory.systemTemp.createTemp('store_');
+    });
+    tearDown(() async {
+      if (await tmp.exists()) await tmp.delete(recursive: true);
+    });
+
+    test(
+      'save → load round-trips the run and preserves trial results',
+      () async {
+        final store = FileReportStore(tmp);
+        final r = _buildRun(
+          name: 'r1',
+          taskPassRates: const {'a': 1.0, 'b': 0.5},
+        );
+        await store.save(r);
+        final loaded = await store.load('r1');
+        expect(loaded, isNotNull);
+        expect(loaded!.runName, 'r1');
+        expect(loaded.suite.taskIds, containsAll(['a', 'b']));
+        expect(loaded.trials.length, r.trials.length);
+      },
+    );
+
+    test('listRunNames newest-first; listRecent filters by suite', () async {
+      final store = FileReportStore(tmp);
+      await store.save(
+        EvalRunReport(
+          runName: 'oldest',
+          suite: EvalSuite(
+            name: 'one',
+            agentName: 'agent_x',            kind: SuiteKind.mixed,
+            tasks: [
+              _StubTask(id: 'a', graders: [_NoopGrader()]),
+            ],
+          ),
+          trials: [
+            makeTrialResult(
+              runName: 'oldest',
+              suiteName: 'one',
+              taskId: 'a',
+              trialIndex: 0,
+              scores: [okScore('noop')],
+            ),
+          ],
+          startedAt: DateTime(2024),
+          endedAt: DateTime(2024),
+        ),
+      );
+      await store.save(
+        EvalRunReport(
+          runName: 'newest',
+          suite: EvalSuite(
+            name: 'two',
+            agentName: 'agent_x',            kind: SuiteKind.mixed,
+            tasks: [
+              _StubTask(id: 'a', graders: [_NoopGrader()]),
+            ],
+          ),
+          trials: [
+            makeTrialResult(
+              runName: 'newest',
+              suiteName: 'two',
+              taskId: 'a',
+              trialIndex: 0,
+              scores: [okScore('noop')],
+            ),
+          ],
+          startedAt: DateTime(2026),
+          endedAt: DateTime(2026),
+        ),
+      );
+
+      final all = await store.listRunNames();
+      expect(all, ['newest', 'oldest']);
+
+      final twoOnly = await store.listRecent(suiteName: 'two');
+      expect(twoOnly.map((e) => e.runName), ['newest']);
+    });
+  });
+}

--- a/test/eval/graders_test.dart
+++ b/test/eval/graders_test.dart
@@ -1,0 +1,361 @@
+// ignore_for_file: unused_element_parameter
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dart_agent_core/eval.dart';
+import 'package:test/test.dart';
+
+import '_helpers.dart';
+
+// ─── Code grader ────────────────────────────────────────────────────────────
+
+class _AllPassGrader extends CodeGrader {
+  @override
+  String get name => 'all_pass';
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async => const [
+    Assertion(description: 'a', passed: true),
+    Assertion(description: 'b', passed: true),
+  ];
+}
+
+class _PartialGrader extends CodeGrader {
+  @override
+  String get name => 'partial';
+
+  @override
+  double get passThreshold => 0.5; // partial credit at 50%
+
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async => const [
+    Assertion(description: 'half-pass-1', passed: true),
+    Assertion(description: 'half-fail', passed: false),
+  ];
+}
+
+class _AllFailGrader extends CodeGrader {
+  @override
+  String get name => 'all_fail';
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async => const [
+    Assertion(
+      description: 'will fail',
+      passed: false,
+      actual: 'x',
+      expected: 'y',
+    ),
+  ];
+}
+
+class _EmptyAssertionGrader extends CodeGrader {
+  @override
+  String get name => 'empty';
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async => const [];
+}
+
+// ─── Model grader (LLM-as-judge) ────────────────────────────────────────────
+
+/// Minimal LLM-as-judge grader for testing. Calls the [judgeClient] with
+/// a rubric prompt and parses a numeric score from the reply.
+class _NumericJudgeGrader extends ModelGrader {
+  @override
+  final LLMClient judgeClient;
+  @override
+  final String rubric;
+  final ModelConfig modelConfig;
+  @override
+  final String name;
+
+  _NumericJudgeGrader({
+    required this.judgeClient,
+    required this.rubric,
+    required this.modelConfig,
+    this.name = 'numeric_judge',
+  });
+
+  @override
+  double get passThreshold => 0.7;
+
+  @override
+  Future<Score> grade({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async {
+    final prompt =
+        '$rubric\n\nOutcome: ${outcome.environmentState}\n'
+        'Reply with one line: SCORE=<float between 0 and 1> or SCORE=Unknown';
+    final reply = await judgeClient.generate([
+      UserMessage.text(prompt),
+    ], modelConfig: modelConfig);
+    final text = (reply.textOutput ?? '').trim();
+    final m = RegExp(r'SCORE=([0-9]*\.?[0-9]+|Unknown)').firstMatch(text);
+    if (m == null) {
+      return Score(
+        graderName: name,
+        value: null,
+        passed: null,
+        rationale: 'judge reply unparseable: $text',
+      );
+    }
+    final v = m.group(1)!;
+    if (v == 'Unknown') {
+      return Score(
+        graderName: name,
+        value: null,
+        passed: null,
+        rationale: text,
+      );
+    }
+    final value = double.parse(v);
+    return Score(
+      graderName: name,
+      value: value,
+      passed: value >= passThreshold,
+      rationale: text,
+    );
+  }
+}
+
+// ─── Human grader queue ─────────────────────────────────────────────────────
+
+class _MemoryHumanReviewQueue implements HumanReviewQueue {
+  final Map<String, Score> _verdicts = {};
+  final List<TrialId> enqueued = [];
+
+  @override
+  Future<void> enqueue({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    String? rubric,
+    Map<String, dynamic> metadata = const {},
+  }) async {
+    enqueued.add(trial.id);
+  }
+
+  @override
+  Future<Score?> fetchVerdict(Trial trial) async =>
+      _verdicts[trial.id.toString()];
+
+  void postVerdict(Trial trial, Score score) {
+    _verdicts[trial.id.toString()] = score;
+  }
+}
+
+class _StubHumanGrader extends HumanGrader {
+  @override
+  final HumanReviewQueue queue;
+  @override
+  final String name;
+  _StubHumanGrader({required this.queue, this.name = 'human'});
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+EvalContext _ctx() => EvalContext(
+  clock: const SystemEvalClock(),
+  llmClient: FakeLLMClient([textReply('unused')]),
+  controller: AgentController(),
+);
+
+Future<Score> _grade(Grader g) async {
+  final ctx = _ctx();
+  return g.grade(
+    trial: makeTrial(runName: 'r', suiteName: 's', taskId: 't'),
+    transcript: emptyTranscript(),
+    outcome: const Outcome(environmentState: {'k': 'v'}),
+    context: ctx,
+  );
+}
+
+void main() {
+  group('CodeGrader', () {
+    test('all-pass assertions → value=1.0, passed=true', () async {
+      final s = await _grade(_AllPassGrader());
+      expect(s.value, 1.0);
+      expect(s.passed, true);
+      expect(s.assertions, hasLength(2));
+      expect(s.rationale, isNull);
+    });
+
+    test(
+      'all-fail assertions → value=0.0, passed=false, rationale present',
+      () async {
+        final s = await _grade(_AllFailGrader());
+        expect(s.value, 0.0);
+        expect(s.passed, false);
+        expect(s.rationale, contains('will fail'));
+        expect(s.assertions.first.actual, 'x');
+        expect(s.assertions.first.expected, 'y');
+      },
+    );
+
+    test(
+      'partial assertions with passThreshold=0.5 → value=0.5, passed=true',
+      () async {
+        final s = await _grade(_PartialGrader());
+        expect(s.value, closeTo(0.5, 1e-9));
+        expect(s.passed, true);
+        // Even when crossing threshold, rationale lists the failed assertion.
+        expect(s.rationale, contains('half-fail'));
+      },
+    );
+
+    test(
+      'empty assertions → value=0.0, passed=false (default threshold 1.0)',
+      () async {
+        final s = await _grade(_EmptyAssertionGrader());
+        expect(s.value, 0.0);
+        expect(s.passed, false);
+      },
+    );
+
+    test('Score round-trips through JSON', () async {
+      final s = await _grade(_AllFailGrader());
+      final j = s.toJson();
+      final s2 = Score.fromJson(j);
+      expect(s2.graderName, s.graderName);
+      expect(s2.value, s.value);
+      expect(s2.passed, s.passed);
+      expect(s2.assertions.length, s.assertions.length);
+      expect(s2.assertions.first.actual, s.assertions.first.actual);
+    });
+  });
+
+  group('ModelGrader (LLM-as-judge)', () {
+    test('parses SCORE=0.85 as a passing score', () async {
+      final client = FakeLLMClient([textReply('Looks good. SCORE=0.85')]);
+      final g = _NumericJudgeGrader(
+        judgeClient: client,
+        rubric: 'Rate quality 0–1.',
+        modelConfig: ModelConfig(model: 'judge'),
+      );
+      final s = await _grade(g);
+      expect(s.value, closeTo(0.85, 1e-9));
+      expect(s.passed, true);
+      expect(client.generateCalls, 1);
+    });
+
+    test('parses SCORE=0.3 as failing under threshold 0.7', () async {
+      final client = FakeLLMClient([textReply('Eh. SCORE=0.3')]);
+      final g = _NumericJudgeGrader(
+        judgeClient: client,
+        rubric: 'Rate quality 0–1.',
+        modelConfig: ModelConfig(model: 'judge'),
+      );
+      final s = await _grade(g);
+      expect(s.value, closeTo(0.3, 1e-9));
+      expect(s.passed, false);
+    });
+
+    test('returns null score when judge replies "Unknown" '
+        '(Anthropic Step 5 escape hatch)', () async {
+      final client = FakeLLMClient([
+        textReply('Cannot evaluate. SCORE=Unknown'),
+      ]);
+      final g = _NumericJudgeGrader(
+        judgeClient: client,
+        rubric: 'Rate quality 0–1.',
+        modelConfig: ModelConfig(model: 'judge'),
+      );
+      final s = await _grade(g);
+      expect(s.value, isNull);
+      expect(s.passed, isNull);
+      expect(s.rationale, contains('Unknown'));
+    });
+
+    test('returns null score on unparseable judge output', () async {
+      final client = FakeLLMClient([textReply('lalala no score here')]);
+      final g = _NumericJudgeGrader(
+        judgeClient: client,
+        rubric: '',
+        modelConfig: ModelConfig(model: 'judge'),
+      );
+      final s = await _grade(g);
+      expect(s.value, isNull);
+      expect(s.passed, isNull);
+      expect(s.rationale, contains('unparseable'));
+    });
+
+    test('reports kind = model', () {
+      final g = _NumericJudgeGrader(
+        judgeClient: FakeLLMClient([textReply('SCORE=1')]),
+        rubric: '',
+        modelConfig: ModelConfig(model: 'judge'),
+      );
+      expect(g.kind, GraderKind.model);
+    });
+  });
+
+  group('HumanGrader', () {
+    test('returns pending null score when no verdict yet', () async {
+      final q = _MemoryHumanReviewQueue();
+      final g = _StubHumanGrader(queue: q);
+      final s = await _grade(g);
+      expect(s.value, isNull);
+      expect(s.passed, isNull);
+      expect(s.rationale, 'pending human review');
+      expect(q.enqueued, hasLength(1));
+    });
+
+    test('returns posted verdict on next grade call', () async {
+      final q = _MemoryHumanReviewQueue();
+      final g = _StubHumanGrader(queue: q);
+      final t = makeTrial(runName: 'r', suiteName: 's', taskId: 't');
+
+      // First call enqueues and returns pending
+      final pending = await g.grade(
+        trial: t,
+        transcript: emptyTranscript(),
+        outcome: const Outcome(environmentState: {}),
+        context: _ctx(),
+      );
+      expect(pending.value, isNull);
+
+      // Reviewer posts a verdict
+      q.postVerdict(t, okScore('human', value: 0.9));
+
+      // Second call gets the verdict
+      final final_ = await g.grade(
+        trial: t,
+        transcript: emptyTranscript(),
+        outcome: const Outcome(environmentState: {}),
+        context: _ctx(),
+      );
+      expect(final_.value, 0.9);
+      expect(final_.passed, true);
+      expect(q.enqueued, hasLength(2)); // enqueue is unconditional
+    });
+
+    test('reports kind = human', () {
+      final g = _StubHumanGrader(queue: _MemoryHumanReviewQueue());
+      expect(g.kind, GraderKind.human);
+    });
+  });
+}

--- a/test/eval/langfuse_exporter_test.dart
+++ b/test/eval/langfuse_exporter_test.dart
@@ -1,0 +1,348 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dart_agent_core/eval.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+
+import '_helpers.dart';
+
+/// Captures every POST hit on `/api/public/ingestion`. Drives [Dio] via a
+/// custom [HttpClientAdapter] so no actual network IO happens.
+class _CapturingAdapter implements HttpClientAdapter {
+  final List<Map<String, dynamic>> bodies = [];
+  final List<int> responseCodes;
+  int callIndex = 0;
+
+  _CapturingAdapter({this.responseCodes = const [200]});
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<dynamic>? cancelFuture,
+  ) async {
+    expect(options.uri.path.endsWith('/api/public/ingestion'), isTrue);
+    expect(options.headers['Authorization'], startsWith('Basic '));
+
+    final raw = options.data is String
+        ? options.data as String
+        : jsonEncode(options.data);
+    bodies.add(jsonDecode(raw) as Map<String, dynamic>);
+
+    final code = responseCodes[callIndex.clamp(0, responseCodes.length - 1)];
+    callIndex++;
+    return ResponseBody.fromString(
+      '{"successes":[],"errors":[]}',
+      code,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+LangfuseConfig _testConfig({int flushAt = 50, Duration? interval}) =>
+    LangfuseConfig(
+      host: 'https://example.invalid',
+      publicKey: 'pk-test',
+      secretKey: 'sk-test',
+      environment: 'test',
+      flushAt: flushAt,
+      flushInterval: interval ?? const Duration(milliseconds: 50),
+      maxRetries: 2,
+      requestTimeout: const Duration(seconds: 1),
+    );
+
+LangfuseTraceExporter _exporter(_CapturingAdapter adapter, LangfuseConfig cfg) {
+  final dio = Dio(
+    BaseOptions(
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization':
+            'Basic ${base64.encode(utf8.encode('${cfg.publicKey}:${cfg.secretKey}'))}',
+      },
+      validateStatus: (_) => true,
+    ),
+  );
+  dio.httpClientAdapter = adapter;
+  return LangfuseTraceExporter(cfg, client: LangfuseClient(cfg, dio: dio));
+}
+
+class _StubTask implements EvalTask {
+  @override
+  final String id;
+  @override
+  final String description;
+  @override
+  final Map<String, dynamic> input;
+  @override
+  final Map<String, String> metadata;
+  @override
+  final List<Grader> graders;
+  @override
+  final ReferenceSolution? referenceSolution;
+  @override
+  final int trialsPerRun;
+  @override
+  final Duration? timeout;
+
+  _StubTask(this.id)
+    : description = 'task $id',
+      input = {'q': 'hello'},
+      metadata = const {'failure_bucket': 'simple'},
+      graders = const [],
+      referenceSolution = null,
+      trialsPerRun = 1,
+      timeout = null;
+}
+
+void main() {
+  group('LangfuseConfig', () {
+    test('fromEnv requires publicKey + secretKey', () {
+      expect(() => LangfuseConfig.fromEnv({}), throwsA(isA<StateError>()));
+      final cfg = LangfuseConfig.fromEnv({
+        'LANGFUSE_PUBLIC_KEY': 'pk',
+        'LANGFUSE_SECRET_KEY': 'sk',
+        'LANGFUSE_HOST': 'https://lf.example.com/',
+      });
+      expect(cfg.publicKey, 'pk');
+      expect(cfg.secretKey, 'sk');
+      expect(cfg.host, 'https://lf.example.com/');
+      expect(cfg.ingestionUrl, 'https://lf.example.com/api/public/ingestion');
+    });
+  });
+
+  group('LangfuseTraceExporter', () {
+    test(
+      'emits trace-create / generation-create / span-create / score-create',
+      () async {
+        final adapter = _CapturingAdapter();
+        final cfg = _testConfig(flushAt: 100); // never auto-flush by size
+        final exporter = _exporter(adapter, cfg);
+
+        final trial = makeTrial(
+          runName: 'r1',
+          suiteName: 'suite_a',
+          taskId: 'task_x',
+        );
+        await exporter.onTrialStart(trial, _StubTask('task_x'));
+        await exporter.onLLMCall(
+          trial: trial,
+          requestMessages: [SystemMessage('hi'), UserMessage.text('q')],
+          modelConfig: ModelConfig(model: 'gpt-fake', temperature: 0.5),
+          response: textReply('answer'),
+          duration: const Duration(milliseconds: 120),
+        );
+        final tcStart = DateTime(2025, 1, 1);
+        await exporter.onToolCall(
+          trial: trial,
+          record: ToolCallRecord(
+            callId: 'c1',
+            toolName: 'add',
+            arguments: {'a': 1, 'b': 2},
+            startedAt: tcStart,
+            endedAt: tcStart.add(const Duration(milliseconds: 5)),
+          ),
+        );
+        await exporter.onTrialEnd(
+          trial: trial,
+          transcript: emptyTranscript(),
+          outcome: const Outcome(environmentState: {'answer': '3'}),
+          scores: [
+            okScore('correctness', value: 1.0),
+            failScore('citation', value: 0.5, rationale: 'missing source'),
+            nullScore('skipped'),
+          ],
+        );
+        await exporter.dispose();
+
+        // Collect every event across batches
+        final events = adapter.bodies
+            .expand<Map<String, dynamic>>(
+              (b) => (b['batch'] as List).cast<Map<String, dynamic>>(),
+            )
+            .toList();
+        final byType = <String, List<Map<String, dynamic>>>{};
+        for (final e in events) {
+          byType.putIfAbsent(e['type'] as String, () => []).add(e);
+        }
+
+        // 2 trace-create (start + end-merge), 1 gen, 1 span, 2 numeric scores
+        expect(byType['trace-create'], hasLength(2));
+        expect(byType['generation-create'], hasLength(1));
+        expect(byType['span-create'], hasLength(1));
+        expect(byType['score-create'], hasLength(2));
+
+        // Trace ids match between start + end (server-side merge).
+        final traceIds = byType['trace-create']!
+            .map((e) => (e['body'] as Map)['id'])
+            .toSet();
+        expect(traceIds, hasLength(1));
+
+        final gen =
+            byType['generation-create']!.single['body'] as Map<String, dynamic>;
+        expect(gen['model'], 'gpt-fake');
+        expect(gen['traceId'], traceIds.single);
+        expect(gen['usage']['total'], 15);
+        expect((gen['modelParameters'] as Map)['temperature'], 0.5);
+
+        final span =
+            byType['span-create']!.single['body'] as Map<String, dynamic>;
+        expect(span['name'], 'tool.add');
+        expect(span['traceId'], traceIds.single);
+
+        // Scores: correct dataType + traceId, null score skipped.
+        for (final s in byType['score-create']!) {
+          final body = s['body'] as Map<String, dynamic>;
+          expect(body['dataType'], 'NUMERIC');
+          expect(body['traceId'], traceIds.single);
+          expect(body['environment'], 'test');
+        }
+        final scoreNames = byType['score-create']!
+            .map((e) => (e['body'] as Map)['name'])
+            .toSet();
+        expect(scoreNames, {'correctness', 'citation'});
+      },
+    );
+
+    test('onRunEnd writes a summary trace + per-metric score', () async {
+      final adapter = _CapturingAdapter();
+      final cfg = _testConfig(flushAt: 100);
+      final exporter = _exporter(adapter, cfg);
+
+      await exporter.onRunEnd(
+        runName: 'pr-42',
+        suiteName: 'suite_a',
+        aggregateScores: {'pass@1': 0.8, 'mean_correctness': 0.9},
+      );
+      await exporter.dispose();
+
+      final events = adapter.bodies
+          .expand<Map<String, dynamic>>(
+            (b) => (b['batch'] as List).cast<Map<String, dynamic>>(),
+          )
+          .toList();
+      final traces = events.where((e) => e['type'] == 'trace-create').toList();
+      final scores = events.where((e) => e['type'] == 'score-create').toList();
+      expect(traces, hasLength(1));
+      expect((traces.single['body'] as Map)['name'], 'run-summary:suite_a');
+      expect((traces.single['body'] as Map)['userId'], 'pr-42');
+      expect(scores, hasLength(2));
+      final summaryTraceId = (traces.single['body'] as Map)['id'];
+      for (final s in scores) {
+        expect((s['body'] as Map)['traceId'], summaryTraceId);
+      }
+    });
+
+    test('flushAt triggers immediate flush', () async {
+      final adapter = _CapturingAdapter();
+      final cfg = _testConfig(flushAt: 2);
+      final exporter = _exporter(adapter, cfg);
+
+      // Each onToolCall enqueues exactly one event.
+      final t = DateTime(2025);
+      final trial = makeTrial(runName: 'r', suiteName: 's', taskId: 't');
+      await exporter.onToolCall(
+        trial: trial,
+        record: ToolCallRecord(
+          callId: 'c1',
+          toolName: 'a',
+          arguments: const {},
+          startedAt: t,
+          endedAt: t,
+        ),
+      );
+      await exporter.onToolCall(
+        trial: trial,
+        record: ToolCallRecord(
+          callId: 'c2',
+          toolName: 'b',
+          arguments: const {},
+          startedAt: t,
+          endedAt: t,
+        ),
+      );
+      // After 2 events queued (== flushAt), flush is scheduled. Pump
+      // microtasks so the unawaited flush runs.
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      expect(adapter.bodies, hasLength(1));
+      expect((adapter.bodies.single['batch'] as List).length, 2);
+      await exporter.dispose();
+    });
+
+    test('5xx triggers retry with backoff, then succeeds', () async {
+      final adapter = _CapturingAdapter(responseCodes: [503, 200]);
+      final cfg = LangfuseConfig(
+        host: 'https://example.invalid',
+        publicKey: 'pk',
+        secretKey: 'sk',
+        flushAt: 100,
+        flushInterval: const Duration(milliseconds: 20),
+        maxRetries: 3,
+        requestTimeout: const Duration(seconds: 1),
+      );
+      final exporter = _exporter(adapter, cfg);
+
+      await exporter.onRunEnd(
+        runName: 'r',
+        suiteName: 's',
+        aggregateScores: {'p1': 1.0},
+      );
+      await exporter.dispose();
+      // 503 then 200 → adapter saw 2 calls
+      expect(adapter.callIndex, 2);
+    });
+
+    test('4xx is fatal — no retry', () async {
+      final adapter = _CapturingAdapter(responseCodes: [400, 200]);
+      final cfg = LangfuseConfig(
+        host: 'https://example.invalid',
+        publicKey: 'pk',
+        secretKey: 'sk',
+        flushAt: 100,
+        flushInterval: const Duration(milliseconds: 20),
+        maxRetries: 3,
+        requestTimeout: const Duration(seconds: 1),
+      );
+      final exporter = _exporter(adapter, cfg);
+
+      await exporter.onRunEnd(
+        runName: 'r',
+        suiteName: 's',
+        aggregateScores: {'p1': 1.0},
+      );
+      await exporter.dispose();
+      expect(adapter.callIndex, 1); // no retry on 4xx
+    });
+
+    test('shutdown is idempotent and silently drops further events', () async {
+      final adapter = _CapturingAdapter();
+      final exporter = _exporter(adapter, _testConfig(flushAt: 100));
+      await exporter.dispose();
+      // After dispose, events should be dropped without error.
+      await exporter.onRunEnd(
+        runName: 'late',
+        suiteName: 's',
+        aggregateScores: {'p1': 1.0},
+      );
+      await exporter.dispose();
+      // Only the very first dispose flushed (which had nothing to flush).
+      // Second batch should NOT have been sent.
+      final batches = adapter.bodies;
+      // There may have been one empty flush attempt; ensure no late
+      // events leaked through.
+      for (final b in batches) {
+        final batch = b['batch'] as List;
+        for (final e in batch) {
+          final body = (e as Map)['body'] as Map;
+          expect(body['userId'] != 'late', isTrue);
+        }
+      }
+    });
+  });
+}

--- a/test/eval/llm_record_replay_test.dart
+++ b/test/eval/llm_record_replay_test.dart
@@ -1,0 +1,525 @@
+import 'dart:io';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dart_agent_core/eval.dart';
+import 'package:test/test.dart';
+
+import '_helpers.dart';
+
+ModelConfig _cfg([String model = 'fake-model']) =>
+    ModelConfig(model: model, temperature: 0.7);
+
+// UserMessage.text(...) bakes a fresh DateTime.now() timestamp on each
+// call, which gets included in toJson() and therefore in the request
+// hash. Tests that need stable hashes use [_msg] which fixes the
+// timestamp.
+UserMessage _msg(String text, {int timestamp = 1}) =>
+    UserMessage([TextPart(text)], timestamp: timestamp);
+
+void main() {
+  group('Sha256LLMRequestHash', () {
+    test('same inputs → same hash', () {
+      const h = Sha256LLMRequestHash();
+      final a = h.compute(
+        messages: [_msg('hi')],
+        tools: null,
+        modelConfig: _cfg(),
+      );
+      final b = h.compute(
+        messages: [_msg('hi')],
+        tools: null,
+        modelConfig: _cfg(),
+      );
+      expect(a, b);
+    });
+
+    test('different model → different hash', () {
+      const h = Sha256LLMRequestHash();
+      final a = h.compute(
+        messages: [_msg('hi')],
+        tools: null,
+        modelConfig: _cfg('A'),
+      );
+      final b = h.compute(
+        messages: [_msg('hi')],
+        tools: null,
+        modelConfig: _cfg('B'),
+      );
+      expect(a, isNot(b));
+    });
+
+    test('different message → different hash', () {
+      const h = Sha256LLMRequestHash();
+      final a = h.compute(
+        messages: [_msg('one')],
+        tools: null,
+        modelConfig: _cfg(),
+      );
+      final b = h.compute(
+        messages: [_msg('two')],
+        tools: null,
+        modelConfig: _cfg(),
+      );
+      expect(a, isNot(b));
+    });
+
+    test('jsonOutput flag flips hash', () {
+      const h = Sha256LLMRequestHash();
+      final a = h.compute(
+        messages: [_msg('hi')],
+        tools: null,
+        modelConfig: _cfg(),
+        jsonOutput: false,
+      );
+      final b = h.compute(
+        messages: [_msg('hi')],
+        tools: null,
+        modelConfig: _cfg(),
+        jsonOutput: true,
+      );
+      expect(a, isNot(b));
+    });
+
+    test('timestamp is stripped by default — UserMessages with different '
+        'timestamps still hash equal', () {
+      const h = Sha256LLMRequestHash();
+      final um1 = UserMessage([TextPart('hi')], timestamp: 1);
+      final um2 = UserMessage([TextPart('hi')], timestamp: 999);
+      final h1 = h.compute(messages: [um1], tools: null, modelConfig: _cfg());
+      final h2 = h.compute(messages: [um2], tools: null, modelConfig: _cfg());
+      expect(h1, h2);
+    });
+
+    test('stripMessageKeys adds extra strip keys on top of defaults', () {
+      // App embeds a 'trace_id' that should also be stripped.
+      const stripped = Sha256LLMRequestHash(stripMessageKeys: {'metadata'});
+      const baseline = Sha256LLMRequestHash();
+      final um1 = UserMessage(
+        [TextPart('hi')],
+        timestamp: 1,
+        metadata: const {'trace_id': 'abc'},
+      );
+      final um2 = UserMessage(
+        [TextPart('hi')],
+        timestamp: 1,
+        metadata: const {'trace_id': 'xyz'},
+      );
+      // Default hashing keeps metadata → different trace_ids → different hash.
+      expect(
+        baseline.compute(messages: [um1], tools: null, modelConfig: _cfg()),
+        isNot(
+          baseline.compute(messages: [um2], tools: null, modelConfig: _cfg()),
+        ),
+      );
+      // With metadata stripped → equal hash.
+      expect(
+        stripped.compute(messages: [um1], tools: null, modelConfig: _cfg()),
+        stripped.compute(messages: [um2], tools: null, modelConfig: _cfg()),
+      );
+    });
+
+    test('different trialSalt → different hash (per-trial cache axis)', () {
+      const h = Sha256LLMRequestHash();
+      final args = {
+        'messages': [_msg('hi')],
+        'tools': null,
+        'modelConfig': _cfg(),
+      };
+      final a = h.compute(
+        messages: args['messages'] as List<LLMMessage>,
+        tools: args['tools'] as List<Tool>?,
+        modelConfig: args['modelConfig'] as ModelConfig,
+        trialSalt: 'run_x/task#0',
+      );
+      final b = h.compute(
+        messages: args['messages'] as List<LLMMessage>,
+        tools: args['tools'] as List<Tool>?,
+        modelConfig: args['modelConfig'] as ModelConfig,
+        trialSalt: 'run_x/task#1',
+      );
+      final none = h.compute(
+        messages: args['messages'] as List<LLMMessage>,
+        tools: args['tools'] as List<Tool>?,
+        modelConfig: args['modelConfig'] as ModelConfig,
+      );
+      expect(a, isNot(b));
+      expect(a, isNot(none));
+      expect(b, isNot(none));
+    });
+
+    test('same trialSalt → same hash', () {
+      const h = Sha256LLMRequestHash();
+      final a = h.compute(
+        messages: [_msg('hi')],
+        tools: null,
+        modelConfig: _cfg(),
+        trialSalt: 'run_x/task#0',
+      );
+      final b = h.compute(
+        messages: [_msg('hi')],
+        tools: null,
+        modelConfig: _cfg(),
+        trialSalt: 'run_x/task#0',
+      );
+      expect(a, b);
+    });
+  });
+
+  group('InMemoryRecordingStore', () {
+    test('put/get round-trips a recording', () async {
+      final store = InMemoryRecordingStore();
+      await store.put('h1', textReply('hello'));
+      final got = await store.get('h1');
+      expect(got, isNotNull);
+      expect(got!.textOutput, 'hello');
+    });
+
+    test('miss returns null', () async {
+      final store = InMemoryRecordingStore();
+      expect(await store.get('nope'), isNull);
+    });
+  });
+
+  group('FileRecordingStore', () {
+    late Directory tmp;
+    setUp(() async {
+      tmp = await Directory.systemTemp.createTemp('rec_store_');
+    });
+    tearDown(() async {
+      if (await tmp.exists()) await tmp.delete(recursive: true);
+    });
+
+    test('put then flush then get reads back the same response', () async {
+      final store = FileRecordingStore(tmp);
+      await store.put('abcd1234ef', textReply('hello-disk'));
+      await store.flush();
+      // Re-open to ensure no in-memory caching is helping.
+      final reopened = FileRecordingStore(tmp);
+      final got = await reopened.get('abcd1234ef');
+      expect(got, isNotNull);
+      expect(got!.textOutput, 'hello-disk');
+    });
+
+    test('uses two-level prefix layout under rootDir', () async {
+      final store = FileRecordingStore(tmp);
+      await store.put('abcdef00112233', textReply('layout'));
+      await store.flush();
+      final f = File('${tmp.path}/ab/cd/abcdef00112233.json');
+      expect(await f.exists(), isTrue);
+    });
+  });
+
+  group('RecordingLLMClient', () {
+    test('forwards generate() to inner and persists the response', () async {
+      final inner = FakeLLMClient([textReply('rec1')]);
+      final store = InMemoryRecordingStore();
+      final client = RecordingLLMClient(inner: inner, store: store);
+      final m = _msg('hi');
+      final reply = await client.generate([m], modelConfig: _cfg());
+      expect(reply.textOutput, 'rec1');
+      expect(inner.generateCalls, 1);
+
+      final hash = const Sha256LLMRequestHash().compute(
+        messages: [m],
+        tools: null,
+        modelConfig: _cfg(),
+      );
+      final cached = await store.get(hash);
+      expect(cached, isNotNull);
+      expect(cached!.textOutput, 'rec1');
+    });
+
+    test('rate gate.acquire() is awaited before each generate()', () async {
+      final inner = FakeLLMClient([textReply('a'), textReply('b')]);
+      final gate = _CountingRateLimitGate();
+      final client = RecordingLLMClient(
+        inner: inner,
+        store: InMemoryRecordingStore(),
+        rateLimitGate: gate,
+      );
+      await client.generate([_msg('one', timestamp: 1)], modelConfig: _cfg());
+      await client.generate([_msg('two', timestamp: 2)], modelConfig: _cfg());
+      expect(gate.acquireCalls, 2);
+    });
+  });
+
+  group('ReplayLLMClient', () {
+    test('strict replay hit returns cached without calling fallback', () async {
+      final inner = FakeLLMClient([textReply('SHOULD-NOT-CALL')]);
+      final store = InMemoryRecordingStore();
+      final m = _msg('hi');
+      final hash = const Sha256LLMRequestHash().compute(
+        messages: [m],
+        tools: null,
+        modelConfig: _cfg(),
+      );
+      await store.put(hash, textReply('cached-reply'));
+
+      final client = ReplayLLMClient(
+        store: store,
+        fallback: inner,
+        strictReplay: true,
+      );
+      final reply = await client.generate([m], modelConfig: _cfg());
+      expect(reply.textOutput, 'cached-reply');
+      expect(inner.generateCalls, 0);
+    });
+
+    test('strict replay miss throws RecordingNotFoundException', () async {
+      final client = ReplayLLMClient(store: InMemoryRecordingStore());
+      await expectLater(
+        client.generate([_msg('miss')], modelConfig: _cfg()),
+        throwsA(isA<RecordingNotFoundException>()),
+      );
+    });
+
+    test('non-strict miss falls back to inner client', () async {
+      final inner = FakeLLMClient([textReply('live-reply')]);
+      final client = ReplayLLMClient(
+        store: InMemoryRecordingStore(),
+        fallback: inner,
+        strictReplay: false,
+      );
+      final reply = await client.generate([_msg('miss')], modelConfig: _cfg());
+      expect(reply.textOutput, 'live-reply');
+      expect(inner.generateCalls, 1);
+    });
+
+    test('rate gate.acquire() called only on fallback path', () async {
+      final inner = FakeLLMClient([textReply('live')]);
+      final gate = _CountingRateLimitGate();
+      final store = InMemoryRecordingStore();
+      final mA = _msg('A', timestamp: 1);
+      final hashA = const Sha256LLMRequestHash().compute(
+        messages: [mA],
+        tools: null,
+        modelConfig: _cfg(),
+      );
+      await store.put(hashA, textReply('cached-A'));
+
+      final client = ReplayLLMClient(
+        store: store,
+        fallback: inner,
+        strictReplay: false,
+        rateLimitGate: gate,
+      );
+      // Hit: gate NOT called.
+      await client.generate([mA], modelConfig: _cfg());
+      expect(gate.acquireCalls, 0);
+      // Miss: gate IS called.
+      await client.generate([_msg('B', timestamp: 2)], modelConfig: _cfg());
+      expect(gate.acquireCalls, 1);
+    });
+
+    test(
+      'stream() synthesizes a one-chunk stream from the recording',
+      () async {
+        final store = InMemoryRecordingStore();
+        final m = _msg('hi');
+        final hash = const Sha256LLMRequestHash().compute(
+          messages: [m],
+          tools: null,
+          modelConfig: _cfg(),
+        );
+        await store.put(hash, textReply('streamed'));
+        final client = ReplayLLMClient(store: store);
+        final s = await client.stream([m], modelConfig: _cfg());
+        final chunks = await s.toList();
+        expect(chunks, hasLength(1));
+        expect(chunks.first.modelMessage?.textOutput, 'streamed');
+      },
+    );
+  });
+
+  group('Per-trial salt preserves non-determinism', () {
+    test('RecordingLLMClient: each trial-salted client writes its own '
+        'cache entry for the same logical request', () async {
+      // Inner returns a different reply each call so we can prove that
+      // distinct trials capture distinct responses.
+      final inner = FakeLLMClient([
+        textReply('trial-0'),
+        textReply('trial-1'),
+        textReply('trial-2'),
+      ]);
+      final store = InMemoryRecordingStore();
+      final base = RecordingLLMClient(inner: inner, store: store);
+
+      final m = _msg('same prompt across trials');
+      for (var i = 0; i < 3; i++) {
+        final perTrial = base.withTrialSalt('run_x/task#$i');
+        final r = await perTrial.generate([m], modelConfig: _cfg());
+        expect(r.textOutput, 'trial-$i');
+      }
+
+      // Three distinct hashes ⇒ three distinct cache entries.
+      final hasher = const Sha256LLMRequestHash();
+      final responses = <String?>[];
+      for (var i = 0; i < 3; i++) {
+        final hash = hasher.compute(
+          messages: [m],
+          tools: null,
+          modelConfig: _cfg(),
+          trialSalt: 'run_x/task#$i',
+        );
+        final cached = await store.get(hash);
+        responses.add(cached?.textOutput);
+      }
+      expect(responses, ['trial-0', 'trial-1', 'trial-2']);
+    });
+
+    test('ReplayLLMClient: salted clients hit their own cache slot, not '
+        'a peer trial\'s slot', () async {
+      final hasher = const Sha256LLMRequestHash();
+      final store = InMemoryRecordingStore();
+      final m = _msg('same prompt across trials');
+
+      // Pre-record three distinct responses keyed by trial salt.
+      for (var i = 0; i < 3; i++) {
+        final hash = hasher.compute(
+          messages: [m],
+          tools: null,
+          modelConfig: _cfg(),
+          trialSalt: 'run_x/task#$i',
+        );
+        await store.put(hash, textReply('trial-$i-cached'));
+      }
+
+      // Replay: each trial gets its own response.
+      final base = ReplayLLMClient(store: store, strictReplay: true);
+      for (var i = 0; i < 3; i++) {
+        final perTrial = base.withTrialSalt('run_x/task#$i');
+        final r = await perTrial.generate([m], modelConfig: _cfg());
+        expect(r.textOutput, 'trial-$i-cached');
+      }
+    });
+
+    test('recordings made in run A can be replayed by run B (cacheSalt is '
+        'run-name independent)', () async {
+      final inner = FakeLLMClient([textReply('rec-trial-0')]);
+      final store = InMemoryRecordingStore();
+      // The salt the env should use: derived from trial.cacheSalt,
+      // NOT trial.id.toString(). Same task+trialIndex gives the same
+      // salt regardless of which run wraps around them.
+      const salt = 'task_a#0';
+      final recorder = RecordingLLMClient(
+        inner: inner,
+        store: store,
+        trialSalt: salt,
+      );
+      await recorder.generate([_msg('p')], modelConfig: _cfg());
+
+      // Different "run", same task+trialIndex → same salt → cache hit.
+      final replayer = ReplayLLMClient(
+        store: store,
+        strictReplay: true,
+        trialSalt: salt,
+      );
+      final replayed = await replayer.generate([
+        _msg('p'),
+      ], modelConfig: _cfg());
+      expect(replayed.textOutput, 'rec-trial-0');
+    });
+
+    test(
+      'without per-trial salt the cache collapses (regression guard)',
+      () async {
+        // This documents the alternate behavior: when the env does NOT
+        // pass a trial salt, every trial maps to the same hash, so the
+        // store sees N puts for the same key — by design, cache is
+        // shared (judges, ad-hoc analysis, etc.).
+        final inner = FakeLLMClient([textReply('first'), textReply('second')]);
+        final store = InMemoryRecordingStore();
+        final client = RecordingLLMClient(inner: inner, store: store);
+        final m = _msg('shared prompt');
+        await client.generate([m], modelConfig: _cfg());
+        await client.generate([m], modelConfig: _cfg());
+        final hash = const Sha256LLMRequestHash().compute(
+          messages: [m],
+          tools: null,
+          modelConfig: _cfg(),
+        );
+        // Last write wins: second response overwrote the first.
+        final cached = await store.get(hash);
+        expect(cached?.textOutput, 'second');
+      },
+    );
+  });
+
+  group('RpmRateLimitGate', () {
+    test('allows up to N immediate acquires from the initial bucket', () async {
+      final gate = RpmRateLimitGate(requestsPerMinute: 60);
+      final start = DateTime.now();
+      for (var i = 0; i < 5; i++) {
+        await gate.acquire();
+      }
+      expect(
+        DateTime.now().difference(start),
+        lessThan(const Duration(milliseconds: 200)),
+      );
+    });
+
+    test('throttles when bucket is empty', () async {
+      final gate = RpmRateLimitGate(requestsPerMinute: 6);
+      // Drain initial bucket of 6.
+      for (var i = 0; i < 6; i++) {
+        await gate.acquire();
+      }
+      // 7th acquire shouldn't return within 200ms (refill rate is 6/min).
+      final completed = <bool>[];
+      final pending = gate.acquire().then((_) => completed.add(true));
+      await Future.delayed(const Duration(milliseconds: 200));
+      expect(completed, isEmpty);
+      // Don't await `pending`; let it leak (the test process exits).
+      pending.ignore();
+    });
+  });
+
+  group('TpmRateLimitGate', () {
+    test('allows multiple small acquires until budget is spent', () async {
+      // 60_000 tokens/min = 1000 tokens/sec.
+      final gate = TpmRateLimitGate(tokensPerMinute: 60000);
+      final start = DateTime.now();
+      for (var i = 0; i < 5; i++) {
+        await gate.acquire(estimatedTokens: 100);
+      }
+      expect(
+        DateTime.now().difference(start),
+        lessThan(const Duration(milliseconds: 200)),
+      );
+    });
+
+    test('queues request that exceeds remaining budget', () async {
+      final gate = TpmRateLimitGate(tokensPerMinute: 6);
+      await gate.acquire(estimatedTokens: 6);
+      final completed = <bool>[];
+      final pending = gate
+          .acquire(estimatedTokens: 1)
+          .then((_) => completed.add(true));
+      await Future.delayed(const Duration(milliseconds: 200));
+      expect(completed, isEmpty);
+      pending.ignore();
+    });
+  });
+
+  group('NoopRateLimitGate', () {
+    test('returns immediately', () async {
+      const gate = NoopRateLimitGate();
+      final start = DateTime.now();
+      for (var i = 0; i < 100; i++) {
+        await gate.acquire(estimatedTokens: 1000);
+      }
+      expect(
+        DateTime.now().difference(start),
+        lessThan(const Duration(milliseconds: 50)),
+      );
+    });
+  });
+}
+
+class _CountingRateLimitGate implements RateLimitGate {
+  int acquireCalls = 0;
+  @override
+  Future<void> acquire({int estimatedTokens = 0}) async {
+    acquireCalls++;
+  }
+}

--- a/test/eval/metrics_test.dart
+++ b/test/eval/metrics_test.dart
@@ -1,0 +1,139 @@
+import 'package:dart_agent_core/eval.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('passAtK', () {
+    test('all-pass yields 1.0 for any k <= n', () {
+      final passes = [true, true, true, true];
+      expect(passAtK(passes, 1), closeTo(1.0, 1e-9));
+      expect(passAtK(passes, 4), closeTo(1.0, 1e-9));
+    });
+
+    test('all-fail yields 0.0 for any k', () {
+      final passes = [false, false, false, false];
+      expect(passAtK(passes, 1), 0.0);
+      expect(passAtK(passes, 4), 0.0);
+    });
+
+    test('Codex unbiased formula: 1 success in 4 trials, k=1', () {
+      // n=4, c=1, k=1 → 1 - C(3,1)/C(4,1) = 1 - 3/4 = 0.25
+      expect(passAtK([true, false, false, false], 1), closeTo(0.25, 1e-9));
+    });
+
+    test('Codex unbiased formula: 2 successes in 4 trials, k=2', () {
+      // n=4, c=2, k=2 → 1 - C(2,2)/C(4,2) = 1 - 1/6 ≈ 0.8333
+      expect(
+        passAtK([true, true, false, false], 2),
+        closeTo(1.0 - 1.0 / 6.0, 1e-9),
+      );
+    });
+
+    test('Codex unbiased formula: 3 successes in 5 trials, k=3', () {
+      // n=5, c=3, k=3 → 1 - C(2,3)/C(5,3) -- C(2,3)=0 → 1.0
+      expect(passAtK([true, true, true, false, false], 3), closeTo(1.0, 1e-9));
+    });
+
+    test('k > n returns 0.0', () {
+      expect(passAtK([true, false], 3), 0.0);
+    });
+
+    test('k <= 0 returns 0.0', () {
+      expect(passAtK([true, true], 0), 0.0);
+      expect(passAtK([true, true], -1), 0.0);
+    });
+
+    test('empty list returns 0.0', () {
+      expect(passAtK(<bool>[], 1), 0.0);
+    });
+  });
+
+  group('passCaretK', () {
+    test('all-pass yields 1.0 for any k', () {
+      final passes = [true, true, true];
+      expect(passCaretK(passes, 1), closeTo(1.0, 1e-9));
+      expect(passCaretK(passes, 3), closeTo(1.0, 1e-9));
+    });
+
+    test('half-pass: empirical (c/n)^k', () {
+      // c=2, n=4, k=2 → (0.5)^2 = 0.25
+      expect(passCaretK([true, true, false, false], 2), closeTo(0.25, 1e-9));
+    });
+
+    test('any failure makes k=n yield 0 < (c/n)^k < 1', () {
+      // 3 of 4 pass, k=4 → (0.75)^4 ≈ 0.3164
+      expect(
+        passCaretK([true, true, true, false], 4),
+        closeTo(0.31640625, 1e-9),
+      );
+    });
+
+    test('zero successes returns 0.0', () {
+      expect(passCaretK([false, false], 1), 0.0);
+    });
+
+    test('k <= 0 or empty returns 0.0', () {
+      expect(passCaretK([true], 0), 0.0);
+      expect(passCaretK(<bool>[], 1), 0.0);
+    });
+  });
+
+  group('ClassificationMetrics', () {
+    test('precision/recall/f1/accuracy on perfect classifier', () {
+      const m = ClassificationMetrics(
+        truePositives: 10,
+        falsePositives: 0,
+        trueNegatives: 10,
+        falseNegatives: 0,
+      );
+      expect(m.precision, 1.0);
+      expect(m.recall, 1.0);
+      expect(m.f1, 1.0);
+      expect(m.accuracy, 1.0);
+    });
+
+    test('precision/recall/f1 with mixed errors', () {
+      const m = ClassificationMetrics(
+        truePositives: 6,
+        falsePositives: 2,
+        trueNegatives: 8,
+        falseNegatives: 4,
+      );
+      // P = 6/8 = 0.75; R = 6/10 = 0.6; F1 = 2*0.75*0.6/(0.75+0.6) = 0.6667
+      expect(m.precision, closeTo(0.75, 1e-9));
+      expect(m.recall, closeTo(0.6, 1e-9));
+      expect(m.f1, closeTo(2 * 0.75 * 0.6 / (0.75 + 0.6), 1e-9));
+      expect(m.accuracy, closeTo(14 / 20, 1e-9));
+    });
+
+    test('division-by-zero guards', () {
+      const empty = ClassificationMetrics(
+        truePositives: 0,
+        falsePositives: 0,
+        trueNegatives: 0,
+        falseNegatives: 0,
+      );
+      expect(empty.precision, 0.0);
+      expect(empty.recall, 0.0);
+      expect(empty.f1, 0.0);
+      expect(empty.accuracy, 0.0);
+    });
+
+    test('toJson contains the four counts and derived metrics', () {
+      const m = ClassificationMetrics(
+        truePositives: 1,
+        falsePositives: 1,
+        trueNegatives: 1,
+        falseNegatives: 1,
+      );
+      final j = m.toJson();
+      expect(j['truePositives'], 1);
+      expect(j['falsePositives'], 1);
+      expect(j['trueNegatives'], 1);
+      expect(j['falseNegatives'], 1);
+      expect(j['precision'], 0.5);
+      expect(j['recall'], 0.5);
+      expect(j['f1'], 0.5);
+      expect(j['accuracy'], 0.5);
+    });
+  });
+}

--- a/test/eval/runner_e2e_test.dart
+++ b/test/eval/runner_e2e_test.dart
@@ -1,0 +1,502 @@
+// ignore_for_file: unused_element_parameter
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dart_agent_core/eval.dart';
+import 'package:test/test.dart';
+
+import '_helpers.dart';
+
+// ─── Minimal harness: no real LLM, just decides outcome from task input ─────
+
+class _StubEnvironment implements EvalEnvironment {
+  final Map<String, int> prepares = {};
+  final Map<String, int> disposes = {};
+
+  @override
+  Future<EvalContext> prepare({
+    required Trial trial,
+    required EvalTask task,
+  }) async {
+    prepares[trial.taskId] = (prepares[trial.taskId] ?? 0) + 1;
+    return EvalContext(
+      clock: const SystemEvalClock(),
+      llmClient: FakeLLMClient([textReply('unused')]),
+      controller: AgentController(),
+    );
+  }
+
+  @override
+  Future<void> dispose(EvalContext context) async {
+    disposes['*'] = (disposes['*'] ?? 0) + 1;
+    context.controller.close();
+  }
+}
+
+/// Harness that always succeeds with whatever outcome the task input dictates.
+/// `task.input['outcome_value']` is copied into outcome.environmentState.
+class _StubHarnessFactory implements AgentHarnessFactory {
+  final Duration runDelay;
+  _StubHarnessFactory({this.runDelay = Duration.zero});
+
+  @override
+  Future<AgentHarnessSession> create({
+    required EvalTask task,
+    required Trial trial,
+    required EvalContext context,
+  }) async {
+    return _StubSession(task: task, runDelay: runDelay);
+  }
+}
+
+class _StubSession implements AgentHarnessSession {
+  final EvalTask task;
+  final Duration runDelay;
+  _StubSession({required this.task, required this.runDelay});
+
+  @override
+  Future<({Transcript transcript, Outcome outcome})> run() async {
+    if (runDelay > Duration.zero) {
+      await Future.delayed(runDelay);
+    }
+    if (task.input['throw'] == true) {
+      throw StateError('boom');
+    }
+    if (task.input['hang'] == true) {
+      // Cause a timeout in tests that set a small task timeout.
+      await Future.delayed(const Duration(seconds: 30));
+    }
+    return (
+      transcript: emptyTranscript(),
+      outcome: Outcome(
+        environmentState: {'value': task.input['outcome_value']},
+      ),
+    );
+  }
+
+  @override
+  Future<void> dispose() async {}
+}
+
+class _ExpectsValueGrader extends CodeGrader {
+  final Object? expected;
+  final String taskId;
+  _ExpectsValueGrader({required this.expected, required this.taskId});
+
+  @override
+  String get name => 'expects_value';
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async {
+    final actual = outcome.environmentState['value'];
+    return [
+      Assertion(
+        description: 'value matches expected for $taskId',
+        passed: actual == expected,
+        actual: '$actual',
+        expected: '$expected',
+      ),
+    ];
+  }
+}
+
+class _Task implements EvalTask {
+  @override
+  final String id;
+  @override
+  final List<Grader> graders;
+  @override
+  final ReferenceSolution? referenceSolution = null;
+  @override
+  final int trialsPerRun;
+  @override
+  final Map<String, String> metadata;
+  @override
+  final Map<String, dynamic> input;
+  @override
+  final String description = '';
+  @override
+  final Duration? timeout;
+
+  _Task({
+    required this.id,
+    required this.input,
+    required this.graders,
+    this.trialsPerRun = 1,
+    this.metadata = const {},
+    this.timeout,
+  });
+}
+
+class _RecordingExporter implements TraceExporter {
+  final List<String> events = [];
+
+  @override
+  Future<void> onTrialStart(Trial trial, EvalTask task) async {
+    events.add('trial_start:${trial.taskId}#${trial.trialIndex}');
+  }
+
+  @override
+  Future<void> onLLMCall({
+    required Trial trial,
+    required List<LLMMessage> requestMessages,
+    required ModelConfig modelConfig,
+    required ModelMessage? response,
+    required Duration duration,
+    Object? error,
+  }) async {
+    events.add('llm:${trial.taskId}');
+  }
+
+  @override
+  Future<void> onToolCall({
+    required Trial trial,
+    required ToolCallRecord record,
+  }) async {
+    events.add('tool:${trial.taskId}:${record.toolName}');
+  }
+
+  @override
+  Future<void> onTrialEnd({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required List<Score> scores,
+  }) async {
+    events.add('trial_end:${trial.taskId}#${trial.trialIndex}');
+  }
+
+  @override
+  Future<void> onRunEnd({
+    required String runName,
+    required String suiteName,
+    required Map<String, double> aggregateScores,
+  }) async {
+    events.add('run_end:$runName:${aggregateScores['task_pass_rate']}');
+  }
+
+  @override
+  Future<void> dispose() async {
+    events.add('dispose');
+  }
+}
+
+void main() {
+  group('EvalRunner end-to-end', () {
+    test('runSuite: trials, graders, persisted report, jsonl traces, '
+        'composite exporter, recording-store flush', () async {
+      final tmp = await Directory.systemTemp.createTemp('e2e_');
+      addTearDown(() async {
+        if (await tmp.exists()) await tmp.delete(recursive: true);
+      });
+
+      final tracesFile = File('${tmp.path}/traces.jsonl');
+      final reportsDir = Directory('${tmp.path}/reports')..createSync();
+      final jsonlExporter = JsonlTraceExporter(tracesFile);
+      final recordingExporter = _RecordingExporter();
+      final reportStore = FileReportStore(reportsDir);
+      final recordingStore = InMemoryRecordingStore();
+
+      final suite = EvalSuite(
+        name: 'e2e_suite',
+        agentName: 'agent_x',
+        kind: SuiteKind.mixed,
+        tasks: [
+          _Task(
+            id: 'pos',
+            input: {'outcome_value': 42},
+            graders: [_ExpectsValueGrader(expected: 42, taskId: 'pos')],
+            trialsPerRun: 2,
+            metadata: const {'failure_bucket': 'simple'},
+          ),
+          _Task(
+            id: 'neg',
+            input: {'outcome_value': 'whatever'},
+            graders: [_ExpectsValueGrader(expected: 999, taskId: 'neg')],
+          ),
+          _Task(
+            id: 'errored',
+            input: {'throw': true},
+            graders: [_ExpectsValueGrader(expected: null, taskId: 'errored')],
+          ),
+        ],
+      );
+
+      final runner = EvalRunner(
+        environment: _StubEnvironment(),
+        harnessFactory: _StubHarnessFactory(),
+        exporters: [jsonlExporter, recordingExporter],
+        recordingStore: recordingStore,
+        reportStore: reportStore,
+      );
+
+      final report = await runner.runSuite(
+        runName: 'e2e_run_1',
+        suite: suite,
+        concurrency: 4,
+      );
+
+      // Trials = 2 + 1 + 1 = 4. Two pos pass, one neg fails, one errored.
+      expect(report.trials, hasLength(4));
+
+      // pos: 2 pass; neg: 0; errored: 0 (because trial.status=errored has
+      // no scores from harness — but graders still run, and check value==null
+      // which IS true after error → so errored task actually passes its grader.
+      // Verify by direct inspection:
+      final byTask = report.trialsByTask();
+      expect(byTask['pos']!.every((t) => t.allGradersPassed), isTrue);
+      expect(byTask['neg']!.every((t) => t.allGradersPassed), isFalse);
+      expect(byTask['errored']!.first.trial.status, TrialStatus.errored);
+
+      // Composite exporter delivered all phases to the recording exporter.
+      expect(
+        recordingExporter.events.where((e) => e.startsWith('trial_start:')),
+        hasLength(4),
+      );
+      expect(
+        recordingExporter.events.where((e) => e.startsWith('trial_end:')),
+        hasLength(4),
+      );
+      expect(
+        recordingExporter.events.where((e) => e.startsWith('run_end:')),
+        hasLength(1),
+      );
+      expect(recordingExporter.events.last, 'dispose');
+
+      // JSONL trace file produced rows for each trial start/end + run_end.
+      final lines = await tracesFile.readAsLines();
+      expect(lines.length, greaterThanOrEqualTo(4 + 4 + 1));
+      final kinds = lines
+          .map((l) => (jsonDecode(l) as Map)['kind'] as String)
+          .toSet();
+      expect(
+        kinds.containsAll({'trial_start', 'trial_end', 'run_end'}),
+        isTrue,
+      );
+
+      // Persisted report can be reloaded.
+      final loaded = await reportStore.load('e2e_run_1');
+      expect(loaded, isNotNull);
+      expect(loaded!.trials, hasLength(4));
+
+      // recordingStore.flush() was awaited inside runSuite (no exception).
+      await recordingStore.flush();
+    });
+
+    test('per-task timeout marks the trial timedOut', () async {
+      final suite = EvalSuite(
+        name: 's',
+        agentName: 'agent_x',
+        kind: SuiteKind.mixed,
+        tasks: [
+          _Task(
+            id: 'slow',
+            input: {'hang': true},
+            graders: [_ExpectsValueGrader(expected: null, taskId: 'slow')],
+            timeout: const Duration(milliseconds: 100),
+          ),
+        ],
+      );
+      final runner = EvalRunner(
+        environment: _StubEnvironment(),
+        harnessFactory: _StubHarnessFactory(),
+      );
+      final report = await runner.runSuite(
+        runName: 'timeout_run',
+        suite: suite,
+        concurrency: 1,
+      );
+      expect(report.trials.first.trial.status, TrialStatus.timedOut);
+      expect(report.trials.first.trial.failureReason, contains('timed out'));
+    });
+
+    test(
+      'runTask convenience executes a one-off task without persisting',
+      () async {
+        final tmp = await Directory.systemTemp.createTemp('runtask_');
+        addTearDown(() async {
+          if (await tmp.exists()) await tmp.delete(recursive: true);
+        });
+        final reportStore = FileReportStore(tmp);
+        final runner = EvalRunner(
+          environment: _StubEnvironment(),
+          harnessFactory: _StubHarnessFactory(),
+          reportStore: reportStore,
+        );
+        final task = _Task(
+          id: 'one_off',
+          input: {'outcome_value': 1},
+          graders: [_ExpectsValueGrader(expected: 1, taskId: 'one_off')],
+          trialsPerRun: 1,
+        );
+        final results = await runner.runTask(
+          runName: 'one_off_run',
+          task: task,
+          agentName: 'stub_agent',
+          trialsOverride: 3,
+        );
+        expect(results, hasLength(3));
+        expect(results.every((r) => r.allGradersPassed), isTrue);
+        // The run should NOT be persisted to the store.
+        expect(await reportStore.load('one_off_run'), isNull);
+      },
+    );
+
+    test('filter prunes tasks before scheduling', () async {
+      final suite = EvalSuite(
+        name: 's',
+        agentName: 'agent_x',
+        kind: SuiteKind.mixed,
+        tasks: [
+          _Task(
+            id: 'a',
+            input: {'outcome_value': 1},
+            graders: [_ExpectsValueGrader(expected: 1, taskId: 'a')],
+          ),
+          _Task(
+            id: 'b',
+            input: {'outcome_value': 2},
+            graders: [_ExpectsValueGrader(expected: 2, taskId: 'b')],
+          ),
+        ],
+      );
+      final runner = EvalRunner(
+        environment: _StubEnvironment(),
+        harnessFactory: _StubHarnessFactory(),
+      );
+      final report = await runner.runSuite(
+        runName: 'filter_run',
+        suite: suite,
+        concurrency: 1,
+        filter: (t) => t.id == 'a',
+      );
+      expect(report.trials, hasLength(1));
+      expect(report.trials.first.trial.taskId, 'a');
+    });
+
+    test(
+      'invalid suite (duplicate ids) throws StateError before running',
+      () async {
+        final suite = EvalSuite(
+          name: 's',
+          agentName: 'agent_x',
+          kind: SuiteKind.mixed,
+          tasks: [
+            _Task(
+              id: 'dup',
+              input: const {},
+              graders: [_ExpectsValueGrader(expected: 0, taskId: 'dup')],
+            ),
+            _Task(
+              id: 'dup',
+              input: const {},
+              graders: [_ExpectsValueGrader(expected: 0, taskId: 'dup')],
+            ),
+          ],
+        );
+        final runner = EvalRunner(
+          environment: _StubEnvironment(),
+          harnessFactory: _StubHarnessFactory(),
+        );
+        await expectLater(
+          runner.runSuite(runName: 'r', suite: suite),
+          throwsA(isA<StateError>()),
+        );
+      },
+    );
+  });
+
+  group('parseEvalRunArgs', () {
+    test('parses the full flag set', () {
+      final cfg = parseEvalRunArgs(
+        [
+          '--run-name',
+          'demo',
+          '--concurrency',
+          '4',
+          '--trials-override',
+          '5',
+          '--mode',
+          'record',
+          '--filter-agent',
+          'card_agent,pkm_agent',
+          '--filter-bucket',
+          'tool_use',
+          '--filter-task-id',
+          'a,b,c',
+          '--rpm',
+          '60',
+          '--tpm',
+          '120000',
+          '--recording-dir',
+          '/tmp/rec',
+          '--no-langfuse',
+          '--langfuse-host',
+          'https://lf.local',
+        ],
+        env: const {'LANGFUSE_HOST': 'env-host'},
+      );
+      expect(cfg.runName, 'demo');
+      expect(cfg.concurrency, 4);
+      expect(cfg.trialsOverride, 5);
+      expect(cfg.mode, EvalRunMode.record);
+      expect(cfg.filter.agents, {'card_agent', 'pkm_agent'});
+      expect(cfg.filter.buckets, {'tool_use'});
+      expect(cfg.filter.taskIds, {'a', 'b', 'c'});
+      expect(cfg.rpm, 60);
+      expect(cfg.tpm, 120000);
+      expect(cfg.recordingDir, '/tmp/rec');
+      expect(cfg.langfuseEnabled, isFalse);
+      expect(cfg.langfuseHost, 'https://lf.local');
+    });
+
+    test('default run name has timestamp prefix when none provided', () {
+      final cfg = parseEvalRunArgs(const []);
+      expect(cfg.runName, startsWith('run_'));
+      expect(cfg.mode, EvalRunMode.replay);
+    });
+
+    test(
+      'TaskFilter agent filter is suite-level; bucket / id filters are task-level',
+      () {
+        final suite = EvalSuite(
+          name: 's',
+          agentName: 'stub_agent',
+          kind: SuiteKind.mixed,
+          tasks: [
+            _Task(
+              id: 't',
+              input: const {},
+              graders: const [],
+              metadata: const {'failure_bucket': 'tool_use'},
+            ),
+          ],
+        );
+        final task = suite.tasks.single;
+
+        // Agent filter is checked at the suite level.
+        const matching = TaskFilter(agents: {'stub_agent'});
+        expect(matching.matchesSuite(suite), isTrue);
+        const nonMatching = TaskFilter(agents: {'other_agent'});
+        expect(nonMatching.matchesSuite(suite), isFalse);
+
+        // Bucket / taskId filters are task-level.
+        const bucketHit = TaskFilter(buckets: {'tool_use'});
+        expect(bucketHit.matchesTask(task), isTrue);
+        const bucketMiss = TaskFilter(buckets: {'other_bucket'});
+        expect(bucketMiss.matchesTask(task), isFalse);
+
+        const idHit = TaskFilter(taskIds: {'t'});
+        expect(idHit.matchesTask(task), isTrue);
+        const idMiss = TaskFilter(taskIds: {'other'});
+        expect(idMiss.matchesTask(task), isFalse);
+      },
+    );
+  });
+}

--- a/test/eval/suite_and_report_test.dart
+++ b/test/eval/suite_and_report_test.dart
@@ -1,0 +1,458 @@
+// ignore_for_file: unused_element_parameter
+import 'package:dart_agent_core/eval.dart';
+import 'package:test/test.dart';
+
+import '_helpers.dart';
+
+class _StubTask implements EvalTask {
+  @override
+  final String id;
+  @override
+  final List<Grader> graders;
+  @override
+  final ReferenceSolution? referenceSolution;
+  @override
+  final int trialsPerRun;
+  @override
+  final Map<String, String> metadata;
+  @override
+  final Map<String, dynamic> input;
+  @override
+  final String description;
+  @override
+  final Duration? timeout;
+
+  _StubTask({
+    required this.id,
+    this.graders = const [],
+    this.referenceSolution,
+    this.trialsPerRun = 1,
+    this.metadata = const {},
+    this.input = const {},
+    this.description = '',
+    this.timeout,
+  });
+}
+
+class _NoopGrader extends CodeGrader {
+  @override
+  String get name => 'noop';
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async => const [Assertion(description: 'always', passed: true)];
+}
+
+void main() {
+  group('EvalSuite.validate', () {
+    test('detects duplicate task ids', () {
+      final suite = EvalSuite(
+        name: 's',
+        agentName: 'agent_x',
+        kind: SuiteKind.mixed,
+        tasks: [
+          _StubTask(id: 'a', graders: [_NoopGrader()]),
+          _StubTask(id: 'a', graders: [_NoopGrader()]),
+        ],
+      );
+      final problems = suite.validate();
+      expect(problems.any((p) => p.contains('duplicate task id "a"')), isTrue);
+    });
+
+    test('detects task without graders', () {
+      final suite = EvalSuite(
+        name: 's',
+        agentName: 'agent_x',
+        kind: SuiteKind.mixed,
+        tasks: [_StubTask(id: 'a', graders: const [])],
+      );
+      expect(suite.validate().any((p) => p.contains('no graders')), isTrue);
+    });
+
+    test('flags missing reference solution when required', () {
+      final suite = EvalSuite(
+        name: 's',
+        agentName: 'agent_x',
+        kind: SuiteKind.capability,
+        requireReferenceSolution: true,
+        tasks: [
+          _StubTask(id: 'a', graders: [_NoopGrader()]),
+        ],
+      );
+      expect(
+        suite.validate().any((p) => p.contains('missing referenceSolution')),
+        isTrue,
+      );
+    });
+
+    test('detects trialsPerRun <= 0', () {
+      final suite = EvalSuite(
+        name: 's',
+        agentName: 'agent_x',
+        kind: SuiteKind.mixed,
+        tasks: [
+          _StubTask(id: 'a', graders: [_NoopGrader()], trialsPerRun: 0),
+        ],
+      );
+      expect(
+        suite.validate().any((p) => p.contains('trialsPerRun <= 0')),
+        isTrue,
+      );
+    });
+
+    test('valid suite has empty problem list', () {
+      final suite = EvalSuite(
+        name: 's',
+        agentName: 'agent_x',
+        kind: SuiteKind.mixed,
+        tasks: [
+          _StubTask(id: 'a', graders: [_NoopGrader()]),
+        ],
+      );
+      expect(suite.validate(), isEmpty);
+    });
+  });
+
+  group('EvalRunReport: top-line metrics', () {
+    EvalSuite suiteOf(SuiteKind kind) => EvalSuite(
+      name: 's',
+      agentName: 'agent_x',
+      kind: kind,
+      tasks: [
+        _StubTask(id: 'a', graders: [_NoopGrader()], trialsPerRun: 2),
+        _StubTask(id: 'b', graders: [_NoopGrader()], trialsPerRun: 2),
+      ],
+    );
+
+    test('trialPassRate: empirical pass count / total', () {
+      final report = EvalRunReport(
+        runName: 'r',
+        suite: suiteOf(SuiteKind.mixed),
+        trials: [
+          makeTrialResult(
+            runName: 'r',
+            suiteName: 's',
+            taskId: 'a',
+            trialIndex: 0,
+            scores: [okScore('noop')],
+          ),
+          makeTrialResult(
+            runName: 'r',
+            suiteName: 's',
+            taskId: 'a',
+            trialIndex: 1,
+            scores: [failScore('noop')],
+          ),
+          makeTrialResult(
+            runName: 'r',
+            suiteName: 's',
+            taskId: 'b',
+            trialIndex: 0,
+            scores: [okScore('noop')],
+          ),
+          makeTrialResult(
+            runName: 'r',
+            suiteName: 's',
+            taskId: 'b',
+            trialIndex: 1,
+            scores: [okScore('noop')],
+          ),
+        ],
+        startedAt: DateTime(2025),
+        endedAt: DateTime(2025).add(const Duration(seconds: 1)),
+      );
+      expect(report.trialPassRate, 0.75);
+    });
+
+    test(
+      'taskPassRate for capability suites: at least one trial passes per task',
+      () {
+        final report = EvalRunReport(
+          runName: 'r',
+          suite: suiteOf(SuiteKind.capability),
+          trials: [
+            // task a: 1 of 2 pass → counts as passed in capability suite
+            makeTrialResult(
+              runName: 'r',
+              suiteName: 's',
+              taskId: 'a',
+              trialIndex: 0,
+              scores: [okScore('noop')],
+            ),
+            makeTrialResult(
+              runName: 'r',
+              suiteName: 's',
+              taskId: 'a',
+              trialIndex: 1,
+              scores: [failScore('noop')],
+            ),
+            // task b: 0 of 2 pass → fails
+            makeTrialResult(
+              runName: 'r',
+              suiteName: 's',
+              taskId: 'b',
+              trialIndex: 0,
+              scores: [failScore('noop')],
+            ),
+            makeTrialResult(
+              runName: 'r',
+              suiteName: 's',
+              taskId: 'b',
+              trialIndex: 1,
+              scores: [failScore('noop')],
+            ),
+          ],
+          startedAt: DateTime(2025),
+          endedAt: DateTime(2025),
+        );
+        expect(report.taskPassRate, 0.5);
+      },
+    );
+
+    test(
+      'taskPassRate for regression suites: every trial must pass per task',
+      () {
+        final report = EvalRunReport(
+          runName: 'r',
+          suite: suiteOf(SuiteKind.regression),
+          trials: [
+            // task a: 1 of 2 pass → fails in regression suite
+            makeTrialResult(
+              runName: 'r',
+              suiteName: 's',
+              taskId: 'a',
+              trialIndex: 0,
+              scores: [okScore('noop')],
+            ),
+            makeTrialResult(
+              runName: 'r',
+              suiteName: 's',
+              taskId: 'a',
+              trialIndex: 1,
+              scores: [failScore('noop')],
+            ),
+            // task b: 2 of 2 pass → passes
+            makeTrialResult(
+              runName: 'r',
+              suiteName: 's',
+              taskId: 'b',
+              trialIndex: 0,
+              scores: [okScore('noop')],
+            ),
+            makeTrialResult(
+              runName: 'r',
+              suiteName: 's',
+              taskId: 'b',
+              trialIndex: 1,
+              scores: [okScore('noop')],
+            ),
+          ],
+          startedAt: DateTime(2025),
+          endedAt: DateTime(2025),
+        );
+        expect(report.taskPassRate, 0.5);
+      },
+    );
+
+    test('graderMeans excludes null scores from averages', () {
+      final report = EvalRunReport(
+        runName: 'r',
+        suite: suiteOf(SuiteKind.mixed),
+        trials: [
+          makeTrialResult(
+            runName: 'r',
+            suiteName: 's',
+            taskId: 'a',
+            trialIndex: 0,
+            scores: [okScore('quality', value: 1.0), nullScore('judge')],
+          ),
+          makeTrialResult(
+            runName: 'r',
+            suiteName: 's',
+            taskId: 'a',
+            trialIndex: 1,
+            scores: [okScore('quality', value: 0.5)],
+          ),
+        ],
+        startedAt: DateTime(2025),
+        endedAt: DateTime(2025),
+      );
+      expect(report.graderMeans['quality'], closeTo(0.75, 1e-9));
+      expect(report.graderMeans.containsKey('judge'), isFalse);
+    });
+
+    test('passAtKByTask + passCaretKByTask compute per-task k-tables', () {
+      final report = EvalRunReport(
+        runName: 'r',
+        suite: suiteOf(SuiteKind.mixed),
+        trials: [
+          // a: 1/2 pass
+          makeTrialResult(
+            runName: 'r',
+            suiteName: 's',
+            taskId: 'a',
+            trialIndex: 0,
+            scores: [okScore('noop')],
+          ),
+          makeTrialResult(
+            runName: 'r',
+            suiteName: 's',
+            taskId: 'a',
+            trialIndex: 1,
+            scores: [failScore('noop')],
+          ),
+          // b: 2/2 pass
+          makeTrialResult(
+            runName: 'r',
+            suiteName: 's',
+            taskId: 'b',
+            trialIndex: 0,
+            scores: [okScore('noop')],
+          ),
+          makeTrialResult(
+            runName: 'r',
+            suiteName: 's',
+            taskId: 'b',
+            trialIndex: 1,
+            scores: [okScore('noop')],
+          ),
+        ],
+        startedAt: DateTime(2025),
+        endedAt: DateTime(2025),
+      );
+
+      final passAt = report.passAtKByTask(ks: const [1, 2]);
+      // task a: c=1, n=2 → pass@1 = 1 - C(1,1)/C(2,1) = 0.5; pass@2 = 1 - C(1,2)/C(2,2) = 1 - 0/1 = 1.0
+      expect(passAt['a']![1], closeTo(0.5, 1e-9));
+      expect(passAt['a']![2], closeTo(1.0, 1e-9));
+      // task b: 2/2 → pass@1 = 1.0, pass@2 = 1.0
+      expect(passAt['b']![1], closeTo(1.0, 1e-9));
+      expect(passAt['b']![2], closeTo(1.0, 1e-9));
+
+      final passCk = report.passCaretKByTask(ks: const [1, 2]);
+      // task a: (0.5)^1=0.5; (0.5)^2=0.25
+      expect(passCk['a']![1], closeTo(0.5, 1e-9));
+      expect(passCk['a']![2], closeTo(0.25, 1e-9));
+      // task b: (1.0)^k = 1.0
+      expect(passCk['b']![1], 1.0);
+      expect(passCk['b']![2], 1.0);
+    });
+
+    test('bucketPassRates groups by failure_bucket', () {
+      final report = EvalRunReport(
+        runName: 'r',
+        suite: suiteOf(SuiteKind.mixed),
+        trials: [
+          makeTrialResult(
+            runName: 'r',
+            suiteName: 's',
+            taskId: 'a',
+            trialIndex: 0,
+            scores: [okScore('noop')],
+          ),
+          makeTrialResult(
+            runName: 'r',
+            suiteName: 's',
+            taskId: 'b',
+            trialIndex: 0,
+            scores: [failScore('noop')],
+          ),
+        ],
+        startedAt: DateTime(2025),
+        endedAt: DateTime(2025),
+      );
+      final rates = report.bucketPassRates({'a': 'easy', 'b': 'easy'});
+      expect(rates['easy'], 0.5);
+    });
+
+    test('saturationStatus picks mature & straggler tasks via thresholds', () {
+      // 5 mature + 1 straggler with min trials, both above min threshold
+      final trials = <TrialResult>[
+        // mature_a: 10/10 pass
+        for (var i = 0; i < 10; i++)
+          makeTrialResult(
+            runName: 'r',
+            suiteName: 's',
+            taskId: 'mature_a',
+            trialIndex: i,
+            scores: [okScore('noop')],
+          ),
+        // straggler_a: 0/10 pass
+        for (var i = 0; i < 10; i++)
+          makeTrialResult(
+            runName: 'r',
+            suiteName: 's',
+            taskId: 'straggler_a',
+            trialIndex: i,
+            scores: [failScore('noop')],
+          ),
+      ];
+      final suite = EvalSuite(
+        name: 's',
+        agentName: 'agent_x',
+        kind: SuiteKind.capability,
+        tasks: [
+          _StubTask(id: 'mature_a', graders: [_NoopGrader()], trialsPerRun: 10),
+          _StubTask(
+            id: 'straggler_a',
+            graders: [_NoopGrader()],
+            trialsPerRun: 10,
+          ),
+        ],
+      );
+      final report = EvalRunReport(
+        runName: 'r',
+        suite: suite,
+        trials: trials,
+        startedAt: DateTime(2025),
+        endedAt: DateTime(2025),
+      );
+      final sat = report.saturationStatus(
+        thresholds: const SaturationThresholds(
+          matureTaskPassRate: 0.95,
+          brokenTaskPassRate: 0.0,
+          minTrialsForBrokenJudgment: 10,
+          saturatedSuiteRatio: 0.9,
+        ),
+      );
+      expect(sat.matureTasks, contains('mature_a'));
+      expect(sat.stragglerTasks, contains('straggler_a'));
+      expect(sat.saturatedTaskRatio, closeTo(0.5, 1e-9));
+      expect(sat.suiteSaturated, isFalse); // 0.5 < 0.9
+    });
+
+    test('toMarkdownSummary produces non-empty markdown with key sections', () {
+      final report = EvalRunReport(
+        runName: 'demo',
+        suite: EvalSuite(
+          name: 's',
+          agentName: 'agent_x',
+          kind: SuiteKind.mixed,
+          tasks: [
+            _StubTask(id: 'a', graders: [_NoopGrader()]),
+          ],
+        ),
+        trials: [
+          makeTrialResult(
+            runName: 'demo',
+            suiteName: 's',
+            taskId: 'a',
+            trialIndex: 0,
+            scores: [failScore('quality', value: 0.0, rationale: 'meh')],
+          ),
+        ],
+        startedAt: DateTime(2025),
+        endedAt: DateTime(2025).add(const Duration(seconds: 5)),
+      );
+      final md = report.toMarkdownSummary();
+      expect(md, contains('# Eval Run: `demo`'));
+      expect(md, contains('Top-line metrics'));
+      expect(md, contains('Failed trials'));
+      expect(md, contains('quality'));
+    });
+  });
+}

--- a/test/eval/suite_health_test.dart
+++ b/test/eval/suite_health_test.dart
@@ -1,0 +1,242 @@
+// ignore_for_file: unused_element_parameter
+import 'dart:io';
+
+import 'package:dart_agent_core/eval.dart';
+import 'package:test/test.dart';
+
+import '_helpers.dart';
+
+class _StubTask implements EvalTask {
+  @override
+  final String id;
+  @override
+  final List<Grader> graders;
+  @override
+  final ReferenceSolution? referenceSolution = null;
+  @override
+  final int trialsPerRun;
+  @override
+  final Map<String, String> metadata = const {};
+  @override
+  final Map<String, dynamic> input = const {};
+  @override
+  final String description = '';
+  @override
+  final Duration? timeout = null;
+
+  _StubTask({required this.id, required this.graders, this.trialsPerRun = 10});
+}
+
+class _Noop extends CodeGrader {
+  @override
+  String get name => 'noop';
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async => const [Assertion(description: 'always', passed: true)];
+}
+
+EvalSuite _suite(SuiteKind kind, List<String> taskIds) => EvalSuite(
+  name: 'suite_x',
+  agentName: 'agent_x',  kind: kind,
+  tasks: [
+    for (final id in taskIds) _StubTask(id: id, graders: [_Noop()]),
+  ],
+);
+
+EvalRunReport _runOf({
+  required String name,
+  required SuiteKind kind,
+  required List<String> taskIds,
+  required Map<String, double> taskPassRates,
+  required DateTime startedAt,
+  int trialsPerTask = 10,
+}) {
+  final trials = <TrialResult>[];
+  for (final id in taskIds) {
+    final pr = taskPassRates[id] ?? 0.0;
+    final passing = (pr * trialsPerTask).round();
+    for (var i = 0; i < trialsPerTask; i++) {
+      trials.add(
+        makeTrialResult(
+          runName: name,
+          suiteName: 'suite_x',
+          taskId: id,
+          trialIndex: i,
+          scores: [i < passing ? okScore('noop') : failScore('noop')],
+          startedAt: startedAt,
+        ),
+      );
+    }
+  }
+  return EvalRunReport(
+    runName: name,
+    suite: _suite(kind, taskIds),
+    trials: trials,
+    startedAt: startedAt,
+    endedAt: startedAt.add(const Duration(seconds: 1)),
+  );
+}
+
+void main() {
+  group('SuiteHealthAnalyzer', () {
+    late Directory tmp;
+    late FileReportStore store;
+
+    setUp(() async {
+      tmp = await Directory.systemTemp.createTemp('health_');
+      store = FileReportStore(tmp);
+    });
+    tearDown(() async {
+      if (await tmp.exists()) await tmp.delete(recursive: true);
+    });
+
+    test('throws when no runs are persisted for the suite', () async {
+      final analyzer = SuiteHealthAnalyzer(store);
+      await expectLater(
+        analyzer.analyze(suiteName: 'suite_x'),
+        throwsStateError,
+      );
+    });
+
+    test(
+      'flags graduation candidates after N consecutive runs at mature pass rate',
+      () async {
+        // Persist 5 runs where task "easy" stays at 1.0 and task "hard" at 0.5.
+        const consecRuns = 5;
+        for (var i = 0; i < consecRuns; i++) {
+          final r = _runOf(
+            name: 'r$i',
+            kind: SuiteKind.capability,
+            taskIds: const ['easy', 'hard'],
+            taskPassRates: const {'easy': 1.0, 'hard': 0.5},
+            startedAt: DateTime(2025, 1, 1).add(Duration(days: i)),
+          );
+          await store.save(r);
+        }
+        final analyzer = SuiteHealthAnalyzer(
+          store,
+          thresholds: const SaturationThresholds(
+            matureTaskPassRate: 0.95,
+            consecutiveRunsForGraduation: 5,
+            minTrialsForBrokenJudgment: 10,
+            saturatedSuiteRatio: 0.9,
+          ),
+        );
+        final report = await analyzer.analyze(suiteName: 'suite_x');
+        expect(report.analyzedRunCount, 5);
+        expect(
+          report.graduationCandidates.map((g) => g.taskId),
+          containsAll(['easy']),
+        );
+        expect(
+          report.graduationCandidates.map((g) => g.taskId),
+          isNot(contains('hard')),
+        );
+        // Difficulty histogram populated.
+        expect(report.difficultyHistogram, isNotEmpty);
+      },
+    );
+
+    test(
+      'detects broken-task candidates: mostly-failing across runs above min',
+      () async {
+        for (var i = 0; i < 3; i++) {
+          await store.save(
+            _runOf(
+              name: 'r$i',
+              kind: SuiteKind.capability,
+              taskIds: const ['broken'],
+              taskPassRates: const {'broken': 0.0},
+              startedAt: DateTime(2025, 1, 1).add(Duration(days: i)),
+              trialsPerTask: 10,
+            ),
+          );
+        }
+        final analyzer = SuiteHealthAnalyzer(
+          store,
+          thresholds: const SaturationThresholds(
+            brokenTaskPassRate: 0.0,
+            minTrialsForBrokenJudgment: 10,
+          ),
+        );
+        final report = await analyzer.analyze(suiteName: 'suite_x');
+        expect(report.brokenTaskCandidates, hasLength(1));
+        expect(report.brokenTaskCandidates.first.taskId, 'broken');
+        expect(report.brokenTaskCandidates.first.passRate, 0.0);
+      },
+    );
+
+    test('currentlySaturated reflects latest run only', () async {
+      // Older run: 1 mature out of 2.
+      await store.save(
+        _runOf(
+          name: 'old',
+          kind: SuiteKind.capability,
+          taskIds: const ['a', 'b'],
+          taskPassRates: const {'a': 1.0, 'b': 0.0},
+          startedAt: DateTime(2024),
+        ),
+      );
+      // Newer run: 2/2 mature → saturated.
+      await store.save(
+        _runOf(
+          name: 'new',
+          kind: SuiteKind.capability,
+          taskIds: const ['a', 'b'],
+          taskPassRates: const {'a': 1.0, 'b': 1.0},
+          startedAt: DateTime(2026),
+        ),
+      );
+      final analyzer = SuiteHealthAnalyzer(store);
+      final report = await analyzer.analyze(suiteName: 'suite_x');
+      expect(report.currentSaturationRatio, 1.0);
+      expect(report.currentlySaturated, isTrue);
+    });
+
+    test(
+      'computeSaturationStatus on a single run mirrors EvalRunReport.saturationStatus',
+      () async {
+        final r = _runOf(
+          name: 'r',
+          kind: SuiteKind.capability,
+          taskIds: const ['a', 'b'],
+          taskPassRates: const {'a': 1.0, 'b': 0.0},
+          startedAt: DateTime(2025),
+        );
+        const analyzer = SuiteHealthAnalyzer(_NullStore());
+        final sat = analyzer.computeSaturationStatus(r);
+        expect(sat.matureTasks, contains('a'));
+        expect(sat.saturatedTaskRatio, closeTo(0.5, 1e-9));
+      },
+    );
+  });
+}
+
+/// Stub store for the synchronous `computeSaturationStatus` test which
+/// doesn't touch persisted state.
+class _NullStore implements ReportStore {
+  const _NullStore();
+
+  @override
+  Future<PersistedRunReport?> load(String runName) async => null;
+  @override
+  Future<List<RunIndexEntry>> listRecent({
+    required String suiteName,
+    int limit = 10,
+  }) async => const [];
+  @override
+  Future<List<PersistedRunReport>> loadRecent({
+    required String suiteName,
+    int limit = 10,
+  }) async => const [];
+  @override
+  Future<List<String>> listRunNames({String? suiteFilter, int? limit}) async =>
+      const [];
+  @override
+  Future<void> save(EvalRunReport report) async {}
+}

--- a/test/eval/suite_loader_test.dart
+++ b/test/eval/suite_loader_test.dart
@@ -1,0 +1,391 @@
+// ignore_for_file: unused_element_parameter
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_agent_core/eval.dart';
+import 'package:test/test.dart';
+
+class _StubGrader extends CodeGrader {
+  @override
+  final String name;
+  final Map<String, dynamic> config;
+  _StubGrader({required this.name, this.config = const {}});
+
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async {
+    return [Assertion(description: '$name with config $config', passed: true)];
+  }
+}
+
+void _writeJson(File f, Map<String, dynamic> body) {
+  f.parent.createSync(recursive: true);
+  f.writeAsStringSync(const JsonEncoder.withIndent('  ').convert(body));
+}
+
+Map<String, dynamic> _validTaskJson({
+  String id = 't1',
+  String agentName = 'agent_x',
+  List<Map<String, dynamic>>? graders,
+  Map<String, dynamic>? metadata,
+}) {
+  return {
+    'id': id,
+    'agent_name': agentName,
+    'description': 'desc',
+    'input': {'prompt': 'hi'},
+    'metadata': ?metadata,
+    'graders':
+        graders ??
+        [
+          {
+            'name': 'stub',
+            'config': {'k': 'v'},
+          },
+        ],
+  };
+}
+
+void main() {
+  group('GraderRegistry', () {
+    test('register + build round-trips with config', () {
+      final reg = GraderRegistry();
+      reg.register('stub', (cfg) => _StubGrader(name: 'stub', config: cfg));
+      final g = reg.build('stub', const {'a': 1});
+      expect(g.name, 'stub');
+      expect((g as _StubGrader).config, {'a': 1});
+    });
+
+    test('build of unregistered name throws', () {
+      final reg = GraderRegistry();
+      expect(() => reg.build('missing', const {}), throwsA(isA<StateError>()));
+    });
+
+    test('contains() and registeredNames', () {
+      final reg = GraderRegistry();
+      reg.register('a', (_) => _StubGrader(name: 'a'));
+      reg.register('b', (_) => _StubGrader(name: 'b'));
+      expect(reg.contains('a'), isTrue);
+      expect(reg.contains('zzz'), isFalse);
+      expect(reg.registeredNames.toList(), ['a', 'b']);
+    });
+
+    test('register overwrites prior registration', () {
+      final reg = GraderRegistry();
+      reg.register('x', (_) => _StubGrader(name: 'x'));
+      reg.register('x', (_) => _StubGrader(name: 'x_v2'));
+      expect(reg.build('x', const {}).name, 'x_v2');
+    });
+  });
+
+  group('loadEvalSuiteFromDir — happy path', () {
+    late Directory tmp;
+    late GraderRegistry reg;
+
+    setUp(() async {
+      tmp = await Directory.systemTemp.createTemp('suite_loader_');
+      reg = GraderRegistry()
+        ..register('stub', (cfg) => _StubGrader(name: 'stub', config: cfg));
+    });
+
+    tearDown(() async {
+      if (await tmp.exists()) await tmp.delete(recursive: true);
+    });
+
+    test(
+      'flat layout: tasks/*.json all become tasks in alphabetical order',
+      () async {
+        _writeJson(File('${tmp.path}/suite.json'), {
+          'name': 's',
+          'agent_name': 'agent_x',
+          'kind': 'mixed',
+        });
+        _writeJson(
+          File('${tmp.path}/tasks/b_task.json'),
+          _validTaskJson(id: 'b'),
+        );
+        _writeJson(
+          File('${tmp.path}/tasks/a_task.json'),
+          _validTaskJson(id: 'a'),
+        );
+
+        final suite = loadEvalSuiteFromDir(tmp, graderRegistry: reg);
+        expect(suite.name, 's');
+        expect(suite.kind, SuiteKind.mixed);
+        // Stable order = alphabetical by path.
+        expect(suite.tasks.map((t) => t.id).toList(), ['a', 'b']);
+        // suite.validate() should be clean.
+        expect(suite.validate(), isEmpty);
+      },
+    );
+
+    test('nested layout: positive/ + negative/ folders both load', () async {
+      _writeJson(File('${tmp.path}/suite.json'), {
+        'name': 'capability',
+        'agent_name': 'agent_x',
+        'kind': 'capability',
+      });
+      _writeJson(
+        File('${tmp.path}/tasks/positive/p1.json'),
+        _validTaskJson(id: 'p1'),
+      );
+      _writeJson(
+        File('${tmp.path}/tasks/positive/p2.json'),
+        _validTaskJson(id: 'p2'),
+      );
+      _writeJson(
+        File('${tmp.path}/tasks/negative/n1.json'),
+        _validTaskJson(id: 'n1'),
+      );
+
+      final suite = loadEvalSuiteFromDir(tmp, graderRegistry: reg);
+      expect(suite.tasks.map((t) => t.id).toSet(), {'p1', 'p2', 'n1'});
+    });
+
+    test(
+      'reference_solution + timeout_seconds + trials_per_run decode',
+      () async {
+        _writeJson(File('${tmp.path}/suite.json'), {
+          'name': 's',
+          'agent_name': 'agent_x',
+          'kind': 'mixed',
+          'requireReferenceSolution': true,
+        });
+        _writeJson(File('${tmp.path}/tasks/t.json'), {
+          ..._validTaskJson(),
+          'reference_solution': {
+            'expected_outcome': {'k': 'v'},
+            'source': 'manual',
+          },
+          'trials_per_run': 3,
+          'timeout_seconds': 90,
+        });
+
+        final suite = loadEvalSuiteFromDir(tmp, graderRegistry: reg);
+        final t = suite.tasks.single;
+        expect(t.referenceSolution, isNotNull);
+        expect(t.referenceSolution!.expectedOutcome, {'k': 'v'});
+        expect(t.referenceSolution!.source, ReferenceSolutionSource.manual);
+        expect(t.trialsPerRun, 3);
+        expect(t.timeout, const Duration(seconds: 90));
+        expect(suite.validate(), isEmpty);
+      },
+    );
+
+    test('graders are resolved via the registry with their config', () async {
+      _writeJson(File('${tmp.path}/suite.json'), {
+        'name': 's',
+        'agent_name': 'agent_x',
+        'kind': 'mixed',
+      });
+      _writeJson(File('${tmp.path}/tasks/t.json'), {
+        ..._validTaskJson(
+          graders: [
+            {
+              'name': 'stub',
+              'config': {'a': 1},
+            },
+            {
+              'name': 'stub',
+              'config': {'a': 2},
+            },
+          ],
+        ),
+      });
+      final suite = loadEvalSuiteFromDir(tmp, graderRegistry: reg);
+      final graders = suite.tasks.single.graders.cast<_StubGrader>();
+      expect(graders, hasLength(2));
+      expect(graders[0].config, {'a': 1});
+      expect(graders[1].config, {'a': 2});
+    });
+
+    test('metadata strings are coerced from non-string values', () async {
+      _writeJson(File('${tmp.path}/suite.json'), {
+        'name': 's',
+        'agent_name': 'agent_x',
+        'kind': 'mixed',
+      });
+      _writeJson(
+        File('${tmp.path}/tasks/t.json'),
+        _validTaskJson(metadata: const {'difficulty': 1, 'tag': 'easy'}),
+      );
+      final suite = loadEvalSuiteFromDir(tmp, graderRegistry: reg);
+      expect(suite.tasks.single.metadata['difficulty'], '1');
+      expect(suite.tasks.single.metadata['tag'], 'easy');
+    });
+  });
+
+  group('loadEvalSuiteFromDir — error paths', () {
+    late Directory tmp;
+    late GraderRegistry reg;
+
+    setUp(() async {
+      tmp = await Directory.systemTemp.createTemp('suite_loader_err_');
+      reg = GraderRegistry()
+        ..register('stub', (_) => _StubGrader(name: 'stub'));
+    });
+
+    tearDown(() async {
+      if (await tmp.exists()) await tmp.delete(recursive: true);
+    });
+
+    test('non-existent directory throws ArgumentError', () async {
+      final missing = Directory('${tmp.path}/does_not_exist');
+      expect(
+        () => loadEvalSuiteFromDir(missing, graderRegistry: reg),
+        throwsArgumentError,
+      );
+    });
+
+    test('missing suite.json throws StateError', () async {
+      Directory('${tmp.path}/tasks').createSync();
+      _writeJson(File('${tmp.path}/tasks/t.json'), _validTaskJson());
+      expect(
+        () => loadEvalSuiteFromDir(tmp, graderRegistry: reg),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('invalid suite kind throws StateError', () async {
+      _writeJson(File('${tmp.path}/suite.json'), {
+        'name': 's',
+        'agent_name': 'agent_x',
+        'kind': 'totally_unknown',
+      });
+      _writeJson(File('${tmp.path}/tasks/t.json'), _validTaskJson());
+      expect(
+        () => loadEvalSuiteFromDir(tmp, graderRegistry: reg),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('missing agent_name throws StateError', () async {
+      _writeJson(File('${tmp.path}/suite.json'), {
+        'name': 's',
+        'kind': 'mixed',
+      });
+      _writeJson(File('${tmp.path}/tasks/t.json'), _validTaskJson());
+      expect(
+        () => loadEvalSuiteFromDir(tmp, graderRegistry: reg),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('missing tasks/ directory throws StateError', () async {
+      _writeJson(File('${tmp.path}/suite.json'), {
+        'name': 's',
+        'agent_name': 'agent_x',
+        'kind': 'mixed',
+      });
+      expect(
+        () => loadEvalSuiteFromDir(tmp, graderRegistry: reg),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('empty tasks/ directory throws StateError', () async {
+      _writeJson(File('${tmp.path}/suite.json'), {
+        'name': 's',
+        'agent_name': 'agent_x',
+        'kind': 'mixed',
+      });
+      Directory('${tmp.path}/tasks').createSync();
+      expect(
+        () => loadEvalSuiteFromDir(tmp, graderRegistry: reg),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('malformed task JSON includes file path in the error', () async {
+      _writeJson(File('${tmp.path}/suite.json'), {
+        'name': 's',
+        'agent_name': 'agent_x',
+        'kind': 'mixed',
+      });
+      File('${tmp.path}/tasks/broken.json')
+        ..parent.createSync(recursive: true)
+        ..writeAsStringSync('{ this is not json');
+      try {
+        loadEvalSuiteFromDir(tmp, graderRegistry: reg);
+        fail('expected throw');
+      } on StateError catch (e) {
+        expect(e.message, contains('broken.json'));
+      }
+    });
+
+    test('reference to unregistered grader names known graders', () async {
+      _writeJson(File('${tmp.path}/suite.json'), {
+        'name': 's',
+        'agent_name': 'agent_x',
+        'kind': 'mixed',
+      });
+      _writeJson(File('${tmp.path}/tasks/t.json'), {
+        ..._validTaskJson(
+          graders: [
+            {'name': 'does_not_exist'},
+          ],
+        ),
+      });
+      try {
+        loadEvalSuiteFromDir(tmp, graderRegistry: reg);
+        fail('expected throw');
+      } on StateError catch (e) {
+        expect(e.message, contains('does_not_exist'));
+        expect(e.message, contains('stub'));
+      }
+    });
+
+    test('missing required field "id" throws StateError', () async {
+      _writeJson(File('${tmp.path}/suite.json'), {
+        'name': 's',
+        'agent_name': 'agent_x',
+        'kind': 'mixed',
+      });
+      final body = _validTaskJson();
+      body.remove('id');
+      _writeJson(File('${tmp.path}/tasks/t.json'), body);
+      expect(
+        () => loadEvalSuiteFromDir(tmp, graderRegistry: reg),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('empty graders list throws StateError', () async {
+      _writeJson(File('${tmp.path}/suite.json'), {
+        'name': 's',
+        'agent_name': 'agent_x',
+        'kind': 'mixed',
+      });
+      _writeJson(
+        File('${tmp.path}/tasks/t.json'),
+        _validTaskJson(graders: const []),
+      );
+      expect(
+        () => loadEvalSuiteFromDir(tmp, graderRegistry: reg),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('requireReferenceSolution=true + missing reference_solution → suite '
+        'validation problem', () async {
+      _writeJson(File('${tmp.path}/suite.json'), {
+        'name': 's',
+        'agent_name': 'agent_x',
+        'kind': 'capability',
+        'requireReferenceSolution': true,
+      });
+      _writeJson(File('${tmp.path}/tasks/t.json'), _validTaskJson());
+      final suite = loadEvalSuiteFromDir(tmp, graderRegistry: reg);
+      final problems = suite.validate();
+      expect(
+        problems.any((p) => p.contains('missing referenceSolution')),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/eval/transcripts_cli_test.dart
+++ b/test/eval/transcripts_cli_test.dart
@@ -1,0 +1,281 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_agent_core/eval.dart';
+import 'package:test/test.dart';
+
+import '_helpers.dart';
+
+class _StubTask implements EvalTask {
+  @override
+  final String id;
+  @override
+  final List<Grader> graders;
+  @override
+  final ReferenceSolution? referenceSolution = null;
+  @override
+  final int trialsPerRun = 1;
+  @override
+  final Map<String, String> metadata = const {};
+  @override
+  final Map<String, dynamic> input = const {};
+  @override
+  final String description = '';
+  @override
+  final Duration? timeout = null;
+  _StubTask({required this.id, required this.graders});
+}
+
+class _NoopGrader extends CodeGrader {
+  @override
+  String get name => 'noop';
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async => const [Assertion(description: 'always', passed: true)];
+}
+
+EvalSuite _suite(List<String> ids) => EvalSuite(
+  name: 's',
+  agentName: 'agent_x',  kind: SuiteKind.mixed,
+  tasks: [
+    for (final id in ids) _StubTask(id: id, graders: [_NoopGrader()]),
+  ],
+);
+
+EvalRunReport _run({
+  required String name,
+  required Map<String, double> taskPassRates,
+  int trialsPerTask = 2,
+  DateTime? startedAt,
+}) {
+  final ids = taskPassRates.keys.toList();
+  final trials = <TrialResult>[];
+  for (final id in ids) {
+    final pr = taskPassRates[id]!;
+    final passing = (pr * trialsPerTask).round();
+    for (var i = 0; i < trialsPerTask; i++) {
+      trials.add(
+        makeTrialResult(
+          runName: name,
+          suiteName: 's',
+          taskId: id,
+          trialIndex: i,
+          scores: [i < passing ? okScore('noop') : failScore('noop')],
+        ),
+      );
+    }
+  }
+  final s = startedAt ?? DateTime(2025);
+  return EvalRunReport(
+    runName: name,
+    suite: _suite(ids),
+    trials: trials,
+    startedAt: s,
+    endedAt: s.add(const Duration(seconds: 1)),
+  );
+}
+
+/// Run the transcript viewer with stdout/stderr captured. Returns the
+/// (stdout, stderr, exitCode) tuple.
+Future<({String out, String err, int code})> _runViewer(
+  List<String> args,
+) async {
+  final stdoutBuffer = StringBuffer();
+  final stderrBuffer = StringBuffer();
+  final code = await runZonedTranscriptViewer(
+    args,
+    onStdout: (s) => stdoutBuffer.write(s),
+    onStderr: (s) => stderrBuffer.write(s),
+  );
+  return (
+    out: stdoutBuffer.toString(),
+    err: stderrBuffer.toString(),
+    code: code,
+  );
+}
+
+/// We don't want stdout to actually print during tests; the viewer prints
+/// to the global stdout. We capture by overriding. The viewer uses
+/// dart:io stdout/stderr directly so we use IOOverrides.
+Future<int> runZonedTranscriptViewer(
+  List<String> args, {
+  required void Function(String) onStdout,
+  required void Function(String) onStderr,
+}) async {
+  return IOOverrides.runZoned<Future<int>>(
+    () => runTranscriptViewer(args),
+    stdout: () => _CapturingStdout(onStdout),
+    stderr: () => _CapturingStdout(onStderr),
+  );
+}
+
+/// Minimal Stdout wrapper that delegates writes to a callback.
+class _CapturingStdout implements Stdout {
+  final void Function(String) sink;
+  _CapturingStdout(this.sink);
+
+  @override
+  void writeln([Object? object = '']) => sink('${object ?? ''}\n');
+
+  @override
+  void write(Object? object) => sink('${object ?? ''}');
+
+  @override
+  void writeAll(Iterable objects, [String separator = '']) {
+    sink(objects.map((e) => '$e').join(separator));
+  }
+
+  @override
+  void writeCharCode(int charCode) => sink(String.fromCharCode(charCode));
+
+  @override
+  Future close() async {}
+  @override
+  Future get done => Future.value();
+  @override
+  Future flush() async {}
+
+  @override
+  Encoding encoding = utf8;
+  @override
+  bool get hasTerminal => false;
+  @override
+  IOSink get nonBlocking => throw UnimplementedError();
+  @override
+  bool get supportsAnsiEscapes => false;
+  @override
+  int get terminalColumns => 80;
+  @override
+  int get terminalLines => 24;
+  @override
+  void add(List<int> data) => sink(utf8.decode(data));
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {}
+  @override
+  Future addStream(Stream<List<int>> stream) async {}
+  Future<dynamic> any(bool Function(int) test) => throw UnimplementedError();
+  Stream<List<int>> asBroadcastStream({
+    void Function(StreamSubscription<List<int>>)? onListen,
+    void Function(StreamSubscription<List<int>>)? onCancel,
+  }) => throw UnimplementedError();
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  group('runTranscriptViewer', () {
+    late Directory tmp;
+    late FileReportStore store;
+
+    setUp(() async {
+      tmp = await Directory.systemTemp.createTemp('viewer_');
+      store = FileReportStore(tmp);
+
+      // Persist two runs so list / show / diff / export all have data.
+      await store.save(
+        _run(
+          name: 'main',
+          taskPassRates: const {'task_x': 1.0, 'task_y': 0.5},
+          startedAt: DateTime(2024),
+        ),
+      );
+      await store.save(
+        _run(
+          name: 'pr',
+          taskPassRates: const {'task_x': 0.0, 'task_y': 1.0},
+          startedAt: DateTime(2026),
+        ),
+      );
+    });
+
+    tearDown(() async {
+      if (await tmp.exists()) await tmp.delete(recursive: true);
+    });
+
+    test('list (no filter) prints all run names newest-first', () async {
+      final r = await _runViewer(['list', '--store', tmp.path]);
+      expect(r.code, 0);
+      // Most recent (`pr`) first.
+      final lines = r.out.trim().split('\n');
+      expect(lines, containsAllInOrder(['pr', 'main']));
+    });
+
+    test(
+      'show prints scores, outcome, transcript metrics for a trial',
+      () async {
+        final r = await _runViewer([
+          'show',
+          '--store',
+          tmp.path,
+          '--trial',
+          'main/task_x#0',
+        ]);
+        expect(r.code, 0);
+        expect(r.out, contains('Trial: main / task_x #0'));
+        expect(r.out, contains('Status: passed'));
+        expect(r.out, contains('Scores'));
+        expect(r.out, contains('Outcome'));
+        expect(r.out, contains('Transcript metrics'));
+      },
+    );
+
+    test('show with --format json emits parseable JSON', () async {
+      final r = await _runViewer([
+        'show',
+        '--store',
+        tmp.path,
+        '--trial',
+        'main/task_x#0',
+        '--format',
+        'json',
+      ]);
+      expect(r.code, 0);
+      final j = jsonDecode(r.out.trim()) as Map<String, dynamic>;
+      expect(j['trial'], isA<Map>());
+      expect(j['scores'], isA<List>());
+    });
+
+    test('diff prints both runs side-by-side for a task', () async {
+      final r = await _runViewer([
+        'diff',
+        '--store',
+        tmp.path,
+        '--task',
+        'task_x',
+        '--runs',
+        'main,pr',
+      ]);
+      expect(r.code, 0);
+      expect(r.out, contains('main'));
+      expect(r.out, contains('pr'));
+      expect(r.out, contains('PASS'));
+      expect(r.out, contains('FAIL'));
+    });
+
+    test('export markdown contains task ids and per-trial scores', () async {
+      final r = await _runViewer([
+        'export',
+        '--store',
+        tmp.path,
+        '--run',
+        'main',
+      ]);
+      expect(r.code, 0);
+      expect(r.out, contains('# Run `main`'));
+      expect(r.out, contains('task_x'));
+      expect(r.out, contains('task_y'));
+    });
+
+    test('unknown command exits with code 2', () async {
+      final r = await _runViewer(['bogus']);
+      expect(r.code, 2);
+      expect(r.err, contains('unknown command'));
+    });
+  });
+}

--- a/test/eval/trial_test.dart
+++ b/test/eval/trial_test.dart
@@ -1,0 +1,42 @@
+import 'package:dart_agent_core/eval.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Trial.cacheSalt', () {
+    Trial t({
+      String runName = 'r',
+      String taskId = 'task_x',
+      int trialIndex = 0,
+    }) => Trial(
+      runName: runName,
+      suiteName: 's',
+      taskId: taskId,
+      trialIndex: trialIndex,
+      startedAt: DateTime(2025),
+      endedAt: DateTime(2025),
+      status: TrialStatus.passed,
+    );
+
+    test('format is taskId#trialIndex', () {
+      expect(t(taskId: 'foo', trialIndex: 3).cacheSalt, 'foo#3');
+    });
+
+    test('does NOT include runName (cross-run replay friendly)', () {
+      final a = t(runName: 'run_a').cacheSalt;
+      final b = t(runName: 'run_b').cacheSalt;
+      expect(a, b);
+    });
+
+    test('different trialIndex → different salt', () {
+      final i0 = t(trialIndex: 0).cacheSalt;
+      final i1 = t(trialIndex: 1).cacheSalt;
+      expect(i0, isNot(i1));
+    });
+
+    test('different taskId → different salt', () {
+      final a = t(taskId: 'a').cacheSalt;
+      final b = t(taskId: 'b').cacheSalt;
+      expect(a, isNot(b));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds an [Anthropic-aligned](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents) evaluation subsystem to `dart_agent_core`, exposed through a separate `package:dart_agent_core/eval.dart` entry point — apps that don't need eval primitives don't pay the import cost, and existing imports stay unchanged.

The subsystem covers the full Anthropic eight-step workflow (manual checks → unambiguous tasks → balanced sets → robust harness → grader design → run / report → suite health → judge calibration), with both code-defined and file-system-defined suites.

## What's in this PR

**Library (`lib/src/eval/`)**

| Area | Components |
|---|---|
| core | `EvalTask` / `EvalSuite` / `EvalRunner` / `Trial` / `Outcome` / `Transcript` / `EvalEnvironment` / `AgentHarnessFactory` |
| graders | `RuleGrader` / `ScriptGrader` / `ClassificationGrader` (code), `ModelGrader` (LLM judge), `HumanGrader` |
| llm | hash-based `RecordingLLMClient` / `ReplayLLMClient`, `FileRecordingStore`, `RpmRateLimitGate` / `TpmRateLimitGate` / `NoopRateLimitGate` |
| metrics | `pass@k` / `pass^k`, `ClassificationMetrics` (P / R / F1 / accuracy), `SaturationStatus` |
| reporting | `ReportStore` / `FileReportStore`, `diffRunReports`, markdown + JSON output |
| suite_health | `SuiteHealthAnalyzer` — graduation / broken-task detection across runs |
| calibration | `JudgeCalibrator` — Spearman / Pearson / MAE |
| loaders | `loadEvalSuiteFromDir`, `JsonEvalTask`, `GraderRegistry` |
| observability | `JsonlTraceExporter` / `CompositeTraceExporter`, `runTranscriptViewer` |

**Examples**

- `example/min_eval/` — 130-line self-contained echo-agent demo
- `example/eval_demo/`
  - `calculator/` — code-defined suite, 4 arithmetic tools, 3 tasks
  - `card_agent/` — code-defined suite simulating a real card-creation agent
  - `pkm_agent/` — **JSON file-tree-defined suite** (`suites/pkm_capability/{suite.json, tasks/positive/*.json, tasks/negative/*.json}`)
  - `_shared/agent_harness.dart` — common harness reused by all three demos
  - `main.dart` — `--suite calculator|card_agent|pkm_agent|all`, `--mode live|record|replay`, `--rpm`, `--concurrency`

**CLI**

- `bin/transcripts.dart` — thin wrapper over `runTranscriptViewer` for `list` / `show` / `diff` / `export` of persisted run reports

**Docs**

- `doc/eval-guide.zh-CN.md` — usage guide

## Test plan

```
dart analyze    →  No issues found!
dart test       →  130/130 passing
```

End-to-end against an OpenAI-compatible endpoint (`anthropic/claude-opus-4.7`):

| Suite | Tasks | Trials | Task pass | Trial pass |
|---|---|---|---|---|
| calculator_demo  | 3 | 6 | 100% | 100% |
| card_agent_demo  | 4 | 8 |  50% |  75% |
| pkm_agent_demo   | 4 | 8 |  75% |  75% |

Replay mode against the recordings from the live run produces **bit-identical** results with zero outbound network requests.

## Notes for reviewers

- `lib/eval.dart` is a separate library entry point. `dart_agent_core.dart` is unchanged, so existing consumers see no API surface change.
- `.gitignore` adds `.eval_reports/` / `.eval_traces/` / `.eval_recordings/` (eval runner local outputs).
- Each `Trial` carries a `cacheSalt` of the form `taskId#trialIndex`, so `trialsPerRun > 1` produces independent cache keys (no collapse during record/replay).
