### PR TITLE
fix(core): ignore late events after close

### DIFF
--- a/lib/src/core/event_bus.dart
+++ b/lib/src/core/event_bus.dart
@@ -12,16 +12,22 @@ class EventBus {
     sync: true,
   );
   final Map<Type, Future<dynamic> Function(Event)> _requestHandlers = {};
+  var _closed = false;
 
   /// Publishes an event to all subscribers.
   /// [sync] determines whether the event is fired synchronously or asynchronously.
   /// - If [sync] is true, listeners are notified immediately.
   /// - If [sync] is false (default), notification is scheduled as a microtask.
   void publish(Event event, {bool sync = false}) {
+    if (_closed) return;
     if (sync) {
       _streamController.add(event);
     } else {
-      Future.microtask(() => _streamController.add(event));
+      Future.microtask(() {
+        if (!_closed) {
+          _streamController.add(event);
+        }
+      });
     }
   }
 
@@ -53,6 +59,10 @@ class EventBus {
   /// If [orElse] is provided, it will be called if no handler is registered immediately (non-blocking).
   /// If [orElse] is NOT provided and no handler is registered, it will throw an exception immediately.
   Future<R> request<R>(Event event, {R Function()? orElse}) async {
+    if (_closed) {
+      if (orElse != null) return orElse();
+      throw StateError('EventBus is closed');
+    }
     var handler = _requestHandlers[event.runtimeType];
 
     if (handler != null) {
@@ -71,6 +81,8 @@ class EventBus {
 
   /// Closes the event bus.
   void close() {
+    if (_closed) return;
+    _closed = true;
     _streamController.close();
     _requestHandlers.clear();
   }

--- a/test/core/event_bus_test.dart
+++ b/test/core/event_bus_test.dart
@@ -1,0 +1,32 @@
+import 'dart:async';
+
+import 'package:dart_agent_core/src/core/event_bus.dart';
+import 'package:test/test.dart';
+
+class _TestEvent extends Event {}
+
+void main() {
+  test('drops async events scheduled before close', () async {
+    final bus = EventBus();
+    final events = <_TestEvent>[];
+    final sub = bus.on<_TestEvent>().listen(events.add);
+
+    bus.publish(_TestEvent());
+    bus.close();
+
+    await Future<void>.delayed(Duration.zero);
+
+    expect(events, isEmpty);
+    await sub.cancel();
+  });
+
+  test('close is idempotent and publish after close is ignored', () {
+    final bus = EventBus();
+
+    bus.close();
+
+    expect(bus.close, returnsNormally);
+    expect(() => bus.publish(_TestEvent()), returnsNormally);
+    expect(() => bus.publish(_TestEvent(), sync: true), returnsNormally);
+  });
+}


### PR DESCRIPTION
## Summary
- make EventBus close idempotent
- ignore async publish callbacks that drain after close
- add regression tests for late async events and post-close publish

## Tests
- dart analyze lib/src/core/event_bus.dart test/core/event_bus_test.dart
- dart test test/core/event_bus_test.dart test/eval/transcript_recorder_test.dart