### PR TITLE
feat: execute RunJavaScript through the central tool path

### DIFF
--- a/lib/src/agent/stateful_agent.dart
+++ b/lib/src/agent/stateful_agent.dart
@@ -714,8 +714,12 @@ class StatefulAgent {
   Future<String> _runJavaScriptScript(
     String scriptPath,
     String? args,
-    int? timeoutMs,
-  ) async {
+    int? timeoutMs, {
+    CancelToken? cancelToken,
+  }) async {
+    if (cancelToken?.isCancelled ?? false) {
+      return 'Error: JavaScript execution was cancelled.';
+    }
     if (!_isDirectorySkillModeEnabled) {
       return 'Error: directory skill mode is not enabled.';
     }
@@ -784,6 +788,21 @@ class StatefulAgent {
     final isAbsolute =
         path.startsWith('/') || (path.length >= 2 && path[1] == ':');
     return isAbsolute;
+  }
+
+  String? _javaScriptArgsAsString(dynamic rawArgs) {
+    if (rawArgs == null) return null;
+    if (rawArgs is String) return rawArgs;
+    if (rawArgs is Map) return jsonEncode(rawArgs);
+    return rawArgs.toString();
+  }
+
+  int? _javaScriptTimeoutMs(dynamic rawTimeout) {
+    if (rawTimeout is num) return rawTimeout.toInt();
+    if (rawTimeout is String && rawTimeout.trim().isNotEmpty) {
+      return int.tryParse(rawTimeout);
+    }
+    return null;
   }
 
   Future<void> _prepareDirectorySkills(
@@ -1727,9 +1746,6 @@ class StatefulAgent {
     AgentState state, {
     CancelToken? cancelToken,
   }) async {
-    // TODO(skill-scripts): Directory-skill script execution (especially JS sandbox)
-    // should be integrated here, because this is the central tool-call execution path.
-    // We intentionally do not execute scripts for mobile runtime in this iteration.
     final batchCallId = uuid.v4();
     final futures = calls.map((call) async {
       final tool = tools?.firstWhere(
@@ -1766,6 +1782,22 @@ class StatefulAgent {
             arguments: call.arguments,
             content: [TextPart('Error decoding arguments: $e')],
             isError: true,
+          );
+        }
+
+        if (call.name == 'RunJavaScript') {
+          final resultValue = await _runJavaScriptScript(
+            decodedArgs['script_path']?.toString() ?? '',
+            _javaScriptArgsAsString(decodedArgs['args']),
+            _javaScriptTimeoutMs(decodedArgs['timeout_ms']),
+            cancelToken: cancelToken,
+          );
+          return ExecutionToolResult(
+            id: call.id,
+            name: call.name,
+            arguments: call.arguments,
+            content: [TextPart(resultValue)],
+            isError: resultValue.startsWith('Error:'),
           );
         }
 

--- a/test/directory_skills_test.dart
+++ b/test/directory_skills_test.dart
@@ -207,6 +207,125 @@ void main() {
     },
   );
 
+  test(
+    'agent loop executes RunJavaScript through the central tool path',
+    () async {
+      final root = Directory('${tempDirectory.path}/allowed')..createSync();
+      final script = File('${root.path}/skill.js')
+        ..writeAsStringSync('ctx.args.n');
+      final runtime = _RecordingJavaScriptRuntime();
+      final client = _CapturingLLMClient([
+        _runJavaScriptCall(
+          id: 'js-1',
+          scriptPath: script.absolute.path,
+          args: '{"n":1}',
+        ),
+        ModelMessage(
+          model: 'fake-model',
+          textOutput: 'done',
+          stopReason: 'stop',
+        ),
+      ]);
+      final agent = _createAgent(
+        client: client,
+        skillDirectoryPaths: [root.path],
+        javaScriptRuntime: runtime,
+      );
+
+      await agent.run([
+        UserMessage.text('Run the skill script.'),
+      ], useStream: false);
+
+      expect(runtime.executedPaths, [script.absolute.path]);
+      expect(runtime.executedArgs, [
+        {'n': 1},
+      ]);
+      final toolResult = agent.state.history.messages
+          .whereType<FunctionExecutionResultMessage>()
+          .single
+          .results
+          .single;
+      expect(toolResult.isError, isFalse);
+      expect(
+        jsonDecode((toolResult.content.single as TextPart).text),
+        containsPair('success', true),
+      );
+    },
+  );
+
+  test(
+    'agent loop sandbox rejects RunJavaScript paths outside skill roots',
+    () async {
+      final root = Directory('${tempDirectory.path}/allowed')..createSync();
+      final outside = File('${tempDirectory.path}/outside.js')
+        ..writeAsStringSync('// rejected');
+      final runtime = _RecordingJavaScriptRuntime();
+      final client = _CapturingLLMClient([
+        _runJavaScriptCall(id: 'js-out', scriptPath: outside.absolute.path),
+        ModelMessage(
+          model: 'fake-model',
+          textOutput: 'done',
+          stopReason: 'stop',
+        ),
+      ]);
+      final agent = _createAgent(
+        client: client,
+        skillDirectoryPaths: [root.path],
+        javaScriptRuntime: runtime,
+      );
+
+      await agent.run([
+        UserMessage.text('Run a script outside the skill root.'),
+      ], useStream: false);
+
+      expect(runtime.executedPaths, isEmpty);
+      final toolResult = agent.state.history.messages
+          .whereType<FunctionExecutionResultMessage>()
+          .single
+          .results
+          .single;
+      expect(toolResult.isError, isTrue);
+      expect(
+        (toolResult.content.single as TextPart).text,
+        contains('must stay under one of the skillDirectoryPaths'),
+      );
+    },
+  );
+
+  test(
+    'cancelled RunJavaScript does not start the JavaScript runtime',
+    () async {
+      final root = Directory('${tempDirectory.path}/allowed')..createSync();
+      final script = File('${root.path}/skill.js')..writeAsStringSync('1');
+      final runtime = _RecordingJavaScriptRuntime();
+      final cancelToken = CancelToken();
+      final client = _CancelAfterGenerateClient(cancelToken, [
+        _runJavaScriptCall(id: 'js-cancel', scriptPath: script.absolute.path),
+      ]);
+      final agent = _createAgent(
+        client: client,
+        skillDirectoryPaths: [root.path],
+        javaScriptRuntime: runtime,
+      );
+
+      await expectLater(
+        agent.run(
+          [UserMessage.text('Run then cancel.')],
+          useStream: false,
+          cancelToken: cancelToken,
+        ),
+        throwsA(
+          isA<AgentException>().having(
+            (error) => error.code,
+            'code',
+            AgentExceptionCode.cancelled,
+          ),
+        ),
+      );
+      expect(runtime.executedPaths, isEmpty);
+    },
+  );
+
   test('clone sub-agents inherit every configured skill root', () async {
     final systemRoot = Directory('${tempDirectory.path}/system')..createSync();
     final projectRoot = Directory('${tempDirectory.path}/project')
@@ -350,8 +469,36 @@ class _CapturingLLMClient extends LLMClient {
   }
 }
 
+class _CancelAfterGenerateClient extends _CapturingLLMClient {
+  final CancelToken tokenToCancel;
+
+  _CancelAfterGenerateClient(this.tokenToCancel, [super.replies]);
+
+  @override
+  Future<ModelMessage> generate(
+    List<LLMMessage> messages, {
+    List<Tool>? tools,
+    ToolChoice? toolChoice,
+    required ModelConfig modelConfig,
+    bool? jsonOutput,
+    CancelToken? cancelToken,
+  }) async {
+    final reply = await super.generate(
+      messages,
+      tools: tools,
+      toolChoice: toolChoice,
+      modelConfig: modelConfig,
+      jsonOutput: jsonOutput,
+      cancelToken: cancelToken,
+    );
+    tokenToCancel.cancel('stop');
+    return reply;
+  }
+}
+
 class _RecordingJavaScriptRuntime implements JavaScriptRuntime {
   final executedPaths = <String>[];
+  final executedArgs = <Map<String, dynamic>?>[];
 
   @override
   Future<JavaScriptExecutionResult> executeFile({
@@ -362,8 +509,30 @@ class _RecordingJavaScriptRuntime implements JavaScriptRuntime {
     required JavaScriptBridgeContext bridgeContext,
   }) async {
     executedPaths.add(scriptPath);
+    executedArgs.add(args);
     return JavaScriptExecutionResult(success: true);
   }
+}
+
+ModelMessage _runJavaScriptCall({
+  required String id,
+  required String scriptPath,
+  String? args,
+}) {
+  return ModelMessage(
+    model: 'fake-model',
+    functionCalls: [
+      FunctionCall(
+        id: id,
+        name: 'RunJavaScript',
+        arguments: jsonEncode({
+          'script_path': scriptPath,
+          if (args != null) 'args': args,
+        }),
+      ),
+    ],
+    stopReason: 'tool_use',
+  );
 }
 
 class _TestSkill extends Skill {


### PR DESCRIPTION
## Summary
- RunJavaScript now executes in `_executeTools`, the path that handles model function calls.
- The skill-root sandbox and cancel token apply there: paths outside `skillDirectoryPaths` are rejected, and a cancelled run does not start the runtime.
- Agent-loop tests cover execute, reject-outside-root, and cancel. Direct `Function.apply` callers of the tool executable still work.

Fixes #29

## Test plan
- [x] `dart test test/directory_skills_test.dart`