### PR TITLE
fix: clarify eval metrics with insufficient samples

### DIFF
--- a/doc/eval-guide.md
+++ b/doc/eval-guide.md
@@ -887,6 +887,9 @@ Anthropic recommends targeting **pass@1 close to 100% and as large a
 k as possible for pass^k** — the latter measures sustained
 reliability.
 
+When `k` exceeds the observed trial count `n`, Markdown reports show
+`pass@k` as `N/A` and mark `pass^k` as a low-confidence empirical estimate.
+
 ```dart
 final passAt = report.passAtKByTask(ks: [1, 3, 5]);
 final passCk = report.passCaretKByTask(ks: [1, 3, 5]);

--- a/doc/eval-guide.zh-CN.md
+++ b/doc/eval-guide.zh-CN.md
@@ -830,6 +830,9 @@ class Outcome {
 `pass^k = (c/n)^k`。"k 次尝试全部成功"的概率。Anthropic 推荐
 **pass@1 接近 100%、pass^k 的 k 越大越好**（连续稳定通过的能力）。
 
+当 `k` 大于实际 trial 数 `n` 时，Markdown 报告会将 `pass@k` 显示为
+`N/A`，并把 `pass^k` 标记为低置信度的经验估计。
+
 ```dart
 final passAt = report.passAtKByTask(ks: [1, 3, 5]);
 final passCk = report.passCaretKByTask(ks: [1, 3, 5]);

--- a/lib/src/eval/metrics/pass_caret_k.dart
+++ b/lib/src/eval/metrics/pass_caret_k.dart
@@ -5,10 +5,11 @@
 /// version because it's intuitive and consistent with how teams report
 /// "X out of Y trials passed" in CI reports.
 ///
-/// Returns 0.0 when k <= 0 or n == 0.
+/// Returns 0.0 when k <= 0, n == 0, or k > n (cannot evaluate that many).
 double passCaretK(List<bool> trialPasses, int k) {
   final n = trialPasses.length;
   if (k <= 0 || n == 0) return 0.0;
+  if (k > n) return 0.0;
   final c = trialPasses.where((p) => p).length;
   if (c == 0) return 0.0;
   // (c/n)^k

--- a/lib/src/eval/metrics/pass_caret_k.dart
+++ b/lib/src/eval/metrics/pass_caret_k.dart
@@ -5,11 +5,10 @@
 /// version because it's intuitive and consistent with how teams report
 /// "X out of Y trials passed" in CI reports.
 ///
-/// Returns 0.0 when k <= 0, n == 0, or k > n (cannot evaluate that many).
+/// Returns 0.0 when k <= 0 or n == 0.
 double passCaretK(List<bool> trialPasses, int k) {
   final n = trialPasses.length;
   if (k <= 0 || n == 0) return 0.0;
-  if (k > n) return 0.0;
   final c = trialPasses.where((p) => p).length;
   if (c == 0) return 0.0;
   // (c/n)^k

--- a/lib/src/eval/reporting/report_generator.dart
+++ b/lib/src/eval/reporting/report_generator.dart
@@ -42,6 +42,7 @@ String generateMarkdownReport(
   final passAtK = report.passAtKByTask(ks: ksToReport);
   final passCK = report.passCaretKByTask(ks: ksToReport);
   if (passAtK.isNotEmpty && ksToReport.isNotEmpty) {
+    var hasInsufficientSamples = false;
     b.writeln('## pass@k / pass^k by task');
     b.writeln();
     final headers = [
@@ -51,16 +52,26 @@ String generateMarkdownReport(
     b.writeln('| ${headers.join(' | ')} |');
     b.writeln('|${'---|' * headers.length}');
     for (final taskId in passAtK.keys) {
+      final trialCount = byTask[taskId]?.length ?? 0;
       final cells = <String>[
         '`$taskId`',
         for (final k in ksToReport) ...[
-          _pct(passAtK[taskId]?[k] ?? 0),
-          _pct(passCK[taskId]?[k] ?? 0),
+          if (k > trialCount) 'N/A' else _pct(passAtK[taskId]?[k] ?? 0),
+          '${_pct(passCK[taskId]?[k] ?? 0)}${k > trialCount ? ' ⚠️' : ''}',
         ],
       ];
+      hasInsufficientSamples |= ksToReport.any((k) => k > trialCount);
       b.writeln('| ${cells.join(' | ')} |');
     }
     b.writeln();
+    if (hasInsufficientSamples) {
+      b.writeln(
+        '> ⚠️ When `k` exceeds the observed trial count `n`, `pass@k` is '
+        'not available. `pass^k` remains an empirical estimate but is marked '
+        'as low confidence.',
+      );
+      b.writeln();
+    }
   }
 
   // Bucket pass rates

--- a/test/eval/metrics_test.dart
+++ b/test/eval/metrics_test.dart
@@ -76,8 +76,8 @@ void main() {
       expect(passCaretK(<bool>[], 1), 0.0);
     });
 
-    test('k > n returns 0.0', () {
-      expect(passCaretK([true, false], 5), 0.0);
+    test('k > n remains a valid empirical estimate', () {
+      expect(passCaretK([true, false], 5), closeTo(0.03125, 1e-9));
     });
   });
 

--- a/test/eval/metrics_test.dart
+++ b/test/eval/metrics_test.dart
@@ -75,6 +75,10 @@ void main() {
       expect(passCaretK([true], 0), 0.0);
       expect(passCaretK(<bool>[], 1), 0.0);
     });
+
+    test('k > n returns 0.0', () {
+      expect(passCaretK([true, false], 5), 0.0);
+    });
   });
 
   group('ClassificationMetrics', () {

--- a/test/eval/suite_and_report_test.dart
+++ b/test/eval/suite_and_report_test.dart
@@ -342,6 +342,36 @@ void main() {
       expect(passCk['b']![2], 1.0);
     });
 
+    test('markdown marks metrics with insufficient samples', () {
+      final report = EvalRunReport(
+        runName: 'r',
+        suite: suiteOf(SuiteKind.mixed),
+        trials: [
+          makeTrialResult(
+            runName: 'r',
+            suiteName: 's',
+            taskId: 'a',
+            trialIndex: 0,
+            scores: [okScore('noop')],
+          ),
+          makeTrialResult(
+            runName: 'r',
+            suiteName: 's',
+            taskId: 'a',
+            trialIndex: 1,
+            scores: [failScore('noop')],
+          ),
+        ],
+        startedAt: DateTime(2025),
+        endedAt: DateTime(2025),
+      );
+
+      final markdown = generateMarkdownReport(report, ksToReport: const [5]);
+
+      expect(markdown, contains('| `a` | N/A | 3.1% ⚠️ |'));
+      expect(markdown, contains('`pass^k` remains an empirical estimate'));
+    });
+
     test('bucketPassRates groups by failure_bucket', () {
       final report = EvalRunReport(
         runName: 'r',


### PR DESCRIPTION
## Summary

Clarify eval-report behavior when the requested `k` exceeds the observed trial count `n`.

- Keep `passCaretK` mathematically defined as `(c / n)^k`; the public function remains numeric and API-compatible.
- Render `pass@k` as `N/A` in Markdown reports when `k > n`, because the combinatorial metric cannot be evaluated from the available trials.
- Render `pass^k` normally but add a warning marker, because it remains a valid empirical estimate with low confidence.
- Document the distinction in the English and Chinese eval guides.
- Add regression coverage for both metric calculation and report rendering.

## Test plan

- [x] `dart format` on touched Dart files
- [x] `dart analyze .`
- [x] `dart test test/eval/metrics_test.dart test/eval/suite_and_report_test.dart`
- [x] `dart test` (247 tests)
- [x] `git diff --check`
