### PR TITLE
Avoid duplicate prompt tool history entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.4
+
+- Fix repeated `systemPromptHistory` / `toolsHistory` entries across separate agent runs by initializing prompt/tool hashes from the last recorded state snapshot instead of starting each run from `null`.
+- Preserve the existing change-detection semantics: system prompts are compared by content hash, and tools are compared by sorted tool-name hash.
+
 ## 2.0.3
 
 - **BREAKING**: replace `systemCallback`, legacy pre/post tool hooks, turn-completion hooks, and controller request/response loop controls with the unified `AgentHook` pipeline. `AgentController` is now used for observation events; flow control belongs in hooks.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 ```yaml
 dependencies:
-  dart_agent_core: ^2.0.3
+  dart_agent_core: ^2.0.4
 ```
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -39,7 +39,7 @@
 
 ```yaml
 dependencies:
-  dart_agent_core: ^2.0.3
+  dart_agent_core: ^2.0.4
 ```
 
 ---

--- a/lib/src/agent/stateful_agent.dart
+++ b/lib/src/agent/stateful_agent.dart
@@ -875,8 +875,8 @@ class StatefulAgent {
       await _prepareDirectorySkills(effectiveInput);
       state.currentLoopCount = 0;
       state.currentLoopUsages.clear();
-      int? lastSystemPromptHash;
-      int? lastToolsHash;
+      int? lastSystemPromptHash = _lastRecordedSystemPromptHash();
+      int? lastToolsHash = _lastRecordedToolsHash();
 
       state.isRunning = true;
       state.lastError = null;
@@ -1356,6 +1356,25 @@ class StatefulAgent {
       systemPromptHash: currentSystemPromptHash,
       toolsHash: currentToolsHash,
     );
+  }
+
+  int? _lastRecordedSystemPromptHash() {
+    if (state.systemPromptHistory.isEmpty) {
+      return null;
+    }
+    return state.systemPromptHistory.last.content.hashCode;
+  }
+
+  int? _lastRecordedToolsHash() {
+    if (state.toolsHistory.isEmpty) {
+      return null;
+    }
+    final toolNames =
+        state.toolsHistory.last.tools
+            .map((t) => t['name'] as String? ?? '')
+            .toList()
+          ..sort();
+    return toolNames.join(',').hashCode;
   }
 
   Future<ModelMessage?> _applyModelChunkPhase(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_agent_core
 description: A mobile-first, local-first Dart library for building and evaluating stateful, tool-using AI agents with multi-provider LLM support.
-version: 2.0.3
+version: 2.0.4
 repository: https://github.com/memex-lab/dart_agent_core
 homepage: https://github.com/memex-lab/dart_agent_core
 issue_tracker: https://github.com/memex-lab/dart_agent_core/issues

--- a/test/agent_hooks_test.dart
+++ b/test/agent_hooks_test.dart
@@ -208,6 +208,84 @@ void main() {
     ]);
   });
 
+  test(
+    'system and tool history only append when model context changes',
+    () async {
+      final client = _CapturingLLMClient([_textReply('done')]);
+      final state = AgentState.empty();
+      final tools = [_echoTool((args) => args['value'])];
+      final agent = StatefulAgent(
+        name: 'hooked',
+        client: client,
+        modelConfig: ModelConfig(model: 'fake-model'),
+        state: state,
+        systemPrompts: ['stable system'],
+        withGeneralPrinciples: false,
+        disableSubAgents: true,
+        tools: tools,
+      );
+
+      await agent.run([UserMessage.text('first')], useStream: false);
+
+      expect(state.systemPromptHistory, hasLength(1));
+      expect(state.toolsHistory, hasLength(1));
+      expect(state.systemPromptHistory.single.content, 'stable system');
+
+      await agent.run([UserMessage.text('second')], useStream: false);
+
+      expect(state.systemPromptHistory, hasLength(1));
+      expect(state.toolsHistory, hasLength(1));
+
+      agent.systemPrompts.add('changed system');
+      tools[0] = Tool(
+        name: 'echo',
+        description: 'changed echo',
+        parameters: const {
+          'type': 'object',
+          'properties': {
+            'value': {'type': 'string'},
+          },
+          'required': ['value'],
+        },
+        parameterMode: ToolParameterMode.object,
+        executable: (Map<String, dynamic> args) => args['value'],
+      );
+
+      await agent.run([UserMessage.text('third')], useStream: false);
+
+      expect(state.systemPromptHistory, hasLength(2));
+      expect(state.toolsHistory, hasLength(1));
+      expect(
+        state.systemPromptHistory.last.content,
+        'stable system\n\nchanged system',
+      );
+      expect(state.toolsHistory.single.tools.single['description'], 'echo');
+
+      tools[0] = Tool(
+        name: 'echo_v2',
+        description: 'changed echo',
+        parameters: const {
+          'type': 'object',
+          'properties': {
+            'value': {'type': 'string'},
+          },
+          'required': ['value'],
+        },
+        parameterMode: ToolParameterMode.object,
+        executable: (Map<String, dynamic> args) => args['value'],
+      );
+
+      await agent.run([UserMessage.text('fourth')], useStream: false);
+
+      expect(state.systemPromptHistory, hasLength(2));
+      expect(state.toolsHistory, hasLength(2));
+      expect(
+        state.toolsHistory.last.tools.single['description'],
+        'changed echo',
+      );
+    },
+  );
+
   test('beforeModelCall can respond without calling the model', () async {
     final client = _CapturingLLMClient([]);
     final state = AgentState.empty();


### PR DESCRIPTION
## Summary
- Initialize prompt/tool history hashes from the last recorded state snapshot instead of starting each run from null.
- Preserve the existing comparison behavior: system prompt content hash and tool-name hash only.
- Add a regression test covering repeated runs, system prompt changes, and tool-name-only tracking.

## Validation
- dart format lib/src/agent/stateful_agent.dart test/agent_hooks_test.dart
- dart analyze .
- dart test test/agent_hooks_test.dart
- dart test