### PR TITLE
fix: support Gemini 3.6 tool results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.4
+
+- Fix Gemini tool-result history by sending `functionResponse` parts with the supported `user` role, restoring function-calling compatibility with Gemini 3.6 while retaining compatibility with earlier models.
+- Add regression coverage for Gemini function-call and function-response roles and IDs.
+
 ## 2.1.3
 
 - Allow `ImagePart` to carry a hosted `url` in addition to base64 data.

--- a/lib/src/llm/gemini_client.dart
+++ b/lib/src/llm/gemini_client.dart
@@ -327,7 +327,9 @@ Map<String, dynamic> _createRequestBody(
     if (m is ModelMessage) {
       role = 'model';
     } else if (m is FunctionExecutionResultMessage) {
-      role = 'function';
+      // Gemini represents tool results as user content containing a
+      // functionResponse part. `function` is not a supported content role.
+      role = 'user';
     }
 
     List<Map<String, dynamic>> parts = [];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_agent_core
 description: A mobile-first, local-first Dart library for building and evaluating stateful, tool-using AI agents with multi-provider LLM and MCP support.
-version: 2.1.3
+version: 2.1.4
 repository: https://github.com/memex-lab/dart_agent_core
 homepage: https://github.com/memex-lab/dart_agent_core
 issue_tracker: https://github.com/memex-lab/dart_agent_core/issues

--- a/test/gemini_client_test.dart
+++ b/test/gemini_client_test.dart
@@ -97,6 +97,8 @@ void main() {
           (contents[1]['parts'] as List).single['functionResponse']
               as Map<String, dynamic>;
 
+      expect(contents[0]['role'], 'model');
+      expect(contents[1]['role'], 'user');
       expect(functionCall['id'], 'call_abc123');
       expect(functionCall['name'], 'Glob');
       expect(functionCall['args'], {'pattern': '*.dart'});


### PR DESCRIPTION
## Summary
- send Gemini function responses with the supported user role
- add regression coverage for function-call and function-response roles and IDs
- bump the package version to 2.1.3 and update the changelog

## Verification
- dart analyze .
- dart test
- live tool-call round trips with gemini-3.1-flash-lite, gemini-3.5-flash, and gemini-3.6-flash

Closes #34