### PR TITLE
fix: keep stream text when usage is on every chunk

### DIFF
--- a/lib/src/llm/openai_client.dart
+++ b/lib/src/llm/openai_client.dart
@@ -595,8 +595,20 @@ class OpenAIResponseTransformer
         'system_fingerprint': data["system_fingerprint"],
       };
 
-      // 0. Handle Usage (often in last chunk with empty choices)
-      if (data['usage'] != null) {
+      // 0. Handle Usage (often in last chunk with empty choices).
+      // SiliconFlow / vLLM continuous_usage_stats put `usage` on every
+      // content chunk — only take the usage-only path when there is no
+      // delta payload, otherwise fall through so content is not dropped.
+      final choices = data['choices'] as List? ?? [];
+      final previewDelta = choices.isNotEmpty ? choices[0]['delta'] : null;
+      final hasDeltaPayload =
+          previewDelta != null &&
+          (previewDelta['content'] != null ||
+              previewDelta['reasoning_content'] != null ||
+              previewDelta['audio'] != null ||
+              previewDelta['tool_calls'] != null);
+
+      if (data['usage'] != null && !hasDeltaPayload) {
         final u = data['usage'];
         final modelUsage = ModelUsage(
           promptTokens: u['prompt_tokens'] ?? 0,
@@ -611,9 +623,8 @@ class OpenAIResponseTransformer
 
         // Some providers (e.g. GLM) send finish_reason and usage in the same
         // chunk. Extract finish_reason from choices if present so it is not lost.
-        final usageChoices = data['choices'] as List? ?? [];
-        if (usageChoices.isNotEmpty) {
-          final usageChoice = usageChoices[0];
+        if (choices.isNotEmpty) {
+          final usageChoice = choices[0];
           final inlineFinishReason = usageChoice['finish_reason'];
           if (inlineFinishReason != null) {
             pendingFinishReason = inlineFinishReason;
@@ -664,7 +675,6 @@ class OpenAIResponseTransformer
         continue;
       }
 
-      final choices = data['choices'] as List? ?? [];
       if (choices.isEmpty) continue;
 
       final choice = choices[0];

--- a/test/openai_stream_usage_test.dart
+++ b/test/openai_stream_usage_test.dart
@@ -1,0 +1,92 @@
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final config = ModelConfig(model: 'test-model');
+
+  test('keeps content when usage is present on every chunk', () async {
+    final chunks = <Map<String, dynamic>>[
+      {
+        'id': '1',
+        'object': 'chat.completion.chunk',
+        'choices': [
+          {
+            'index': 0,
+            'delta': {'content': 'Hi'},
+            'finish_reason': null,
+          },
+        ],
+        'usage': {
+          'prompt_tokens': 1,
+          'completion_tokens': 1,
+          'total_tokens': 2,
+        },
+      },
+      {
+        'id': '1',
+        'choices': [
+          {
+            'index': 0,
+            'delta': {'content': ' there'},
+            'finish_reason': null,
+          },
+        ],
+        'usage': {
+          'prompt_tokens': 1,
+          'completion_tokens': 2,
+          'total_tokens': 3,
+        },
+      },
+      {
+        'id': '1',
+        'choices': [
+          {'index': 0, 'delta': <String, dynamic>{}, 'finish_reason': 'stop'},
+        ],
+        'usage': {
+          'prompt_tokens': 1,
+          'completion_tokens': 2,
+          'total_tokens': 3,
+        },
+      },
+    ];
+
+    final messages = await Stream<Map<String, dynamic>>.fromIterable(chunks)
+        .transform(OpenAIResponseTransformer(config))
+        .toList();
+
+    expect(
+      messages.where((m) => m.textOutput != null).map((m) => m.textOutput),
+      ['Hi', ' there'],
+    );
+    expect(messages.any((m) => m.stopReason == 'stop'), isTrue);
+  });
+
+  test('still yields usage-only terminal chunks (OpenAI include_usage)', () async {
+    final chunks = <Map<String, dynamic>>[
+      {
+        'choices': [
+          {
+            'index': 0,
+            'delta': {'content': 'ok'},
+            'finish_reason': null,
+          },
+        ],
+      },
+      {
+        'choices': <dynamic>[],
+        'usage': {
+          'prompt_tokens': 4,
+          'completion_tokens': 1,
+          'total_tokens': 5,
+        },
+      },
+    ];
+
+    final messages = await Stream<Map<String, dynamic>>.fromIterable(chunks)
+        .transform(OpenAIResponseTransformer(config))
+        .toList();
+
+    expect(messages.first.textOutput, 'ok');
+    expect(messages.last.usage?.totalTokens, 5);
+  });
+}


### PR DESCRIPTION
## Summary
- `OpenAIResponseTransformer` treated any chunk with a non-null `usage` object as a terminal usage-only event and skipped `delta.content`.
- SiliconFlow and vLLM (`continuous_usage_stats`) send `usage` on every content chunk, so the stream completed with zero text.
- Only take the usage-only path when the chunk has no delta payload. Fixes #23.

## Test plan
- [x] `dart test test/openai_stream_usage_test.dart` — content survives per-chunk usage; classic OpenAI terminal usage chunk still yields `ModelUsage`.