### PR TITLE
feat: let ImagePart carry a hosted image URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.3
+
+- Allow `ImagePart` to carry a hosted `url` in addition to base64 data.
+- OpenAI Chat Completions and Responses send that URL as `image_url` instead of wrapping it as a data URI.
+- Anthropic Messages uses `source.type: url` for hosted images. Gemini and Bedrock still require base64.
+
 ## 2.1.2
 
 - Stop all tool execution when an agent run is already cancelled, including directory-skill JavaScript runtimes.

--- a/lib/src/agent/util.dart
+++ b/lib/src/agent/util.dart
@@ -18,7 +18,11 @@ String buildConversationHistory(
       final content = msg.contents
           .map((p) {
             if (p is TextPart) return p.text;
-            if (p is ImagePart) return '[Media: Image (${p.mimeType})]';
+            if (p is ImagePart) {
+              return p.hasUrl
+                  ? '[Media: Image (url)]'
+                  : '[Media: Image (${p.mimeType})]';
+            }
             if (p is VideoPart) return '[Media: Video (${p.mimeType})]';
             if (p is AudioPart) return '[Media: Audio (${p.mimeType})]';
             if (p is DocumentPart) return '[Media: Document (${p.mimeType})]';

--- a/lib/src/core/message.dart
+++ b/lib/src/core/message.dart
@@ -183,22 +183,51 @@ class TextPart extends UserContentPart {
 class ImagePart extends UserContentPart {
   final String base64Data;
   final String mimeType;
+  final String? url;
   final String? detail;
-  ImagePart(this.base64Data, this.mimeType, {this.detail});
+
+  ImagePart(this.base64Data, this.mimeType, {this.detail, this.url});
+
+  bool get hasUrl => url != null && url!.isNotEmpty;
+
+  void requireBase64(String clientName) {
+    if (hasUrl && base64Data.isEmpty) {
+      throw ArgumentError(
+        '$clientName requires base64 ImagePart data; url-only images are not supported.',
+      );
+    }
+  }
+
+  /// HTTPS URL or data URI for OpenAI Chat Completions / Responses.
+  String get openAiImageUrl {
+    if (hasUrl) return url!;
+    if (base64Data.startsWith('data')) return base64Data;
+    return 'data:$mimeType;base64,$base64Data';
+  }
+
+  /// Anthropic Messages `source` object (`url` or `base64`).
+  Map<String, dynamic> get claudeImageSource {
+    if (hasUrl) {
+      return {'type': 'url', 'url': url};
+    }
+    return {'type': 'base64', 'media_type': mimeType, 'data': base64Data};
+  }
 
   @override
   Map<String, dynamic> toJson() => {
     'type': 'image',
-    'base64Data': base64Data,
+    if (base64Data.isNotEmpty) 'base64Data': base64Data,
     'mimeType': mimeType,
+    if (hasUrl) 'url': url,
     if (detail != null) 'detail': detail,
   };
 
   factory ImagePart.fromJson(Map<String, dynamic> json) {
     return ImagePart(
-      json['base64Data'],
-      json['mimeType'] as String,
-      detail: json['detail'],
+      json['base64Data'] as String? ?? '',
+      json['mimeType'] as String? ?? 'image/jpeg',
+      detail: json['detail'] as String?,
+      url: json['url'] as String?,
     );
   }
 }

--- a/lib/src/core/message.dart
+++ b/lib/src/core/message.dart
@@ -223,11 +223,18 @@ class ImagePart extends UserContentPart {
   };
 
   factory ImagePart.fromJson(Map<String, dynamic> json) {
+    final base64Data = json['base64Data'] as String? ?? '';
+    final url = json['url'] as String?;
+    if (base64Data.isEmpty && (url == null || url.isEmpty)) {
+      throw const FormatException(
+        'ImagePart requires either base64Data or url.',
+      );
+    }
     return ImagePart(
-      json['base64Data'] as String? ?? '',
+      base64Data,
       json['mimeType'] as String? ?? 'image/jpeg',
       detail: json['detail'] as String?,
-      url: json['url'] as String?,
+      url: url,
     );
   }
 }

--- a/lib/src/llm/bedrock_claude_client.dart
+++ b/lib/src/llm/bedrock_claude_client.dart
@@ -329,6 +329,7 @@ class BedrockClaudeClient extends LLMClient {
                     if (c is TextPart) {
                       return {'type': 'text', 'text': c.text};
                     } else if (c is ImagePart) {
+                      c.requireBase64('BedrockClaudeClient');
                       return {
                         'type': 'image',
                         'source': {
@@ -368,6 +369,7 @@ class BedrockClaudeClient extends LLMClient {
                           return {'type': 'text', 'text': p.text};
                         }
                         if (p is ImagePart) {
+                          p.requireBase64('BedrockClaudeClient');
                           return {
                             'type': 'image',
                             'source': {

--- a/lib/src/llm/claude_client.dart
+++ b/lib/src/llm/claude_client.dart
@@ -302,14 +302,7 @@ class ClaudeClient extends LLMClient {
                     if (c is TextPart) {
                       return {'type': 'text', 'text': c.text};
                     } else if (c is ImagePart) {
-                      return {
-                        'type': 'image',
-                        'source': {
-                          'type': 'base64',
-                          'media_type': c.mimeType,
-                          'data': c.base64Data,
-                        },
-                      };
+                      return {'type': 'image', 'source': c.claudeImageSource};
                     } else if (c is DocumentPart) {
                       return {
                         'type': 'document',
@@ -350,11 +343,7 @@ class ClaudeClient extends LLMClient {
                         if (p is ImagePart) {
                           return {
                             'type': 'image',
-                            'source': {
-                              'type': 'base64',
-                              'media_type': p.mimeType,
-                              'data': p.base64Data,
-                            },
+                            'source': p.claudeImageSource,
                           };
                         }
                         return null;

--- a/lib/src/llm/gemini_client.dart
+++ b/lib/src/llm/gemini_client.dart
@@ -337,6 +337,7 @@ Map<String, dynamic> _createRequestBody(
         if (part is TextPart) {
           parts.add({'text': part.text});
         } else if (part is ImagePart) {
+          part.requireBase64('GeminiClient');
           parts.add({
             'inlineData': {'mimeType': part.mimeType, 'data': part.base64Data},
           });
@@ -388,6 +389,7 @@ Map<String, dynamic> _createRequestBody(
           if (part is TextPart) {
             // Keep implementation simple for text
           } else if (part is ImagePart) {
+            part.requireBase64('GeminiClient');
             partsList.add({
               'inlineData': {
                 'mimeType': part.mimeType,

--- a/lib/src/llm/openai_client.dart
+++ b/lib/src/llm/openai_client.dart
@@ -287,7 +287,7 @@ Map<String, dynamic> _createRequestBody(
               return {
                 'type': 'image_url',
                 'image_url': {
-                  'url': _convertBase64ToUrl(part.base64Data, part.mimeType),
+                  'url': part.openAiImageUrl,
                   if (part.detail != null) 'detail': part.detail,
                 },
               };
@@ -516,13 +516,6 @@ ModelMessage _parseResponse(
   } catch (e) {
     throw Exception('Unexpected response format from OpenAI: $data');
   }
-}
-
-String _convertBase64ToUrl(String base64Data, String mimeType) {
-  if (base64Data.startsWith("data")) {
-    return base64Data;
-  }
-  return 'data:$mimeType;base64,$base64Data';
 }
 
 class OpenAIChunkDecoder

--- a/lib/src/llm/responses_client.dart
+++ b/lib/src/llm/responses_client.dart
@@ -389,7 +389,7 @@ Map<String, dynamic> _createRequestBody(
         } else if (part is ImagePart) {
           contentList.add({
             'type': 'input_image',
-            'image_url': _convertBase64ToUrl(part.base64Data, part.mimeType),
+            'image_url': part.openAiImageUrl,
             if (part.detail != null) 'detail': part.detail,
           });
         } else if (part is AudioPart) {
@@ -901,11 +901,4 @@ class ButtonToolCallBuffer {
     required this.name,
     required this.arguments,
   });
-}
-
-String _convertBase64ToUrl(String base64Data, String mimeType) {
-  if (base64Data.startsWith("data")) {
-    return base64Data;
-  }
-  return 'data:$mimeType;base64,$base64Data';
 }

--- a/test/image_part_test.dart
+++ b/test/image_part_test.dart
@@ -45,6 +45,13 @@ void main() {
       expect(image.url, 'https://cdn.example/a.png');
       expect(image.hasUrl, isTrue);
     });
+
+    test('rejects json without base64 data or a url', () {
+      expect(
+        () => ImagePart.fromJson({'type': 'image', 'mimeType': 'image/png'}),
+        throwsA(isA<FormatException>()),
+      );
+    });
   });
 
   group('OpenAIClient image_url', () {

--- a/test/image_part_test.dart
+++ b/test/image_part_test.dart
@@ -1,0 +1,170 @@
+import 'dart:convert';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ImagePart', () {
+    test('base64 roundtrips through toJson/fromJson', () {
+      final part = ImagePart('abc123', 'image/png', detail: 'high');
+      final restored = ImagePart.fromJson(part.toJson());
+
+      expect(restored.base64Data, 'abc123');
+      expect(restored.mimeType, 'image/png');
+      expect(restored.detail, 'high');
+      expect(restored.url, isNull);
+      expect(restored.openAiImageUrl, 'data:image/png;base64,abc123');
+      expect(restored.claudeImageSource, {
+        'type': 'base64',
+        'media_type': 'image/png',
+        'data': 'abc123',
+      });
+    });
+
+    test('url roundtrips through toJson/fromJson', () {
+      const href = 'https://example.com/photo.jpg';
+      final part = ImagePart('', 'image/jpeg', url: href, detail: 'low');
+      final restored = ImagePart.fromJson(part.toJson());
+
+      expect(restored.hasUrl, isTrue);
+      expect(restored.url, href);
+      expect(restored.toJson().containsKey('base64Data'), isFalse);
+      expect(restored.openAiImageUrl, href);
+      expect(restored.claudeImageSource, {'type': 'url', 'url': href});
+    });
+
+    test('UserMessage with a url image roundtrips', () {
+      final message = UserMessage([
+        TextPart('see this'),
+        ImagePart('', 'image/png', url: 'https://cdn.example/a.png'),
+      ], timestamp: 1);
+      final restored = UserMessage.fromJson(message.toJson());
+      final image = restored.contents[1] as ImagePart;
+
+      expect(image.url, 'https://cdn.example/a.png');
+      expect(image.hasUrl, isTrue);
+    });
+  });
+
+  group('OpenAIClient image_url', () {
+    test('sends a hosted url without wrapping it as a data uri', () async {
+      const href = 'https://example.com/cat.png';
+      final adapter = _CaptureAdapter([(_) => _openaiOk()]);
+      final client = OpenAIClient(
+        apiKey: 'test-key',
+        client: Dio()..httpClientAdapter = adapter,
+      );
+
+      await client.generate([
+        UserMessage([ImagePart('', 'image/png', url: href)]),
+      ], modelConfig: ModelConfig(model: 'gpt-test'));
+
+      final body = _asJsonMap(adapter.requests.single);
+      final content =
+          (body['messages'][0] as Map<String, dynamic>)['content'] as List;
+      expect(content[0]['type'], 'image_url');
+      expect(content[0]['image_url']['url'], href);
+    });
+
+    test('still sends base64 as a data uri', () async {
+      final adapter = _CaptureAdapter([(_) => _openaiOk()]);
+      final client = OpenAIClient(
+        apiKey: 'test-key',
+        client: Dio()..httpClientAdapter = adapter,
+      );
+
+      await client.generate([
+        UserMessage([ImagePart('abc', 'image/png')]),
+      ], modelConfig: ModelConfig(model: 'gpt-test'));
+
+      final body = _asJsonMap(adapter.requests.single);
+      final content =
+          (body['messages'][0] as Map<String, dynamic>)['content'] as List;
+      expect(content[0]['image_url']['url'], 'data:image/png;base64,abc');
+    });
+  });
+
+  group('ClaudeClient image url', () {
+    test('sends Anthropic url source for hosted images', () async {
+      const href = 'https://example.com/cat.png';
+      final adapter = _CaptureAdapter([(_) => _claudeOk()]);
+      final client = ClaudeClient(
+        apiKey: 'test-key',
+        client: Dio()..httpClientAdapter = adapter,
+      );
+
+      await client.generate([
+        UserMessage([ImagePart('', 'image/png', url: href)]),
+      ], modelConfig: ModelConfig(model: 'claude-test'));
+
+      final body = _asJsonMap(adapter.requests.single);
+      final content =
+          (body['messages'][0] as Map<String, dynamic>)['content'] as List;
+      expect(content[0]['source'], {'type': 'url', 'url': href});
+    });
+  });
+}
+
+class _CaptureAdapter implements HttpClientAdapter {
+  final List<ResponseBody Function(RequestOptions)> responses;
+  final List<Object?> requests = [];
+
+  _CaptureAdapter(this.responses);
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add(options.data);
+    return responses.removeAt(0)(options);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+Map<String, dynamic> _asJsonMap(Object? data) {
+  if (data is Map<String, dynamic>) return data;
+  if (data is Map) return Map<String, dynamic>.from(data);
+  return jsonDecode(data as String) as Map<String, dynamic>;
+}
+
+ResponseBody _openaiOk() {
+  return ResponseBody.fromString(
+    jsonEncode({
+      'id': '1',
+      'object': 'chat.completion',
+      'choices': [
+        {
+          'index': 0,
+          'message': {'role': 'assistant', 'content': 'ok'},
+          'finish_reason': 'stop',
+        },
+      ],
+      'usage': {'prompt_tokens': 1, 'completion_tokens': 1, 'total_tokens': 2},
+    }),
+    200,
+    headers: {
+      Headers.contentTypeHeader: [Headers.jsonContentType],
+    },
+  );
+}
+
+ResponseBody _claudeOk() {
+  return ResponseBody.fromString(
+    jsonEncode({
+      'content': [
+        {'type': 'text', 'text': 'ok'},
+      ],
+      'stop_reason': 'end_turn',
+      'usage': {'input_tokens': 1, 'output_tokens': 1},
+    }),
+    200,
+    headers: {
+      Headers.contentTypeHeader: [Headers.jsonContentType],
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- `ImagePart` can now hold a hosted `url` as well as base64 data.
- OpenAI Chat Completions and Responses send that URL as `image_url` instead of wrapping it as a data URI.
- Anthropic Messages uses `source.type: url`. Gemini and Bedrock still require base64.

Fixes #31

## Test plan
- [x] `dart test test/image_part_test.dart`
- [ ] OpenAI / Claude request with `ImagePart(..., url: 'https://...')` uses the HTTPS URL, not a data URI
- [ ] Existing base64 `ImagePart` still becomes `data:image/...;base64,...`
