### PR TITLE
docs: port Chinese README provider examples into English

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,7 +649,7 @@ See the [`example/`](example) directory:
 ## Documentation
 
 - [Architecture & Lifecycle](doc/architecture.md) — Agent loop, streaming events, agent hooks, loop detection, cancellation
-- [LLM Providers & Configuration](doc/providers.md) — OpenAI, Gemini, Bedrock setup, ModelConfig, proxy support
+- [LLM Providers & Configuration](doc/providers.md) — OpenAI, Gemini, Bedrock, Claude, Kimi, Qwen, GLM, Doubao, MiniMax, Ollama, OpenRouter, ModelConfig, proxy support
 - [Tools & Planning](doc/tools_and_planning.md) — Tool creation, parameter mapping, AgentToolResult, skills, sub-agents, planner
 - [Model Context Protocol](doc/mcp.md) — Stdio/HTTP connections, progressive discovery, bridge tools, lifecycle, platform notes
 - [State & Memory Management](doc/state_and_memory.md) — AgentState, FileStateStorage, context compression, episodic memory

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Features
 
-- **Multi-provider support**: Unified `LLMClient` interface for OpenAI (Chat Completions & Responses API), Google Gemini, and Anthropic Claude via AWS Bedrock.
+- **Multi-provider support**: Unified `LLMClient` interface for OpenAI (Chat Completions & Responses API), Google Gemini, and Anthropic Claude (direct API and AWS Bedrock). Many OpenAI-compatible models can be used through `OpenAIClient` (Kimi, Qwen, GLM, Ollama, OpenRouter); Doubao through `ResponsesClient`; MiniMax through `ClaudeClient`.
 - **Tool use**: Wrap any Dart function as a tool with a JSON Schema definition. The agent dispatches calls, feeds results back, and loops until done. Tools support two parameter modes: function mode (positional/named parameter mapping via `Function.apply`) and object mode (receive all arguments as a `Map<String, dynamic>`). Tools can return `AgentToolResult` to carry multimodal content, metadata, or a stop signal.
 - **Model Context Protocol (MCP)**: Connect to local stdio or remote Streamable HTTP MCP servers. The agent discovers and invokes server tools, resources, and prompts through a compact progressive-disclosure bridge.
 - **Multimodal input**: `UserMessage` accepts text, images, audio, video, and documents as content parts. Model responses can include text, images, video, and audio.

--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ void main() async {
 
 ## Supported Providers
 
+`dart_agent_core` hides provider differences behind a single `LLMClient`. Initialize the matching client and pass it to `StatefulAgent`.
+
+Many models expose an OpenAI Chat Completions API, so you can point `OpenAIClient` at a custom `baseUrl`.
+
 ### OpenAI (Chat Completions)
 
 ```dart
@@ -166,6 +170,90 @@ Directly calls the Anthropic Messages API, no AWS Bedrock needed.
 final client = ClaudeClient(
   apiKey: Platform.environment['ANTHROPIC_API_KEY'] ?? '',
 );
+```
+
+### Kimi (Moonshot AI)
+
+Kimi is OpenAI Chat Completions compatible. Point `OpenAIClient` at Kimi's `baseUrl`. Models such as `kimi-k2` and `kimi-k2-thinking` work; `reasoning_content` from thinking models is handled automatically.
+
+```dart
+final client = OpenAIClient(
+  apiKey: Platform.environment['MOONSHOT_API_KEY'] ?? '',
+  baseUrl: 'https://api.moonshot.cn/v1',
+);
+final config = ModelConfig(model: 'kimi-k2');
+```
+
+### Qwen (Alibaba DashScope)
+
+DashScope exposes an OpenAI-compatible API.
+
+```dart
+final client = OpenAIClient(
+  apiKey: Platform.environment['DASHSCOPE_API_KEY'] ?? '',
+  baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+);
+final config = ModelConfig(model: 'qwen3.5-plus');
+```
+
+### Zhipu GLM
+
+GLM exposes an OpenAI-compatible API.
+
+```dart
+final client = OpenAIClient(
+  apiKey: Platform.environment['GLM_API_KEY'] ?? '',
+  baseUrl: 'https://open.bigmodel.cn/api/coding/paas/v4',
+);
+final config = ModelConfig(model: 'GLM-4.7');
+```
+
+### Volcengine Doubao-Seed
+
+Doubao is compatible with the OpenAI Responses API. Use `ResponsesClient`.
+
+```dart
+final client = ResponsesClient(
+  apiKey: Platform.environment['ARK_API_KEY'] ?? '',
+  baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
+);
+final config = ModelConfig(model: 'doubao-seed-1-8-251228');
+```
+
+### MiniMax
+
+MiniMax exposes an Anthropic-compatible API. Use `ClaudeClient`.
+
+```dart
+final client = ClaudeClient(
+  apiKey: Platform.environment['MINIMAX_API_KEY'] ?? '',
+  baseUrl: 'https://api.minimaxi.com/anthropic',
+);
+final config = ModelConfig(model: 'MiniMax-M2.5');
+```
+
+### Ollama (local)
+
+Ollama serves an OpenAI-compatible API locally and does not require an API key.
+
+```dart
+final client = OpenAIClient(
+  apiKey: '', // Ollama does not need an API key
+  baseUrl: 'http://localhost:11434/v1',
+);
+final config = ModelConfig(model: 'qwen2.5:7b');
+```
+
+### OpenRouter
+
+OpenRouter aggregates many models behind an OpenAI-compatible API.
+
+```dart
+final client = OpenAIClient(
+  apiKey: Platform.environment['OPENROUTER_API_KEY'] ?? '',
+  baseUrl: 'https://openrouter.ai/api/v1',
+);
+final config = ModelConfig(model: 'anthropic/claude-opus-4.6');
 ```
 
 All clients support HTTP proxies via `proxyUrl` and configurable retry/timeout parameters. See [Providers doc](doc/providers.md) for details.


### PR DESCRIPTION
## Summary
- English README Features now mention Claude direct plus Kimi, Qwen, GLM, Doubao, MiniMax, Ollama, and OpenRouter, matching README.zh-CN.md.
- Adds the same provider setup snippets that already lived only in the Chinese README.
- Documentation index lists those providers next to the existing providers guide.

## Test plan
- [x] Skim the Supported Providers section in README.md against README.zh-CN.md
- [x] Confirm the new snippets match `doc/providers.md` (no API/URL drift)
- [x] Click through the Documentation index link for providers