### PR TITLE
fix: ignore stale or null activeSkills during skill compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.5
+
+- Keep `deactivate_skills` from throwing when `AgentState.activeSkills` is still null.
+- Skip unknown names in `activeSkills` while composing tools, so a stale persisted skill cannot crash the run.
+
 ## 2.1.4
 
 - Fix Gemini tool-result history by sending `functionResponse` parts with the supported `user` role, restoring function-calling compatibility with Gemini 3.6 while retaining compatibility with earlier models.

--- a/lib/src/agent/skill.dart
+++ b/lib/src/agent/skill.dart
@@ -257,6 +257,7 @@ String _activateSkills(List<String> skillNames) {
 
 String _deactivateSkills(List<String> skillNames) {
   final state = AgentCallToolContext.current!.state;
+  state.activeSkills ??= [];
   final skills = AgentCallToolContext.current!.agent.skills ?? [];
   final forceActiveSkillNames = skills
       .where((s) => s.forceActivate)

--- a/lib/src/agent/stateful_agent.dart
+++ b/lib/src/agent/stateful_agent.dart
@@ -626,7 +626,17 @@ class StatefulAgent {
         ...forceActiveSkillNames,
       }).toList();
       for (var skillName in activeSkillNames) {
-        final skill = skills!.firstWhere((s) => s.name == skillName);
+        Skill? skill;
+        for (final candidate in skills!) {
+          if (candidate.name == skillName) {
+            skill = candidate;
+            break;
+          }
+        }
+        if (skill == null) {
+          _logger.warning('[$name] Ignoring unknown active skill "$skillName"');
+          continue;
+        }
         toolsCopy.addAll(skill.tools ?? []);
       }
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_agent_core
 description: A mobile-first, local-first Dart library for building and evaluating stateful, tool-using AI agents with multi-provider LLM and MCP support.
-version: 2.1.4
+version: 2.1.5
 repository: https://github.com/memex-lab/dart_agent_core
 homepage: https://github.com/memex-lab/dart_agent_core
 issue_tracker: https://github.com/memex-lab/dart_agent_core/issues

--- a/test/in_memory_skills_test.dart
+++ b/test/in_memory_skills_test.dart
@@ -1,0 +1,247 @@
+import 'dart:convert';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('deactivate_skills succeeds when activeSkills is still null', () async {
+    final client = _QueuedLLMClient([
+      _toolCallReply('deactivate_skills', {
+        'skill_names': ['optional'],
+      }),
+      _textReply('done'),
+    ]);
+    final state = AgentState.empty();
+    expect(state.activeSkills, isNull);
+
+    final agent = _agent(
+      client: client,
+      state: state,
+      skills: [
+        _NamedSkill('optional'),
+        _NamedSkill('core', forceActivate: true),
+      ],
+    );
+
+    await agent.run([UserMessage.text('drop optional')], useStream: false);
+
+    expect(state.activeSkills, isEmpty);
+    expect(client.generateCalls, 2);
+  });
+
+  test('unknown activeSkills names do not crash composeTools', () async {
+    final client = _QueuedLLMClient([_textReply('ok')]);
+    final state = AgentState.empty()..activeSkills = ['deleted_skill'];
+    final agent = _agent(
+      client: client,
+      state: state,
+      skills: [
+        _NamedSkill(
+          'optional',
+          tools: [
+            Tool(
+              name: 'optional_tool',
+              description: 'optional',
+              parameters: const {'type': 'object', 'properties': {}},
+              parameterMode: ToolParameterMode.object,
+              executable: (Map<String, dynamic> _) => 'optional',
+            ),
+          ],
+        ),
+      ],
+    );
+
+    expect(() => agent.composeTools(), returnsNormally);
+    expect(
+      agent.composeTools().map((tool) => tool.name),
+      isNot(contains('optional_tool')),
+    );
+
+    await agent.run([UserMessage.text('hello')], useStream: false);
+    expect(client.generateCalls, 1);
+  });
+
+  test('activate_skills adds optional tools on the next compose', () async {
+    final client = _QueuedLLMClient([
+      _toolCallReply('activate_skills', {
+        'skill_names': ['search'],
+      }),
+      _textReply('activated'),
+    ]);
+    final searchTool = Tool(
+      name: 'search_notes',
+      description: 'search',
+      parameters: const {'type': 'object', 'properties': {}},
+      parameterMode: ToolParameterMode.object,
+      executable: (Map<String, dynamic> _) => 'hit',
+    );
+    final agent = _agent(
+      client: client,
+      state: AgentState.empty(),
+      skills: [
+        _NamedSkill('search', tools: [searchTool]),
+      ],
+    );
+
+    expect(
+      agent.composeTools().map((tool) => tool.name),
+      isNot(contains('search_notes')),
+    );
+
+    await agent.run([UserMessage.text('activate search')], useStream: false);
+
+    expect(agent.state.activeSkills, contains('search'));
+    expect(
+      agent.composeTools().map((tool) => tool.name),
+      contains('search_notes'),
+    );
+  });
+
+  test(
+    'forceActivate skills cannot be deactivated and stay in composeTools',
+    () async {
+      final client = _QueuedLLMClient([
+        _toolCallReply('deactivate_skills', {
+          'skill_names': ['core'],
+        }),
+        _textReply('still core'),
+      ]);
+      final coreTool = Tool(
+        name: 'core_tool',
+        description: 'core',
+        parameters: const {'type': 'object', 'properties': {}},
+        parameterMode: ToolParameterMode.object,
+        executable: (Map<String, dynamic> _) => 'core',
+      );
+      final agent = _agent(
+        client: client,
+        state: AgentState.empty(),
+        skills: [
+          _NamedSkill('core', forceActivate: true, tools: [coreTool]),
+          _NamedSkill('optional'),
+        ],
+      );
+
+      await agent.run([UserMessage.text('drop core')], useStream: false);
+
+      expect(
+        agent.composeTools().map((tool) => tool.name),
+        contains('core_tool'),
+      );
+      final result = agent.state.history.messages
+          .whereType<FunctionExecutionResultMessage>()
+          .single
+          .results
+          .single;
+      expect(
+        (result.content.single as TextPart).text,
+        contains('force activated'),
+      );
+    },
+  );
+
+  test('skills and skillDirectoryPaths cannot be enabled together', () {
+    expect(
+      () => StatefulAgent(
+        name: 'conflict',
+        client: _QueuedLLMClient([_textReply('x')]),
+        modelConfig: ModelConfig(model: 'fake-model'),
+        state: AgentState.empty(),
+        skills: [_NamedSkill('in-memory')],
+        skillDirectoryPaths: ['/tmp/skills'],
+        withGeneralPrinciples: false,
+        disableSubAgents: true,
+      ),
+      throwsA(isA<AssertionError>()),
+    );
+  });
+}
+
+StatefulAgent _agent({
+  required LLMClient client,
+  required AgentState state,
+  required List<Skill> skills,
+}) {
+  return StatefulAgent(
+    name: 'skills',
+    client: client,
+    modelConfig: ModelConfig(model: 'fake-model'),
+    state: state,
+    skills: skills,
+    withGeneralPrinciples: false,
+    disableSubAgents: true,
+  );
+}
+
+class _NamedSkill extends Skill {
+  _NamedSkill(String name, {super.forceActivate, super.tools})
+    : super(
+        name: name,
+        description: 'skill $name',
+        systemPrompt: 'Use $name when relevant.',
+      );
+}
+
+class _QueuedLLMClient extends LLMClient {
+  final List<ModelMessage> replies;
+  int generateCalls = 0;
+
+  _QueuedLLMClient(this.replies);
+
+  @override
+  Future<ModelMessage> generate(
+    List<LLMMessage> messages, {
+    List<Tool>? tools,
+    ToolChoice? toolChoice,
+    required ModelConfig modelConfig,
+    bool? jsonOutput,
+    CancelToken? cancelToken,
+  }) async {
+    if (generateCalls >= replies.length) {
+      throw StateError('Unexpected extra generate() call');
+    }
+    return replies[generateCalls++];
+  }
+
+  @override
+  Future<Stream<StreamingMessage>> stream(
+    List<LLMMessage> messages, {
+    List<Tool>? tools,
+    ToolChoice? toolChoice,
+    required ModelConfig modelConfig,
+    bool? jsonOutput,
+    CancelToken? cancelToken,
+  }) async {
+    return Stream.value(
+      StreamingMessage(
+        modelMessage: await generate(
+          messages,
+          tools: tools,
+          toolChoice: toolChoice,
+          modelConfig: modelConfig,
+          jsonOutput: jsonOutput,
+          cancelToken: cancelToken,
+        ),
+      ),
+    );
+  }
+}
+
+ModelMessage _textReply(String text) {
+  return ModelMessage(
+    textOutput: text,
+    model: 'fake-model',
+    stopReason: 'stop',
+  );
+}
+
+ModelMessage _toolCallReply(String name, Map<String, dynamic> arguments) {
+  return ModelMessage(
+    model: 'fake-model',
+    stopReason: 'tool_calls',
+    functionCalls: [
+      FunctionCall(id: 'call-1', name: name, arguments: jsonEncode(arguments)),
+    ],
+  );
+}


### PR DESCRIPTION
## Summary
- `deactivate_skills` no longer throws when `AgentState.activeSkills` is still null.
- Unknown names in `activeSkills` are skipped while composing tools, so a persisted/renamed skill cannot crash the run.
- Adds in-memory skill tests for activate/deactivate, force-activate, and the skills vs skillDirectoryPaths assert.
- Bumps the package to 2.1.5.

## Test plan
- [x] `dart test test/in_memory_skills_test.dart`
- [x] `dart analyze .`
- [x] Existing directory-skill tests still pass (`dart test test/directory_skills_test.dart`)