### PR TITLE
fix: wrap Gemini required toolChoice under functionCallingConfig

### DIFF
--- a/lib/src/llm/gemini_client.dart
+++ b/lib/src/llm/gemini_client.dart
@@ -506,7 +506,7 @@ Map<String, dynamic> _createRequestBody(
         if (toolChoice?.allowedFunctionNames != null) {
           toolConfig['allowedFunctionNames'] = toolChoice!.allowedFunctionNames;
         }
-        body['toolConfig'] = toolConfig;
+        body['toolConfig'] = {'functionCallingConfig': toolConfig};
         break;
       case null:
         // Do nothing

--- a/test/gemini_client_test.dart
+++ b/test/gemini_client_test.dart
@@ -106,6 +106,57 @@ void main() {
       expect(functionResponse['name'], 'Glob');
       expect(functionResponse['response'], {'content': '["lib/main.dart"]'});
     });
+
+    test(
+      'required toolChoice wraps mode under functionCallingConfig',
+      () async {
+        final adapter = _CaptureAdapter([
+          (_) => _jsonResponse({
+            'candidates': [
+              {
+                'content': {
+                  'parts': [
+                    {'text': 'ok'},
+                  ],
+                },
+                'finishReason': 'STOP',
+              },
+            ],
+          }),
+        ]);
+        final client = GeminiClient(
+          apiKey: 'test-key',
+          client: Dio()..httpClientAdapter = adapter,
+        );
+
+        await client.generate(
+          [UserMessage.text('use a tool')],
+          tools: [
+            Tool(
+              name: 'Glob',
+              description: 'Find files',
+              parameters: const {
+                'type': 'object',
+                'properties': <String, dynamic>{},
+              },
+            ),
+          ],
+          toolChoice: ToolChoice(
+            mode: ToolChoiceMode.required,
+            allowedFunctionNames: const ['Glob'],
+          ),
+          modelConfig: ModelConfig(model: 'gemini-test'),
+        );
+
+        final body = adapter.bodies.single as Map<String, dynamic>;
+        expect(body['toolConfig'], {
+          'functionCallingConfig': {
+            'mode': 'ANY',
+            'allowedFunctionNames': ['Glob'],
+          },
+        });
+      },
+    );
   });
 }
 


### PR DESCRIPTION
## Summary
Hey memex team — while reading `GeminiClient` after the 3.6 tool-result work I noticed `ToolChoiceMode.required` does not match the shape you already use for `none` / `auto`.

Those two wrap `{functionCallingConfig: ...}`. `required` was sending a flat `{mode: ANY}`, which Gemini rejects. This wraps it the same way, including `allowedFunctionNames`.

## Test plan
- [x] `dart test test/gemini_client_test.dart`
- [x] `dart analyze` on the touched files