### PR TITLE
docs: add Chinese architecture and providers guides

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -648,8 +648,8 @@ final agent = StatefulAgent(
 
 ## 文档
 
-- [架构与生命周期](doc/architecture.md) — Agent 循环、流式事件、Agent Hook、循环检测、取消机制
-- [LLM Provider 与配置](doc/providers.md) — OpenAI、Gemini、Bedrock、Claude、Kimi、Qwen、GLM 等配置，ModelConfig，代理支持
+- [架构与生命周期](doc/architecture.zh-CN.md) — Agent 循环、流式事件、Agent Hook、循环检测、取消机制
+- [LLM Provider 与配置](doc/providers.zh-CN.md) — OpenAI、Gemini、Bedrock、Claude、Kimi、Qwen、GLM 等配置，ModelConfig，代理支持
 - [工具与规划](doc/tools_and_planning.md) — 工具创建、参数映射、AgentToolResult、技能、子 Agent、规划器
 - [Model Context Protocol](doc/mcp.zh-CN.md) — stdio/HTTP 连接、渐进式发现、桥接工具、生命周期与平台说明
 - [状态与记忆管理](doc/state_and_memory.md) — AgentState、FileStateStorage、上下文压缩、情节记忆

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -650,9 +650,9 @@ final agent = StatefulAgent(
 
 - [架构与生命周期](doc/architecture.zh-CN.md) — Agent 循环、流式事件、Agent Hook、循环检测、取消机制
 - [LLM Provider 与配置](doc/providers.zh-CN.md) — OpenAI、Gemini、Bedrock、Claude、Kimi、Qwen、GLM 等配置，ModelConfig，代理支持
-- [工具与规划](doc/tools_and_planning.md) — 工具创建、参数映射、AgentToolResult、技能、子 Agent、规划器
+- [工具与规划](doc/tools_and_planning.zh-CN.md) — 工具创建、参数映射、AgentToolResult、技能、子 Agent、规划器
 - [Model Context Protocol](doc/mcp.zh-CN.md) — stdio/HTTP 连接、渐进式发现、桥接工具、生命周期与平台说明
-- [状态与记忆管理](doc/state_and_memory.md) — AgentState、FileStateStorage、上下文压缩、情节记忆
+- [状态与记忆管理](doc/state_and_memory.zh-CN.md) — AgentState、FileStateStorage、上下文压缩、情节记忆
 - [评估指南](doc/eval-guide.zh-CN.md) — 对齐 Anthropic 方法论的评估子系统：task / grader / suite、pass@k / pass^k、录制回放、Langfuse 上报、跨 run 健康度
 
 ---

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,5 +1,7 @@
 # Architecture & Lifecycle
 
+[English](architecture.md) | [简体中文](architecture.zh-CN.md)
+
 ## The `StatefulAgent`
 
 `StatefulAgent` manages an `AgentState` and runs an autonomous "think-act-observe" loop. Every call to `run()` or `runStream()` starts the loop with the current state and continues until a stop condition is met.

--- a/doc/architecture.zh-CN.md
+++ b/doc/architecture.zh-CN.md
@@ -1,0 +1,201 @@
+# 架构与生命周期
+
+[English](architecture.md) | [简体中文](architecture.zh-CN.md)
+
+## `StatefulAgent`
+
+`StatefulAgent` 持有一份 `AgentState`，并运行自主的「思考—行动—观察」循环。每次调用 `run()` 或 `runStream()` 都会基于当前状态启动循环，直到满足停止条件。
+
+### Agent 循环步骤
+
+1. **压缩上下文**（可选）：若挂载了 `ContextCompressor` 且 Token 超过阈值，会在发起模型调用前把旧消息压缩为情节记忆（episodic memory）。
+2. **组装请求**：系统提示词与工具列表会根据系统提示、激活技能、规划器工具、子 Agent 工具、记忆工具以及已连接的 MCP Server 动态组装。
+3. **运行 `beforeModelCall` Hook**（可选）：Hook 可以改写系统提示词、请求消息、工具列表、tool choice、模型配置，或直接返回合成的模型响应。若希望数据在后续回合或 resume 后仍然有效，应写入 `context.state`。
+4. **调用 LLM**：把格式化后的消息历史发给选定的 `LLMClient`；若 Hook 已提供合成响应则跳过。
+5. **运行模型响应 Hook**（可选）：流式分片经过 `onModelChunk`；组装后的完整响应经过 `afterModelCall`，可改写、重试或中止。
+6. **处理响应**：
+   - 若模型未返回工具调用，循环结束并返回最终 `ModelMessage`。
+   - 若模型请求一个或多个 `FunctionCall`，`beforeToolCall` Hook 可以允许、改写、拒绝、延后或中止每次调用。执行结果与合成结果会追加到历史中；`afterToolCall` Hook 可以改写结果或注入后续上下文，然后循环回到第 1 步。
+7. **停止条件**：循环在以下情况退出：没有工具调用、工具返回 `stopFlag = true`、Hook 返回 stop/abort、`AgentException`（循环检测、取消、被 Hook 停止），或未处理的异常。
+
+### 流式生命周期
+
+Flutter UI 推荐使用 `agent.runStream()`，它会产出 `Stream<StreamingEvent>`：
+
+```dart
+await for (final event in agent.runStream([UserMessage.text('Do XYZ')])) {
+  switch (event.eventType) {
+    case StreamingEventType.beforeCallModel:
+      // 即将调用 LLM；event.data 为 CallLLMParams
+      break;
+    case StreamingEventType.modelChunkMessage:
+      // LLM 流式分片；event.data 为 ModelMessage
+      final chunk = event.data as ModelMessage;
+      stdout.write(chunk.textOutput);
+      break;
+    case StreamingEventType.modelRetrying:
+      // Provider 遇到瞬时错误，或 Agent 收到空响应
+      break;
+    case StreamingEventType.fullModelMessage:
+      // 本回合组装完成的 ModelMessage
+      break;
+    case StreamingEventType.functionCallRequest:
+      // 模型请求工具调用；event.data 为 List<FunctionCall>
+      break;
+    case StreamingEventType.functionCallResult:
+      // 工具执行完成；event.data 为 FunctionExecutionResultMessage
+      break;
+  }
+}
+```
+
+### `run()` 与 `runStream()`
+
+`run()` 是便捷封装：收集所有 `fullModelMessage` 与 `functionCallResult` 事件，并以 `List<LLMMessage>` 返回。内部仍调用 `runStream()`。
+
+当挂载了 `McpManager` 时，每次 run 还会暴露 MCP Server 摘要与桥接工具。MCP 会话会在 run 清理阶段断开；后续 run 前需要重新连接。详见 [Model Context Protocol](mcp.zh-CN.md)。
+
+---
+
+## `AgentController` 事件
+
+挂载 `AgentController` 可观测生命周期事件。Controller 事件用于 UI 更新、追踪、指标与诊断，**不会**控制 Agent 循环。
+
+**发布/订阅（即发即忘）：**
+
+```dart
+final controller = AgentController();
+
+controller.on<BeforeToolCallEvent>((event) {
+  print('About to call: ${event.functionCall.name}');
+});
+
+controller.on<AfterToolCallEvent>((event) {
+  print('Tool result: ${event.result.name}, error: ${event.result.isError}');
+});
+
+controller.on<PlanChangedEvent>((event) {
+  // event.plan 为更新后的 PlanState
+  for (final step in event.plan.steps) {
+    print('${step.status.name}: ${step.description}');
+  }
+});
+
+final agent = StatefulAgent(..., controller: controller);
+```
+
+---
+
+## `AgentHook`
+
+如需控制 Agent loop，使用 `AgentHook`。Hook 的结果是 typed 的，因此可在不同阶段显式 proceed、respond、retry、deny、defer、stop、continue 或 abort。
+
+```dart
+class RuntimeContextHook extends AgentHook {
+  @override
+  ModelCallHookResult beforeModelCall(ModelCallHookContext context) {
+    final transientMessage = UserMessage.text(
+      'Current time: ${DateTime.now()}',
+    );
+
+    return ModelCallHookResult.proceed(
+      request: context.request.copyWith(
+        requestMessages: [
+          ...context.request.requestMessages,
+          transientMessage,
+        ],
+      ),
+    );
+  }
+}
+
+class ToolPolicyHook extends AgentHook {
+  @override
+  ToolCallHookResult beforeToolCall(ToolCallHookContext context) {
+    if (context.call.name != 'delete_file') {
+      return ToolCallHookResult.proceed(context.call);
+    }
+    return ToolCallHookResult.deny(
+      content: [TextPart('delete_file is blocked by local policy.')],
+    );
+  }
+}
+
+final agent = StatefulAgent(
+  ...,
+  hooks: [RuntimeContextHook(), ToolPolicyHook()],
+);
+```
+
+只想影响本次模型调用时，改写 `ModelCallRequest.requestMessages`。需要把 Hook 创建的上下文保留到后续 loop 或 resume 时，写入 `context.state.history.messages`。
+
+可用 hook phase：
+
+| Phase | 典型控制 |
+|-------|------------------|
+| `beforeRun` | 改写初始输入或中止 |
+| `beforeModelCall` | 改写模型请求、返回合成响应，或中止 |
+| `onModelChunk` | 改写/丢弃流式分片，或中止 |
+| `afterModelCall` | 改写最终响应、重试，或中止 |
+| `beforeToolCall` | 改写调用、以合成结果拒绝/延后，或中止 |
+| `afterToolCall` | 改写结果、注入上下文、停止，或中止 |
+| `onTurnCompletion` | 接受最终回答、继续追加消息，或中止 |
+| `beforePersistState` / `afterPersistState` | 包裹 `autoSaveStateFunc`、跳过保存，或中止 |
+| `afterRun` | 观察最终输入、模型消息与错误 |
+
+---
+
+## 取消与挂起
+
+向 `run()` 或 `runStream()` 传入 `CancelToken`（来自 `dio` 包）即可在运行中取消：
+
+```dart
+final cancelToken = CancelToken();
+
+// 在其他位置取消
+cancelToken.cancel('user cancelled');
+
+// 带取消能力运行
+await agent.run(messages, cancelToken: cancelToken);
+```
+
+取消会抛出 `AgentException(AgentExceptionCode.cancelled, ...)`。若要挂起并稍后恢复（而不是彻底取消），用消息 `"Suspend"` 取消 —— 这会走可通过 `isSuspend()` 识别的挂起路径。
+
+---
+
+## 循环检测
+
+除非自行提供实现，`StatefulAgent` 会自动创建 `DefaultLoopDetector`。它使用两种机制：
+
+1. **工具签名追踪**：同一工具以相同参数连续调用 `N` 次（默认 `toolLoopThreshold = 5`）即判定为循环。
+2. **周期性 LLM 诊断**：在 `llmCheckAfterTurns` 回合之后（默认 30），每隔 `llmCheckInterval` 回合（默认 10），Agent 会把近期历史发给 LLM，询问是否发生循环。若 `confidence > 0.8` 则判定为循环。
+
+检测到循环会抛出 `AgentException(AgentExceptionCode.loopDetection, ...)`。
+
+可以自定义阈值，或提供完全不同的实现：
+
+```dart
+final agent = StatefulAgent(
+  ...
+  loopDetector: DefaultLoopDetector(
+    state: state,
+    client: client,
+    modelConfig: modelConfig,
+    toolLoopThreshold: 3,
+    llmCheckAfterTurns: 20,
+    llmCheckInterval: 5,
+  ),
+);
+```
+
+---
+
+## 恢复暂停的 Agent
+
+若 `state.isRunning == true`（例如 Agent 在运行中被挂起），调用 `resume()` 即可从中断处继续：
+
+```dart
+final responses = await agent.resume();
+// 或
+await for (final event in agent.resumeStream()) { ... }
+```

--- a/doc/providers.md
+++ b/doc/providers.md
@@ -1,5 +1,7 @@
 # LLM Providers & Configuration
 
+[English](providers.md) | [简体中文](providers.zh-CN.md)
+
 `dart_agent_core` abstracts differences between LLM providers behind a single `LLMClient` interface. Initialize the client you need and pass it to `StatefulAgent`.
 
 ## Supported Providers

--- a/doc/providers.zh-CN.md
+++ b/doc/providers.zh-CN.md
@@ -1,0 +1,234 @@
+# LLM Provider 与配置
+
+[English](providers.md) | [简体中文](providers.zh-CN.md)
+
+`dart_agent_core` 通过统一的 `LLMClient` 接口屏蔽不同 LLM 提供商的差异。初始化所需客户端后传给 `StatefulAgent` 即可。
+
+## 支持的 Provider
+
+### OpenAI（Chat Completions）
+
+使用 OpenAI Chat Completions API。默认 `baseUrl` 为 `https://api.openai.com`，库会再拼接 `/chat/completions` 作为最终端点。可覆盖 `baseUrl` 以接入 Azure OpenAI 或兼容代理。
+
+```dart
+final client = OpenAIClient(
+  apiKey: Platform.environment['OPENAI_API_KEY'] ?? '',
+  // Azure 示例：'https://YOUR_RESOURCE.openai.azure.com/openai/v1'
+  // baseUrl: 'https://api.openai.com',
+);
+final config = ModelConfig(model: 'gpt-4o', temperature: 0.7);
+```
+
+额外构造参数：
+
+| 参数 | 默认值 | 说明 |
+|-----------|---------|-------------|
+| `timeout` | 300s | 请求超时 |
+| `connectTimeout` | 60s | 连接超时 |
+| `proxyUrl` | null | HTTP 代理（支持 `http://user:pass@host:port`） |
+| `maxRetries` | 3 | 瞬时错误重试次数 |
+| `initialRetryDelayMs` | 1000 | 初始重试退避（毫秒） |
+| `maxRetryDelayMs` | 10000 | 最大重试退避（毫秒） |
+
+### OpenAI（Responses API）
+
+使用较新的 OpenAI Responses API。`LLMClient` 接口（`generate` / `stream`）相同，但底层请求格式与 Chat Completions 不同。客户端会自动从 `ModelMessage` 提取 `responseId`，并在下次请求中作为 `previous_response_id` 传入，只发送上次响应之后的新消息。这能降低多轮对话的 Token 用量。
+
+`ResponsesClient` 还提供 `checkResponseId(responseId)`，用于校验已保存的 response ID 在服务端是否仍然有效。
+
+```dart
+final client = ResponsesClient(
+  apiKey: Platform.environment['OPENAI_API_KEY'] ?? '',
+);
+final config = ModelConfig(model: 'gpt-4o');
+```
+
+### Google Gemini
+
+对接 Google Generative Language API。客户端会处理 Gemini 特有的格式（system instruction、content role、function call schema）。
+
+```dart
+final client = GeminiClient(
+  apiKey: Platform.environment['GEMINI_API_KEY'] ?? '',
+);
+final config = ModelConfig(model: 'gemini-2.5-pro');
+```
+
+### Amazon Bedrock（Claude）
+
+Bedrock 使用 AWS Signature V4 鉴权，而不是简单 API Key。客户端会根据 AWS 凭证自动计算签名。
+
+```dart
+final client = BedrockClaudeClient(
+  region: 'us-east-1',
+  accessKeyId: Platform.environment['AWS_ACCESS_KEY_ID'] ?? '',
+  secretAccessKey: Platform.environment['AWS_SECRET_ACCESS_KEY'] ?? '',
+  sessionToken: Platform.environment['AWS_SESSION_TOKEN'], // 可选，临时凭证
+);
+final config = ModelConfig(model: 'us.anthropic.claude-3-5-sonnet-20241022-v2:0');
+```
+
+---
+
+## `ModelConfig`
+
+`ModelConfig` 传给 `StatefulAgent`，并在每次调用时转发给 LLM 客户端。
+
+```dart
+final config = ModelConfig(
+  model: 'gpt-4o-mini',
+  temperature: 0.7,
+  maxTokens: 4096,
+  topP: 0.9,
+  // topK: Gemini 支持
+  // extra: Provider 特有参数（见下文）
+  // generationConfig: Gemini 特有生成配置
+);
+```
+
+### 通过 `extra` 传递 Provider 特有参数
+
+`extra` map 会合并进请求体，用于传递 `ModelConfig` 没有独立字段的 Provider 特有参数。
+
+**Claude Extended Thinking（Bedrock）：**
+
+```dart
+final config = ModelConfig(
+  model: 'us.anthropic.claude-3-7-sonnet-20250219-v1:0',
+  maxTokens: 16000,
+  extra: {
+    'thinking': {'type': 'enabled', 'budget_tokens': 10000},
+  },
+);
+```
+
+启用 thinking 后，模型推理过程可从 `(modelMessage).thought` 读取，校验签名在 `(modelMessage).thoughtSignature`。
+
+**OpenAI reasoning 模型（o 系列）：**
+
+```dart
+final config = ModelConfig(
+  model: 'o3-mini',
+  extra: {'reasoning_effort': 'high'},
+);
+```
+
+---
+
+## 代理支持
+
+所有客户端都支持通过 `proxyUrl` 配置 HTTP 代理，并支持 Basic Auth：
+
+```dart
+final client = OpenAIClient(
+  apiKey: '...',
+  proxyUrl: 'http://user:password@proxy.example.com:8080',
+);
+```
+
+---
+
+## OpenAI 兼容 Provider
+
+许多 LLM 提供商暴露 OpenAI 兼容的 Chat Completions API。可以用带自定义 `baseUrl` 的 `OpenAIClient` 接入。
+
+### Kimi（Moonshot AI）
+
+```dart
+final client = OpenAIClient(
+  apiKey: Platform.environment['MOONSHOT_API_KEY'] ?? '',
+  baseUrl: 'https://api.moonshot.cn/v1',
+);
+final config = ModelConfig(model: 'kimi-k2');
+// thinking 模型：ModelConfig(model: 'kimi-k2-thinking')
+// reasoning_content 会自动处理
+```
+
+### 通义千问（Qwen）
+
+```dart
+final client = OpenAIClient(
+  apiKey: Platform.environment['DASHSCOPE_API_KEY'] ?? '',
+  baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+);
+final config = ModelConfig(model: 'qwen3.5-plus');
+```
+
+### 智谱 GLM
+
+```dart
+final client = OpenAIClient(
+  apiKey: Platform.environment['GLM_API_KEY'] ?? '',
+  baseUrl: 'https://open.bigmodel.cn/api/coding/paas/v4',
+);
+final config = ModelConfig(model: 'GLM-4.7');
+```
+
+### Ollama（本地部署）
+
+```dart
+final client = OpenAIClient(
+  apiKey: '', // 不需要 API Key
+  baseUrl: 'http://localhost:11434/v1',
+);
+final config = ModelConfig(model: 'qwen2.5:7b');
+```
+
+### OpenRouter
+
+```dart
+final client = OpenAIClient(
+  apiKey: Platform.environment['OPENROUTER_API_KEY'] ?? '',
+  baseUrl: 'https://openrouter.ai/api/v1',
+);
+final config = ModelConfig(model: 'anthropic/claude-opus-4.6');
+```
+
+---
+
+## Responses API 兼容 Provider
+
+### 火山引擎豆包（Doubao-Seed）
+
+```dart
+final client = ResponsesClient(
+  apiKey: Platform.environment['ARK_API_KEY'] ?? '',
+  baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
+);
+final config = ModelConfig(model: 'doubao-seed-1-8-251228');
+```
+
+---
+
+## Anthropic API 兼容 Provider
+
+### Anthropic Claude（直连）
+
+```dart
+final client = ClaudeClient(
+  apiKey: Platform.environment['ANTHROPIC_API_KEY'] ?? '',
+);
+final config = ModelConfig(model: 'claude-sonnet-4-20250514');
+```
+
+### MiniMax
+
+MiniMax 暴露 Anthropic 兼容 API 端点。
+
+```dart
+final client = ClaudeClient(
+  apiKey: Platform.environment['MINIMAX_API_KEY'] ?? '',
+  baseUrl: 'https://api.minimaxi.com/anthropic',
+);
+final config = ModelConfig(model: 'MiniMax-M2.5');
+```
+
+---
+
+## Thinking / Reasoning 模型
+
+支持 extended thinking 的模型（例如 `kimi-k2-thinking`、`o1`、`o3`、`deepseek-r1`）会在响应中返回 `reasoning_content`。框架会自动处理：
+
+- 流式与非流式响应都会把 `reasoning_content` 解析到 `ModelMessage.thought`。
+- 多轮对话会按 API 要求在 assistant 消息中回传 `reasoning_content`。
+- 通过 `modelMessage.thought` 读取思考内容。


### PR DESCRIPTION
## Summary
- Adds `doc/architecture.zh-CN.md`, a Chinese translation of the agent loop, hooks, cancellation, and resume guide.
- Adds `doc/providers.zh-CN.md`, a Chinese translation of LLM client setup including OpenAI-compatible providers.
- English pages get language switchers; README.zh-CN.md now links those two guides to the Chinese files.

## Test plan
- [x] Read architecture.zh-CN.md against architecture.md for missing sections
- [x] Read providers.zh-CN.md against providers.md for URL/model drift
- [x] Open the English ↔ Chinese switchers at the top of both guides
- [x] From README.zh-CN.md, follow 架构与生命周期 and LLM Provider 与配置