### PR TITLE
fix: reject FileStateStorage sessionIds that escape the directory

### DIFF
--- a/lib/src/agent/file_state_storage_io.dart
+++ b/lib/src/agent/file_state_storage_io.dart
@@ -18,7 +18,21 @@ class FileStateStorage implements StateStorage {
   Directory get _directory => Directory(directoryPath);
 
   File _getFile(String sessionId) {
+    _assertSafeSessionId(sessionId);
     return File('$directoryPath/$sessionId.json');
+  }
+
+  static void _assertSafeSessionId(String sessionId) {
+    if (sessionId.isEmpty ||
+        sessionId.contains('/') ||
+        sessionId.contains(r'\') ||
+        sessionId.contains('..')) {
+      throw ArgumentError.value(
+        sessionId,
+        'sessionId',
+        'must be a single path segment',
+      );
+    }
   }
 
   @override

--- a/test/file_state_storage_session_id_test.dart
+++ b/test/file_state_storage_session_id_test.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Directory directory;
+
+  setUp(() {
+    directory = Directory.systemTemp.createTempSync(
+      'file_state_storage_session_id_',
+    );
+  });
+
+  tearDown(() {
+    if (directory.existsSync()) {
+      directory.deleteSync(recursive: true);
+    }
+  });
+
+  test('save and load keep the file under the storage directory', () async {
+    final storage = FileStateStorage(directory.path);
+    await storage.save(AgentState(sessionId: 'session_123'));
+
+    expect(File('${directory.path}/session_123.json').existsSync(), isTrue);
+
+    final loaded = await storage.loadOrCreate('session_123', null);
+    expect(loaded.sessionId, 'session_123');
+  });
+
+  test('rejects a sessionId that would escape the storage directory', () async {
+    final storage = FileStateStorage(directory.path);
+
+    expect(
+      () => storage.save(AgentState(sessionId: '../../escaped')),
+      throwsA(isA<ArgumentError>()),
+    );
+    expect(File('${directory.parent.path}/escaped.json').existsSync(), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
Hey memex team — `FileStateStorage` was concatenating `sessionId` straight onto the directory path.

A value like `../../escaped` can write or delete a JSON file outside the storage folder. This rejects empty IDs and anything with `/`, `\`, or `..`, and keeps a normal `session_123` round-trip.

## Test plan
- [x] `dart test test/file_state_storage_session_id_test.dart`
- [x] `dart analyze` on the touched files