### PR TITLE
feat(eval): record transcripts in runner

### DIFF
--- a/doc/eval-guide.md
+++ b/doc/eval-guide.md
@@ -43,10 +43,11 @@ Strictly aligned with Anthropic's terminology:
 | **Agent Harness** | `AgentHarnessFactory` / `AgentHarnessSession` | The scaffolding that lets a model behave as an agent (you provide it) |
 | **Evaluation Suite** | `EvalSuite` | A set of tasks targeting one capability or behavior |
 
-Design principle (Anthropic Step 5): **default to grading the Outcome,
-not the Transcript**. "flight booked" should be checked against the
-database, not against whether the agent said "Your flight has been
-booked".
+Design principle (Anthropic Step 5): **grade the right evidence**. For
+final-world-state questions, use the `Outcome` ("flight booked" should
+be checked against the database, not against whether the agent said it
+was booked). For process questions, use the `Transcript` (for example,
+whether the agent read before writing or called a required tool).
 
 </br>
 
@@ -174,17 +175,25 @@ abstract class AgentHarnessSession {
 The harness is the **only** layer that knows what your agent looks
 like: it instantiates `StatefulAgent`, registers `Tool[]`, calls
 `agent.run([UserMessage(task.input['prompt'])])`, and once it returns,
-assembles a transcript and an outcome from the agent state and
-workspace.
+collects the final `Outcome` from the workspace or application
+services. The generic execution trace is recorded automatically by the
+`EvalRunner`'s built-in `EvalTranscriptRecorder` through
+`context.controller`; harnesses must reuse that controller.
 
-`run()` must return **two** things:
+`run()` must return **two** things. In the common case, the business
+harness only needs to fill `Outcome`; it can return an empty
+`Transcript`, and the runner will replace it with the recorder
+snapshot:
 
 - `Transcript` — what the agent **did**: message sequence, tool calls,
-  retry / error events, turns / token counters. **Graders should
-  generally not look here** (path, not result)
+  retry / error events, turns / token counters. The framework records
+  this by default; construct it manually only when you need to override
+  or add custom trace data. Graders should use it whenever the score is
+  about process, tool use, messages, events, or metrics.
 - `Outcome` — what the environment **ended up like**.
   `environmentState` is an arbitrary map whose schema is a contract
-  between you and your graders. **Graders look here by default**
+  between you and your graders. Graders should use it whenever the
+  score is about final state.
 
 Common mistakes when populating `Outcome.environmentState`:
 
@@ -211,7 +220,7 @@ A real example from the PKM agent demo
 
 ```dart
 // Fact-collection code at the end of Harness.run()
-Outcome _capturePkmOutcome(Directory ws, SessionState state) {
+Outcome _capturePkmOutcome(Directory ws) {
   // 1. Walk the workspace
   final created = <String>[];
   final snippets = <String, String>{};
@@ -234,13 +243,15 @@ Outcome _capturePkmOutcome(Directory ws, SessionState state) {
 
   // 3. Check sentinel files (some tools leave side-effect markers)
   final skipped = File('${ws.path}/skipped.txt').existsSync();
-  final insightFile = Directory('${ws.path}/insights').listSync().firstOrNull;
+  final insightsDir = Directory('${ws.path}/insights');
+  final updatedInsight =
+      insightsDir.existsSync() && insightsDir.listSync().whereType<File>().isNotEmpty;
 
   return Outcome(
     environmentState: {
       'wrote_files': created,
       'fact_ids_in_files': factIds.toList(),
-      'updated_insight': insightFile != null,
+      'updated_insight': updatedInsight,
       'skipped': skipped,
     },
     workspaceDiff: WorkspaceDiff(created: created, contentSnippets: snippets),
@@ -459,7 +470,7 @@ class _EchoSession implements AgentHarnessSession {
 
     return (
       transcript: Transcript(
-        messages: List.unmodifiable(agent.state.history.messages),
+        messages: const [],
         toolCalls: const [],
         metrics: const TranscriptMetrics(nTurns: 0, nToolCalls: 0, nTotalTokens: 0),
       ),
@@ -845,10 +856,10 @@ class Outcome {
 }
 ```
 
-**Anthropic Step 5 hammers this point**: graders default to looking at
-`outcome` and only consult `transcript` when judging "did the path
-look right" (e.g. "must have called this tool" → check
-`transcript.toolCalls`).
+**Anthropic Step 5 hammers this point**: each grader evaluates the part
+of the trial that contains the evidence it needs. Outcome graders check
+final state; transcript graders check behavior over time, tool calls,
+messages, reasoning/events, and performance metrics.
 
 </br>
 

--- a/doc/eval-guide.zh-CN.md
+++ b/doc/eval-guide.zh-CN.md
@@ -40,9 +40,10 @@ agents"](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents)
 | **Agent Harness** | `AgentHarnessFactory` / `AgentHarnessSession` | 让模型像 Agent 一样行动的脚手架（你提供） |
 | **Evaluation Suite** | `EvalSuite` | 一组围绕同一能力/行为的 task |
 
-设计原则（Anthropic Step 5）：**默认看 Outcome，不看 Transcript**。
-"flight booked" 应当看数据库里有没有航班记录，而不是 Agent 是否说了
-"Your flight has been booked"。
+设计原则（Anthropic Step 5）：**按指标选择正确证据**。终态问题看
+`Outcome`（例如 "flight booked" 应当看数据库里有没有航班记录，而不是
+Agent 是否说了 "Your flight has been booked"）；过程问题看
+`Transcript`（例如是否先读后写、是否调用了必需工具）。
 
 </br>
 
@@ -164,15 +165,21 @@ abstract class AgentHarnessSession {
 ```
 
 Harness 是**唯一**知道你 agent 长什么样的层：实例化 `StatefulAgent`、
-注册 `Tool[]`、调 `agent.run([UserMessage(task.input['prompt'])])`、
-等它跑完，从 agent 状态和工作区拼出 transcript + outcome。
+注册 `Tool[]`、调 `agent.run([UserMessage(task.input['prompt'])])`，
+然后从工作区或业务服务里采集最终 `Outcome`。通用运行轨迹由
+`EvalRunner` 内置的 `EvalTranscriptRecorder` 从 `context.controller`
+自动录制；Harness 必须复用这个 controller。
 
-`run()` 必须返回**两件**东西：
+`run()` 必须返回**两件**东西。通常业务 Harness 只需要认真填
+`Outcome`，`Transcript` 可以返回空对象，Runner 会用自动录制的 snapshot
+补上：
 
 - `Transcript` — agent **做了什么**：消息序列、工具调用、retry / error
-  事件、turns / tokens 计数。**Grader 一般不该看这个**（看路径而非结果）
+  事件、turns / tokens 计数。默认由框架录制；只有需要覆盖或补充自定义
+  轨迹时才手动构造。凡是评估过程、工具使用、消息、事件或指标的 grader
+  都应该读它。
 - `Outcome` — 环境**最终是什么状态**：`environmentState` 是任意 Map，
-  schema 由你和 grader 约定。**Grader 默认看这个**
+  schema 由你和 grader 约定。凡是评估最终状态的 grader 都应该读它。
 
 `Outcome.environmentState` 的常见错误：
 
@@ -195,7 +202,7 @@ PKM agent 真实例子（节选自 `example/eval_demo/pkm_agent/harness.dart`）
 
 ```dart
 // Harness.run() 末尾的"事实采集"代码
-Outcome _capturePkmOutcome(Directory ws, SessionState state) {
+Outcome _capturePkmOutcome(Directory ws) {
   // ① 扫工作区目录
   final created = <String>[];
   final snippets = <String, String>{};
@@ -218,13 +225,15 @@ Outcome _capturePkmOutcome(Directory ws, SessionState state) {
 
   // ③ 检查哨兵文件（agent 调用某些工具会触发副作用文件）
   final skipped = File('${ws.path}/skipped.txt').existsSync();
-  final insightFile = Directory('${ws.path}/insights').listSync().firstOrNull;
+  final insightsDir = Directory('${ws.path}/insights');
+  final updatedInsight =
+      insightsDir.existsSync() && insightsDir.listSync().whereType<File>().isNotEmpty;
 
   return Outcome(
     environmentState: {
       'wrote_files': created,
       'fact_ids_in_files': factIds.toList(),
-      'updated_insight': insightFile != null,
+      'updated_insight': updatedInsight,
       'skipped': skipped,
     },
     workspaceDiff: WorkspaceDiff(created: created, contentSnippets: snippets),
@@ -439,7 +448,7 @@ class _EchoSession implements AgentHarnessSession {
 
     return (
       transcript: Transcript(
-        messages: List.unmodifiable(agent.state.history.messages),
+        messages: const [],
         toolCalls: const [],
         metrics: const TranscriptMetrics(nTurns: 0, nToolCalls: 0, nTotalTokens: 0),
       ),
@@ -794,8 +803,9 @@ class Outcome {
 }
 ```
 
-**Anthropic Step 5 反复强调**：grader 默认看 `outcome`，只有在判断"路径
-是否合理"时才动 `transcript`（例如"必须调用某个工具"才看 `transcript.toolCalls`）。
+**Anthropic Step 5 反复强调**：每个 grader 应该评估 trial 中与指标相关的
+那部分证据。终态 grader 看 `outcome`；过程 grader 看 `transcript`，包括
+工具调用、消息、reasoning / events 和性能指标。
 
 </br>
 

--- a/example/eval_demo/README.md
+++ b/example/eval_demo/README.md
@@ -13,11 +13,10 @@ through any OpenAI-compatible endpoint.
   off-topic prompts.
 - **`EvalEnvironment`** (`environment.dart`): per-trial temp directory,
   optional record/replay wrapping for the LLM client.
-- **`AgentHarnessFactory`** (`harness.dart`): subscribes to the
-  `AgentController` event bus to assemble a `Transcript`
-  (messages + tool calls + retries + exceptions + timing + tokens) and
-  reads `answer.txt` / `declined.txt` from the workspace to produce an
-  `Outcome`.
+- **`AgentHarnessFactory`** (`harness.dart`): runs the agent with the
+  shared `AgentController`, then reads `answer.txt` / `declined.txt` from
+  the workspace to produce an `Outcome`. `EvalRunner` records the
+  `Transcript` automatically from controller events.
 - **Tasks** (`tasks.dart`): three `EvalTask` implementations
   (single-step add, multi-step compose, off-topic decline) covering both
   Anthropic positive and negative cases. Each declares its own graders,

--- a/example/eval_demo/_shared/agent_harness.dart
+++ b/example/eval_demo/_shared/agent_harness.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_agent_core/dart_agent_core.dart';
@@ -12,8 +11,9 @@ import 'package:dart_agent_core/eval.dart';
 ///   - a `captureOutcome` callback that reads disk state at the end of
 ///     the run and produces the [Outcome] map.
 ///
-/// Everything else (event-bus wiring, transcript assembly, message
-/// snapshot) is identical across demos.
+/// The eval runner records the generic transcript from the shared
+/// [AgentController]; this harness only runs the agent and captures the final
+/// environment state.
 class GenericAgentSession implements AgentHarnessSession {
   final EvalTask task;
   final Trial trial;
@@ -22,8 +22,7 @@ class GenericAgentSession implements AgentHarnessSession {
   final String agentName;
   final String systemPrompt;
   final List<Tool> Function(Directory workspace) buildTools;
-  final Outcome Function(Directory workspace, SessionState state)
-  captureOutcome;
+  final Outcome Function(Directory workspace) captureOutcome;
 
   GenericAgentSession({
     required this.task,
@@ -36,13 +35,10 @@ class GenericAgentSession implements AgentHarnessSession {
     required this.captureOutcome,
   });
 
-  final SessionState _state = SessionState();
-
   @override
   Future<({Transcript transcript, Outcome outcome})> run() async {
     final ws = context.workspaceDir!;
     final controller = context.controller;
-    _wireListeners(controller);
 
     final tools = buildTools(ws);
 
@@ -72,138 +68,26 @@ class GenericAgentSession implements AgentHarnessSession {
     try {
       await agent.run([userMessage], useStream: false);
     } catch (e, st) {
-      _state.events.add(
-        TranscriptEvent(
-          at: DateTime.now(),
-          kind: 'agent_run_error',
-          message: e.toString(),
-          details: {'stackTrace': st.toString()},
-        ),
-      );
+      controller.publish(OnAgentErrorEvent(agent, 'agent_run_error: $e\n$st'));
     }
 
-    _state.messages
-      ..clear()
-      ..addAll(agentState.history.messages);
-
-    final outcome = captureOutcome(ws, _state);
-    final transcript = _buildTranscript();
-    return (transcript: transcript, outcome: outcome);
+    final outcome = captureOutcome(ws);
+    return (
+      transcript: Transcript(
+        messages: const [],
+        toolCalls: const [],
+        metrics: const TranscriptMetrics(
+          nTurns: 0,
+          nToolCalls: 0,
+          nTotalTokens: 0,
+        ),
+      ),
+      outcome: outcome,
+    );
   }
 
   @override
   Future<void> dispose() async {
     // Controller is closed by the environment when the trial ends.
   }
-
-  void _wireListeners(AgentController controller) {
-    controller.on<BeforeToolCallEvent>((e) {
-      _state.pendingToolCalls[e.functionCall.id] = ToolCallStart(
-        startedAt: DateTime.now(),
-        toolName: e.functionCall.name,
-        arguments: _decodeArgs(e.functionCall.arguments),
-      );
-    });
-
-    controller.on<AfterToolCallEvent>((e) {
-      final start = _state.pendingToolCalls.remove(e.result.id);
-      final endedAt = DateTime.now();
-      _state.toolCalls.add(
-        ToolCallRecord(
-          callId: e.result.id,
-          toolName: e.result.name,
-          arguments: start?.arguments ?? const {},
-          result: e.result,
-          startedAt: start?.startedAt ?? endedAt,
-          endedAt: endedAt,
-          isError: e.result.isError,
-        ),
-      );
-    });
-
-    controller.on<AfterCallLLMEvent>((e) {
-      _state.nTurns += 1;
-      _state.firstLLMReplyAt ??= DateTime.now();
-      _state.lastLLMReplyAt = DateTime.now();
-      final usage = e.response.usage;
-      if (usage != null) {
-        _state.totalTokens += usage.totalTokens;
-      }
-    });
-
-    controller.on<LLMRetryingEvent>((e) {
-      _state.events.add(
-        TranscriptEvent(
-          at: DateTime.now(),
-          kind: 'llm_retry',
-          message: e.reason,
-        ),
-      );
-    });
-
-    controller.on<OnAgentExceptionEvent>((e) {
-      _state.events.add(
-        TranscriptEvent(
-          at: DateTime.now(),
-          kind: 'agent_exception',
-          message: e.error.toString(),
-        ),
-      );
-    });
-  }
-
-  Map<String, dynamic> _decodeArgs(String raw) {
-    if (raw.trim().isEmpty) return const {};
-    try {
-      final decoded = jsonDecode(raw);
-      if (decoded is Map<String, dynamic>) return decoded;
-      if (decoded is Map) return decoded.cast<String, dynamic>();
-      return const {};
-    } catch (_) {
-      return const {};
-    }
-  }
-
-  Transcript _buildTranscript() {
-    final ttft = _state.firstLLMReplyAt;
-    final ttlt = _state.lastLLMReplyAt;
-    return Transcript(
-      messages: List.unmodifiable(_state.messages),
-      toolCalls: List.unmodifiable(_state.toolCalls),
-      reasoningSteps: const [],
-      events: List.unmodifiable(_state.events),
-      metrics: TranscriptMetrics(
-        nTurns: _state.nTurns,
-        nToolCalls: _state.toolCalls.length,
-        nTotalTokens: _state.totalTokens,
-        timeToFirstToken: ttft?.difference(trial.startedAt),
-        timeToLastToken: ttlt?.difference(trial.startedAt),
-      ),
-    );
-  }
-}
-
-/// Tracks progress of a single agent run. Public so demo
-/// `captureOutcome` callbacks can read tool calls, messages, and timings
-/// without the analyzer warning about private types in public API.
-class SessionState {
-  final List<LLMMessage> messages = [];
-  final List<ToolCallRecord> toolCalls = [];
-  final List<TranscriptEvent> events = [];
-  final Map<String, ToolCallStart> pendingToolCalls = {};
-  DateTime? firstLLMReplyAt;
-  DateTime? lastLLMReplyAt;
-  int nTurns = 0;
-  int totalTokens = 0;
-}
-
-class ToolCallStart {
-  final DateTime startedAt;
-  final String toolName;
-  final Map<String, dynamic> arguments;
-  const ToolCallStart({
-    required this.startedAt,
-    required this.toolName,
-    required this.arguments,
-  });
 }

--- a/example/eval_demo/calculator/harness.dart
+++ b/example/eval_demo/calculator/harness.dart
@@ -33,7 +33,7 @@ class CalculatorAgentHarnessFactory implements AgentHarnessFactory {
   }
 }
 
-Outcome _captureOutcome(Directory ws, SessionState state) {
+Outcome _captureOutcome(Directory ws) {
   final answerFile = File('${ws.path}/answer.txt');
   final declinedFile = File('${ws.path}/declined.txt');
   final explanationFile = File('${ws.path}/explanation.txt');

--- a/example/eval_demo/card_agent/harness.dart
+++ b/example/eval_demo/card_agent/harness.dart
@@ -29,8 +29,8 @@ class CardAgentHarnessFactory implements AgentHarnessFactory {
   }
 }
 
-Outcome _captureCardOutcome(Directory ws, SessionState state) {
-  final factId = _findFactId(state);
+Outcome _captureCardOutcome(Directory ws) {
+  final factId = _findFactId(ws);
   final cardFile = factId == null
       ? null
       : File('${ws.path}/cards/$factId.yaml');
@@ -68,13 +68,13 @@ Outcome _captureCardOutcome(Directory ws, SessionState state) {
   );
 }
 
-/// Pull the fact_id from the most recent successful save_timeline_card
-/// tool call. Falls back to the fact_id in the input prompt.
-String? _findFactId(SessionState state) {
-  for (final tc in state.toolCalls.reversed) {
-    if (tc.toolName == 'save_timeline_card' && !tc.isError) {
-      final fid = tc.arguments['fact_id'];
-      if (fid is String) return fid;
+/// Pull the fact_id from the persisted card filename.
+String? _findFactId(Directory ws) {
+  final cardsDir = Directory('${ws.path}/cards');
+  if (!cardsDir.existsSync()) return null;
+  for (final entry in cardsDir.listSync()) {
+    if (entry is File && entry.path.endsWith('.yaml')) {
+      return entry.uri.pathSegments.last.replaceAll(RegExp(r'\.yaml$'), '');
     }
   }
   return null;

--- a/example/eval_demo/pkm_agent/harness.dart
+++ b/example/eval_demo/pkm_agent/harness.dart
@@ -29,18 +29,10 @@ class PkmAgentHarnessFactory implements AgentHarnessFactory {
   }
 }
 
-Outcome _capturePkmOutcome(Directory ws, SessionState state) {
+Outcome _capturePkmOutcome(Directory ws) {
   final pkmRoot = Directory('${ws.path}/PKM');
   final created = <String>[];
   final modifiedSnippets = <String, String>{};
-  final allWritten = <String>[];
-
-  for (final tc in state.toolCalls) {
-    if (tc.toolName == 'write_file' && !tc.isError) {
-      final path = tc.arguments['path'];
-      if (path is String) allWritten.add(path);
-    }
-  }
 
   if (pkmRoot.existsSync()) {
     for (final entry in pkmRoot.listSync(recursive: true)) {
@@ -85,7 +77,7 @@ Outcome _capturePkmOutcome(Directory ws, SessionState state) {
 
   return Outcome(
     environmentState: {
-      'wrote_files': allWritten,
+      'wrote_files': created,
       'pkm_files_created': created,
       'fact_ids_in_files': factIdInFiles.toList(),
       'insight': ?insight,

--- a/example/min_eval/main.dart
+++ b/example/min_eval/main.dart
@@ -100,7 +100,7 @@ class _EchoSession implements AgentHarnessSession {
 
     return (
       transcript: Transcript(
-        messages: List.unmodifiable(agent.state.history.messages),
+        messages: const [],
         toolCalls: const [],
         metrics: const TranscriptMetrics(
           nTurns: 0,

--- a/lib/eval.dart
+++ b/lib/eval.dart
@@ -23,6 +23,7 @@ export 'src/eval/core/agent_harness_factory.dart';
 export 'src/eval/core/eval_runner.dart';
 export 'src/eval/core/eval_run_report.dart';
 export 'src/eval/core/eval_run_config.dart';
+export 'src/eval/core/transcript_recorder.dart';
 
 // Graders
 export 'src/eval/graders/grader.dart';

--- a/lib/src/eval/core/agent_harness_factory.dart
+++ b/lib/src/eval/core/agent_harness_factory.dart
@@ -11,7 +11,7 @@ abstract class AgentHarnessFactory {
   /// Build a session for one trial. Implementations are responsible for:
   /// - Instantiating the agent (e.g. a StatefulAgent)
   /// - Wiring tools / skills
-  /// - Subscribing to controller events for transcript collection
+  /// - Reusing EvalContext.controller so the runner can record transcripts
   Future<AgentHarnessSession> create({
     required EvalTask task,
     required Trial trial,
@@ -22,7 +22,9 @@ abstract class AgentHarnessFactory {
 /// One trial worth of agent execution. Always created via the factory.
 abstract class AgentHarnessSession {
   /// Run the agent for this trial and produce both a transcript and an
-  /// outcome.
+  /// outcome. Sessions may return an empty transcript when using the
+  /// framework recorder; the runner will replace it with the recorded
+  /// snapshot.
   Future<({Transcript transcript, Outcome outcome})> run();
 
   /// Called after [run] regardless of outcome. Free any per-session

--- a/lib/src/eval/core/eval_runner.dart
+++ b/lib/src/eval/core/eval_runner.dart
@@ -15,6 +15,7 @@ import 'eval_suite.dart';
 import 'eval_task.dart';
 import 'outcome.dart';
 import 'transcript.dart';
+import 'transcript_recorder.dart';
 import 'trial.dart';
 import 'trial_result.dart';
 
@@ -235,6 +236,11 @@ extension on EvalRunner {
     String? failureReason;
 
     final context = await environment.prepare(trial: trial, task: task);
+    final recorder = EvalTranscriptRecorder(
+      controller: context.controller,
+      startedAt: startedAt,
+      now: context.clock.now,
+    );
     try {
       final session = await harnessFactory.create(
         task: task,
@@ -257,22 +263,32 @@ extension on EvalRunner {
         await session.dispose();
       }
     } finally {
+      // EventBus notifications are scheduled as microtasks by default. Give
+      // controller listeners a chance to drain before snapshotting.
+      await Future<void>.delayed(Duration.zero);
+      final currentTranscript = transcript;
+      if (currentTranscript == null || _isEmptyTranscript(currentTranscript)) {
+        transcript = recorder.snapshot();
+      }
+      await recorder.dispose();
       await environment.dispose(context);
     }
 
     final endedAt = DateTime.now();
 
     // If the harness produced no transcript/outcome (timeout/error), make
-    // empty placeholders so graders can still decide what to do.
-    transcript ??= Transcript(
-      messages: const [],
-      toolCalls: const [],
-      metrics: const TranscriptMetrics(
-        nTurns: 0,
-        nToolCalls: 0,
-        nTotalTokens: 0,
-      ),
-    );
+    // placeholders so graders can still decide what to do.
+    final effectiveTranscript =
+        transcript ??
+        Transcript(
+          messages: const [],
+          toolCalls: const [],
+          metrics: const TranscriptMetrics(
+            nTurns: 0,
+            nToolCalls: 0,
+            nTotalTokens: 0,
+          ),
+        );
     outcome ??= const Outcome(environmentState: {});
 
     // Run graders. Each grader returns a Score; runner does not enforce
@@ -282,7 +298,7 @@ extension on EvalRunner {
       try {
         final score = await grader.grade(
           trial: trial,
-          transcript: transcript,
+          transcript: effectiveTranscript,
           outcome: outcome,
           context: context,
           referenceSolution: task.referenceSolution,
@@ -320,7 +336,7 @@ extension on EvalRunner {
 
     final result = TrialResult(
       trial: trial,
-      transcript: transcript,
+      transcript: effectiveTranscript,
       outcome: outcome,
       scores: scores,
     );
@@ -328,7 +344,7 @@ extension on EvalRunner {
     try {
       await exporter.onTrialEnd(
         trial: trial,
-        transcript: transcript,
+        transcript: effectiveTranscript,
         outcome: outcome,
         scores: scores,
       );
@@ -337,5 +353,19 @@ extension on EvalRunner {
     }
 
     return result;
+  }
+
+  bool _isEmptyTranscript(Transcript transcript) {
+    final metrics = transcript.metrics;
+    return transcript.messages.isEmpty &&
+        transcript.toolCalls.isEmpty &&
+        transcript.reasoningSteps.isEmpty &&
+        transcript.events.isEmpty &&
+        metrics.nTurns == 0 &&
+        metrics.nToolCalls == 0 &&
+        metrics.nTotalTokens == 0 &&
+        metrics.timeToFirstToken == null &&
+        metrics.timeToLastToken == null &&
+        metrics.outputTokensPerSec == null;
   }
 }

--- a/lib/src/eval/core/transcript_recorder.dart
+++ b/lib/src/eval/core/transcript_recorder.dart
@@ -1,0 +1,208 @@
+import 'dart:async';
+import 'dart:convert';
+
+import '../../agent/controller.dart';
+import '../../agent/events.dart';
+import '../../core/message.dart';
+import 'transcript.dart';
+
+/// Records a trial transcript from the shared [AgentController].
+///
+/// Agent harnesses should focus on running the agent and collecting the final
+/// [Outcome]. This recorder captures the generic execution trace: messages,
+/// tool calls, retry/error events, reasoning text, and token/turn metrics.
+class EvalTranscriptRecorder {
+  final AgentController controller;
+  final DateTime startedAt;
+  final DateTime Function() now;
+
+  final List<LLMMessage> _messages = [];
+  final List<ToolCallRecord> _toolCalls = [];
+  final List<String> _reasoningSteps = [];
+  final List<TranscriptEvent> _events = [];
+  final Map<String, _ToolCallStart> _pendingToolCalls = {};
+  final List<StreamSubscription<Object?>> _subscriptions = [];
+
+  DateTime? _firstLLMReplyAt;
+  DateTime? _lastLLMReplyAt;
+  int _nTurns = 0;
+  int _totalTokens = 0;
+  bool _disposed = false;
+
+  EvalTranscriptRecorder({
+    required this.controller,
+    required this.startedAt,
+    DateTime Function()? now,
+  }) : now = now ?? DateTime.now {
+    _listen();
+  }
+
+  /// Current transcript snapshot. Safe to call multiple times.
+  Transcript snapshot() {
+    final ttft = _firstLLMReplyAt;
+    final ttlt = _lastLLMReplyAt;
+    return Transcript(
+      messages: List.unmodifiable(_messages),
+      toolCalls: List.unmodifiable(_toolCalls),
+      reasoningSteps: List.unmodifiable(_reasoningSteps),
+      events: List.unmodifiable(_events),
+      metrics: TranscriptMetrics(
+        nTurns: _nTurns,
+        nToolCalls: _toolCalls.length,
+        nTotalTokens: _totalTokens,
+        timeToFirstToken: ttft?.difference(startedAt),
+        timeToLastToken: ttlt?.difference(startedAt),
+      ),
+    );
+  }
+
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    for (final sub in _subscriptions) {
+      await sub.cancel();
+    }
+    _subscriptions.clear();
+  }
+
+  void _listen() {
+    _subscriptions.add(
+      controller.listen<BeforeCallLLMEvent>().listen((e) {
+        _messages
+          ..clear()
+          ..addAll(e.params.messages);
+      }),
+    );
+    _subscriptions.add(
+      controller.listen<AfterCallLLMEvent>().listen((e) {
+        final at = now();
+        _nTurns += 1;
+        _firstLLMReplyAt ??= at;
+        _lastLLMReplyAt = at;
+        final usage = e.response.usage;
+        if (usage != null) {
+          _totalTokens += usage.totalTokens;
+        }
+        final thought = e.response.thought;
+        if (thought != null && thought.trim().isNotEmpty) {
+          _reasoningSteps.add(thought);
+        }
+        _messages
+          ..clear()
+          ..addAll(e.params.messages)
+          ..add(e.response);
+      }),
+    );
+    _subscriptions.add(
+      controller.listen<BeforeToolCallEvent>().listen((e) {
+        _pendingToolCalls[e.functionCall.id] = _ToolCallStart(
+          startedAt: now(),
+          toolName: e.functionCall.name,
+          arguments: _decodeArgs(e.functionCall.arguments),
+        );
+      }),
+    );
+    _subscriptions.add(
+      controller.listen<AfterToolCallEvent>().listen((e) {
+        final endedAt = now();
+        final start = _pendingToolCalls.remove(e.result.id);
+        _toolCalls.add(
+          ToolCallRecord(
+            callId: e.result.id,
+            toolName: e.result.name,
+            arguments: start?.arguments ?? _decodeArgs(e.result.arguments),
+            result: e.result,
+            startedAt: start?.startedAt ?? endedAt,
+            endedAt: endedAt,
+            isError: e.result.isError,
+          ),
+        );
+        _appendToolResultMessage(e.result);
+      }),
+    );
+    _subscriptions.add(
+      controller.listen<LLMRetryingEvent>().listen((e) {
+        _events.add(
+          TranscriptEvent(at: now(), kind: 'llm_retry', message: e.reason),
+        );
+      }),
+    );
+    _subscriptions.add(
+      controller.listen<OnAgentExceptionEvent>().listen((e) {
+        _events.add(
+          TranscriptEvent(
+            at: now(),
+            kind: 'agent_exception',
+            message: e.error.toString(),
+          ),
+        );
+      }),
+    );
+    _subscriptions.add(
+      controller.listen<OnAgentErrorEvent>().listen((e) {
+        _events.add(
+          TranscriptEvent(at: now(), kind: 'agent_error', message: e.error),
+        );
+      }),
+    );
+    _subscriptions.add(
+      controller.listen<OnAgentCancelEvent>().listen((e) {
+        _events.add(
+          TranscriptEvent(
+            at: now(),
+            kind: 'agent_cancel',
+            message: e.reason ?? e.exception.toString(),
+          ),
+        );
+      }),
+    );
+    _subscriptions.add(
+      controller.listen<PlanChangedEvent>().listen((e) {
+        _events.add(
+          TranscriptEvent(
+            at: now(),
+            kind: 'plan_changed',
+            message: 'Plan changed',
+            details: {'plan': e.plan.toJson()},
+          ),
+        );
+      }),
+    );
+  }
+
+  void _appendToolResultMessage(FunctionExecutionResult result) {
+    if (_messages.isNotEmpty &&
+        _messages.last is FunctionExecutionResultMessage) {
+      final last = _messages.removeLast() as FunctionExecutionResultMessage;
+      _messages.add(
+        FunctionExecutionResultMessage(results: [...last.results, result]),
+      );
+      return;
+    }
+    _messages.add(FunctionExecutionResultMessage(results: [result]));
+  }
+
+  Map<String, dynamic> _decodeArgs(String raw) {
+    if (raw.trim().isEmpty) return const {};
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is Map<String, dynamic>) return decoded;
+      if (decoded is Map) return decoded.cast<String, dynamic>();
+      return const {};
+    } catch (_) {
+      return const {};
+    }
+  }
+}
+
+class _ToolCallStart {
+  final DateTime startedAt;
+  final String toolName;
+  final Map<String, dynamic> arguments;
+
+  const _ToolCallStart({
+    required this.startedAt,
+    required this.toolName,
+    required this.arguments,
+  });
+}

--- a/lib/src/eval/graders/grader.dart
+++ b/lib/src/eval/graders/grader.dart
@@ -10,9 +10,9 @@ enum GraderKind { code, model, human }
 
 /// A grader scores some aspect of an agent's performance for one trial.
 ///
-/// Implementations should default to inspecting the [Outcome] rather than
-/// the [Transcript] (Anthropic Step 5: grade what the agent produced, not
-/// the path it took).
+/// Implementations should inspect the artifact that contains the evidence for
+/// that aspect: [Outcome] for final environment state, [Transcript] for the
+/// agent's path, tool calls, messages, events, and metrics.
 abstract class Grader {
   /// Stable name. Used as score key in reports.
   String get name;

--- a/test/eval/transcript_recorder_test.dart
+++ b/test/eval/transcript_recorder_test.dart
@@ -1,0 +1,234 @@
+import 'dart:io';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dart_agent_core/eval.dart';
+import 'package:test/test.dart';
+
+import '_helpers.dart';
+
+void main() {
+  test(
+    'EvalTranscriptRecorder captures messages, tool calls, and metrics',
+    () async {
+      final controller = AgentController();
+      final startedAt = DateTime(2026, 1, 1, 12);
+      var tick = 0;
+      final recorder = EvalTranscriptRecorder(
+        controller: controller,
+        startedAt: startedAt,
+        now: () => startedAt.add(Duration(milliseconds: ++tick * 10)),
+      );
+
+      final agent = _agentWithTool(controller);
+      await agent.run([UserMessage.text('echo hi')], useStream: false);
+      await Future<void>.delayed(Duration.zero);
+
+      final transcript = recorder.snapshot();
+      await recorder.dispose();
+      controller.close();
+
+      expect(transcript.messages, hasLength(5));
+      expect(transcript.messages.first, isA<SystemMessage>());
+      expect(transcript.messages[1], isA<UserMessage>());
+      expect(transcript.messages[2], isA<ModelMessage>());
+      expect(transcript.messages[3], isA<FunctionExecutionResultMessage>());
+      expect(transcript.messages.last, isA<ModelMessage>());
+      expect(transcript.toolCalls, hasLength(1));
+      expect(transcript.toolCalls.single.toolName, 'echo_tool');
+      expect(transcript.toolCalls.single.arguments, {'value': 'hi'});
+      expect(transcript.toolCalls.single.isError, isFalse);
+      expect(transcript.reasoningSteps, ['need echo']);
+      expect(transcript.metrics.nTurns, 2);
+      expect(transcript.metrics.nToolCalls, 1);
+      expect(transcript.metrics.nTotalTokens, 18);
+      expect(
+        transcript.metrics.timeToFirstToken,
+        const Duration(milliseconds: 10),
+      );
+    },
+  );
+
+  test(
+    'EvalRunner replaces an empty harness transcript with recorder output',
+    () async {
+      final environment = _RecorderEnvironment();
+      final runner = EvalRunner(
+        environment: environment,
+        harnessFactory: _RecorderHarnessFactory(),
+      );
+
+      final report = await runner.runSuite(
+        runName: 'recorder_run',
+        suite: EvalSuite(
+          name: 'recorder_suite',
+          agentName: 'agent',
+          kind: SuiteKind.capability,
+          tasks: [_RecorderTask()],
+        ),
+        concurrency: 1,
+      );
+
+      final transcript = report.trials.single.transcript;
+      expect(transcript.messages, isNotEmpty);
+      expect(transcript.toolCalls.single.toolName, 'echo_tool');
+      expect(transcript.metrics.nTurns, 2);
+    },
+  );
+}
+
+StatefulAgent _agentWithTool(AgentController controller) {
+  return StatefulAgent(
+    name: 'recorder_test_agent',
+    client: FakeLLMClient([
+      ModelMessage(
+        model: 'fake-model',
+        stopReason: 'tool_use',
+        thought: 'need echo',
+        usage: ModelUsage(
+          promptTokens: 3,
+          completionTokens: 4,
+          totalTokens: 7,
+          model: 'fake-model',
+        ),
+        functionCalls: [
+          FunctionCall(
+            id: 'call_1',
+            name: 'echo_tool',
+            arguments: '{"value":"hi"}',
+          ),
+        ],
+      ),
+      ModelMessage(
+        model: 'fake-model',
+        stopReason: 'stop',
+        textOutput: 'done',
+        usage: ModelUsage(
+          promptTokens: 5,
+          completionTokens: 6,
+          totalTokens: 11,
+          model: 'fake-model',
+        ),
+      ),
+    ]),
+    modelConfig: ModelConfig(model: 'fake-model'),
+    state: AgentState(sessionId: 'recorder_test'),
+    tools: [
+      Tool(
+        name: 'echo_tool',
+        description: 'Echoes a value.',
+        parameterMode: ToolParameterMode.object,
+        parameters: {
+          'type': 'object',
+          'properties': {
+            'value': {'type': 'string'},
+          },
+          'required': ['value'],
+        },
+        executable: (Map<String, dynamic> args) => 'echo ${args['value']}',
+      ),
+    ],
+    systemPrompts: const ['You are a test agent.'],
+    controller: controller,
+    withGeneralPrinciples: false,
+    planMode: PlanMode.none,
+    disableSubAgents: true,
+    autoSaveStateFunc: (_) async {},
+  );
+}
+
+class _RecorderEnvironment implements EvalEnvironment {
+  @override
+  Future<EvalContext> prepare({
+    required Trial trial,
+    required EvalTask task,
+  }) async {
+    return EvalContext(
+      workspaceDir: await Directory.systemTemp.createTemp('recorder_eval_'),
+      clock: const SystemEvalClock(),
+      llmClient: FakeLLMClient([textReply('unused')]),
+      controller: AgentController(),
+    );
+  }
+
+  @override
+  Future<void> dispose(EvalContext context) async {
+    final ws = context.workspaceDir;
+    if (ws != null && await ws.exists()) {
+      await ws.delete(recursive: true);
+    }
+    context.controller.close();
+  }
+}
+
+class _RecorderHarnessFactory implements AgentHarnessFactory {
+  @override
+  Future<AgentHarnessSession> create({
+    required EvalTask task,
+    required Trial trial,
+    required EvalContext context,
+  }) async {
+    return _RecorderSession(context.controller);
+  }
+}
+
+class _RecorderSession implements AgentHarnessSession {
+  final AgentController controller;
+
+  _RecorderSession(this.controller);
+
+  @override
+  Future<({Transcript transcript, Outcome outcome})> run() async {
+    await _agentWithTool(
+      controller,
+    ).run([UserMessage.text('echo hi')], useStream: false);
+    return (
+      transcript: emptyTranscript(),
+      outcome: const Outcome(environmentState: {'ok': true}),
+    );
+  }
+
+  @override
+  Future<void> dispose() async {}
+}
+
+class _RecorderTask implements EvalTask {
+  @override
+  String get id => 'recorder_task';
+
+  @override
+  String get description => 'recorder task';
+
+  @override
+  Map<String, dynamic> get input => const {};
+
+  @override
+  Map<String, String> get metadata => const {};
+
+  @override
+  ReferenceSolution? get referenceSolution => null;
+
+  @override
+  List<Grader> get graders => [_PassGrader()];
+
+  @override
+  int get trialsPerRun => 1;
+
+  @override
+  Duration? get timeout => const Duration(seconds: 5);
+}
+
+class _PassGrader extends CodeGrader {
+  @override
+  String get name => 'pass';
+
+  @override
+  Future<List<Assertion>> computeAssertions({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async {
+    return [Assertion(description: 'always passes', passed: true)];
+  }
+}


### PR DESCRIPTION
## Summary
- add EvalTranscriptRecorder to capture messages, tool calls, events, reasoning, and metrics from AgentController
- wire EvalRunner to attach the recorder per trial and replace empty harness transcripts with the recorded snapshot
- simplify eval demos so harnesses focus on Outcome collection, and update docs around Transcript vs Outcome grader evidence

## Verification
- dart analyze
- dart test test/eval/transcript_recorder_test.dart
- dart test test/eval/runner_e2e_test.dart
- OPENAI_BASE_URL="$SHARK_OPENAI_BASE_URL" OPENAI_API_KEY="$SHARK_OPENAI_API_KEY" dart run example/eval_demo/main.dart --suite all --trials 1 --concurrency 1 --mode live
  - completed successfully at runtime; process exited 1 because eval pass rate was below 100% for card_agent_demo and pkm_agent_demo, not due to framework errors
