### PR TITLE
chore: release 2.1.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_agent_core
 description: A mobile-first, local-first Dart library for building and evaluating stateful, tool-using AI agents with multi-provider LLM and MCP support.
-version: 2.1.2
+version: 2.1.3
 repository: https://github.com/memex-lab/dart_agent_core
 homepage: https://github.com/memex-lab/dart_agent_core
 issue_tracker: https://github.com/memex-lab/dart_agent_core/issues


### PR DESCRIPTION
## Summary
- bump dart_agent_core to 2.1.3
- publish the hosted ImagePart URL support documented in CHANGELOG.md

## Test plan
- dart analyze .
- dart test (245 tests passed)
- dart pub publish --dry-run (only expected dirty-tree warning before commit)