### PR TITLE
fix(openai): encode DocumentPart as data-URI file_data with mime filename

### DIFF
--- a/lib/src/llm/openai_client.dart
+++ b/lib/src/llm/openai_client.dart
@@ -302,10 +302,15 @@ Map<String, dynamic> _createRequestBody(
                 'input_audio': {'data': part.base64Data, 'format': format},
               };
             } else if (part is DocumentPart) {
-              // Assuming source is base64 encoded data for file_data
+              final fileData = part.base64Data.startsWith('data:')
+                  ? part.base64Data
+                  : 'data:${part.mimeType};base64,${part.base64Data}';
               return {
                 'type': 'file',
-                'file': {'file_data': part.base64Data},
+                'file': {
+                  'filename': _filenameForMimeType(part.mimeType),
+                  'file_data': fileData,
+                },
               };
             } else {
               throw Exception(
@@ -435,6 +440,42 @@ Map<String, dynamic> _createRequestBody(
   }
 
   return body;
+}
+
+/// Sensible download name for OpenAI `file` content parts from a MIME type.
+String _filenameForMimeType(String mimeType) {
+  final mime = mimeType.toLowerCase().split(';').first.trim();
+  switch (mime) {
+    case 'application/pdf':
+      return 'document.pdf';
+    case 'text/plain':
+      return 'document.txt';
+    case 'text/csv':
+    case 'application/csv':
+      return 'document.csv';
+    case 'application/json':
+      return 'document.json';
+    case 'text/html':
+      return 'document.html';
+    case 'text/markdown':
+      return 'document.md';
+    case 'application/msword':
+      return 'document.doc';
+    case 'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+      return 'document.docx';
+    case 'application/vnd.ms-excel':
+      return 'document.xls';
+    case 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+      return 'document.xlsx';
+    default:
+      final slash = mime.indexOf('/');
+      final subtype = slash >= 0 ? mime.substring(slash + 1) : mime;
+      final ext = subtype.contains('+') ? subtype.split('+').last : subtype;
+      if (ext.isNotEmpty && RegExp(r'^[a-z0-9]{1,8}$').hasMatch(ext)) {
+        return 'document.$ext';
+      }
+      return 'document.bin';
+  }
 }
 
 ModelMessage _parseResponse(

--- a/lib/src/llm/openai_client.dart
+++ b/lib/src/llm/openai_client.dart
@@ -302,6 +302,7 @@ Map<String, dynamic> _createRequestBody(
                 'input_audio': {'data': part.base64Data, 'format': format},
               };
             } else if (part is DocumentPart) {
+              // Chat Completions wants file_data as a data URI, not bare base64.
               final fileData = part.base64Data.startsWith('data:')
                   ? part.base64Data
                   : 'data:${part.mimeType};base64,${part.base64Data}';

--- a/test/openai_document_part_test.dart
+++ b/test/openai_document_part_test.dart
@@ -1,0 +1,79 @@
+import 'dart:convert';
+
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OpenAIClient DocumentPart', () {
+    test(
+      'encodes PDF as data-URI file_data with mime-derived filename',
+      () async {
+        final adapter = _CaptureAdapter([(_) => _openaiOk()]);
+        final client = OpenAIClient(
+          apiKey: 'test-key',
+          client: Dio()..httpClientAdapter = adapter,
+        );
+
+        await client.generate([
+          UserMessage([DocumentPart('JVBERi0xLjQ=', 'application/pdf')]),
+        ], modelConfig: ModelConfig(model: 'gpt-test'));
+
+        final body = _asJsonMap(adapter.requests.single);
+        final content =
+            (body['messages'][0] as Map<String, dynamic>)['content'] as List;
+        expect(content[0]['type'], 'file');
+        final file = content[0]['file'] as Map<String, dynamic>;
+        expect(file['file_data'], 'data:application/pdf;base64,JVBERi0xLjQ=');
+        expect(file['filename'], 'document.pdf');
+      },
+    );
+  });
+}
+
+class _CaptureAdapter implements HttpClientAdapter {
+  final List<ResponseBody Function(RequestOptions)> responses;
+  final List<Object?> requests = [];
+
+  _CaptureAdapter(this.responses);
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add(options.data);
+    return responses.removeAt(0)(options);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+Map<String, dynamic> _asJsonMap(Object? data) {
+  if (data is Map<String, dynamic>) return data;
+  if (data is Map) return Map<String, dynamic>.from(data);
+  return jsonDecode(data as String) as Map<String, dynamic>;
+}
+
+ResponseBody _openaiOk() {
+  return ResponseBody.fromString(
+    jsonEncode({
+      'id': '1',
+      'object': 'chat.completion',
+      'choices': [
+        {
+          'index': 0,
+          'message': {'role': 'assistant', 'content': 'ok'},
+          'finish_reason': 'stop',
+        },
+      ],
+      'usage': {'prompt_tokens': 1, 'completion_tokens': 1, 'total_tokens': 2},
+    }),
+    200,
+    headers: {
+      Headers.contentTypeHeader: [Headers.jsonContentType],
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- OpenAI `DocumentPart` encoding now sends `file_data` as a `data:<mime>;base64,...` URI instead of raw base64.
- Adds a sensible `filename` derived from `DocumentPart.mimeType` (e.g. `application/pdf` → `document.pdf`).
- Regression test covers PDF → data-URI prefix + filename.

## Test plan
- [x] Failing test first: `dart test test/openai_document_part_test.dart` (expected raw base64 mismatch)
- [x] After fix: same test passes
- [x] `dart analyze .`
- [x] `dart test`