### PR TITLE
fix: include toolChoice in eval request hashes

### DIFF
--- a/doc/eval-guide.md
+++ b/doc/eval-guide.md
@@ -962,7 +962,7 @@ final replay = ReplayLLMClient(
 
 Request hashing is done by `Sha256LLMRequestHash` (default):
 
-- Includes `messages` / `tools` / `modelConfig` / `jsonOutput` / `trialSalt`
+- Includes `messages` / `tools` / `modelConfig` / `jsonOutput` / `toolChoice` / `trialSalt`
 - Use `stripMessageKeys` to ignore volatile fields (`timestamp`, etc.)
 - Changing the prompt or tools → hash changes → cache misses → CI surfaces it as a re-record signal
 

--- a/doc/eval-guide.zh-CN.md
+++ b/doc/eval-guide.zh-CN.md
@@ -902,7 +902,7 @@ final replay = ReplayLLMClient(
 
 请求 hash 由 `Sha256LLMRequestHash` 计算（默认）：
 
-- 包含 `messages` / `tools` / `modelConfig` / `jsonOutput` / `trialSalt`
+- 包含 `messages` / `tools` / `modelConfig` / `jsonOutput` / `toolChoice` / `trialSalt`
 - 可通过 `stripMessageKeys` 跳过易变字段（`timestamp` 等）
 - prompt 或 tools 改了 → hash 变 → 缓存自动失效，CI 报错提示 re-record
 

--- a/lib/src/eval/llm/llm_request_hash.dart
+++ b/lib/src/eval/llm/llm_request_hash.dart
@@ -35,12 +35,13 @@ abstract class LLMRequestHash {
     required List<Tool>? tools,
     required ModelConfig modelConfig,
     bool? jsonOutput,
+    ToolChoice? toolChoice,
     String? trialSalt,
   });
 }
 
 /// Default SHA-256 based implementation. Hashes the JSON-encoded
-/// `(messages, tools, modelConfig, jsonOutput, trialSalt)` tuple.
+/// `(messages, tools, modelConfig, jsonOutput, toolChoice, trialSalt)` tuple.
 /// `Tool.executable` closures are ignored (they're not in toJson).
 ///
 /// **Default-stripped keys**: `timestamp` is always stripped from
@@ -68,6 +69,7 @@ class Sha256LLMRequestHash implements LLMRequestHash {
     required List<Tool>? tools,
     required ModelConfig modelConfig,
     bool? jsonOutput,
+    ToolChoice? toolChoice,
     String? trialSalt,
   }) {
     final payload = {
@@ -75,6 +77,7 @@ class Sha256LLMRequestHash implements LLMRequestHash {
       'tools': tools?.map((t) => t.toJson()).toList(),
       'model': modelConfig.toJson(),
       'jsonOutput': ?jsonOutput,
+      'toolChoice': ?toolChoice?.toJson(),
       'trialSalt': ?trialSalt,
     };
     final encoded = utf8.encode(_canonicalJson(payload));

--- a/lib/src/eval/llm/recording_llm_client.dart
+++ b/lib/src/eval/llm/recording_llm_client.dart
@@ -75,6 +75,7 @@ class RecordingLLMClient implements LLMClient {
       tools: tools,
       modelConfig: modelConfig,
       jsonOutput: jsonOutput,
+      toolChoice: toolChoice,
       trialSalt: trialSalt,
     );
     try {

--- a/lib/src/eval/llm/replay_llm_client.dart
+++ b/lib/src/eval/llm/replay_llm_client.dart
@@ -84,6 +84,7 @@ class ReplayLLMClient implements LLMClient {
       tools: tools,
       modelConfig: modelConfig,
       jsonOutput: jsonOutput,
+      toolChoice: toolChoice,
       trialSalt: trialSalt,
     );
     final cached = await store.get(hash);

--- a/test/eval/llm_record_replay_test.dart
+++ b/test/eval/llm_record_replay_test.dart
@@ -80,6 +80,33 @@ void main() {
       expect(a, isNot(b));
     });
 
+    test('toolChoice flips hash', () {
+      const h = Sha256LLMRequestHash();
+      final a = h.compute(
+        messages: [_msg('hi')],
+        tools: null,
+        modelConfig: _cfg(),
+        toolChoice: ToolChoice(mode: ToolChoiceMode.auto),
+      );
+      final b = h.compute(
+        messages: [_msg('hi')],
+        tools: null,
+        modelConfig: _cfg(),
+        toolChoice: ToolChoice(
+          mode: ToolChoiceMode.required,
+          allowedFunctionNames: const ['foo'],
+        ),
+      );
+      final none = h.compute(
+        messages: [_msg('hi')],
+        tools: null,
+        modelConfig: _cfg(),
+      );
+      expect(a, isNot(b));
+      expect(a, isNot(none));
+      expect(b, isNot(none));
+    });
+
     test('timestamp is stripped by default — UserMessages with different '
         'timestamps still hash equal', () {
       const h = Sha256LLMRequestHash();


### PR DESCRIPTION
## Summary
Hey @sparkleMing — the record/replay hasher already treats `jsonOutput` as part of the request, but it dropped `toolChoice`.

That means an `auto` recording can be replayed for a later `required` call with the same messages/tools/model. I added `toolChoice` to the hash payload and threaded it through `RecordingLLMClient` / `ReplayLLMClient`.

## Test plan
- [x] `dart test test/eval/llm_record_replay_test.dart`
- [x] `dart analyze` on the touched files