### PR TITLE
fix: map ToolChoiceMode.none for Claude and Bedrock

### DIFF
--- a/lib/src/llm/bedrock_claude_client.dart
+++ b/lib/src/llm/bedrock_claude_client.dart
@@ -423,6 +423,7 @@ class BedrockClaudeClient extends LLMClient {
 
       if (toolChoice != null) {
         if (toolChoice.mode == ToolChoiceMode.none) {
+          // Same as the Anthropic client: type none is required to disable tools.
           body['tool_choice'] = {'type': 'none'};
         } else if (toolChoice.mode == ToolChoiceMode.auto) {
           body['tool_choice'] = {'type': 'auto'};

--- a/lib/src/llm/bedrock_claude_client.dart
+++ b/lib/src/llm/bedrock_claude_client.dart
@@ -422,7 +422,9 @@ class BedrockClaudeClient extends LLMClient {
       }).toList();
 
       if (toolChoice != null) {
-        if (toolChoice.mode == ToolChoiceMode.auto) {
+        if (toolChoice.mode == ToolChoiceMode.none) {
+          body['tool_choice'] = {'type': 'none'};
+        } else if (toolChoice.mode == ToolChoiceMode.auto) {
           body['tool_choice'] = {'type': 'auto'};
         } else if (toolChoice.mode == ToolChoiceMode.required) {
           if (toolChoice.allowedFunctionNames != null &&

--- a/lib/src/llm/claude_client.dart
+++ b/lib/src/llm/claude_client.dart
@@ -389,7 +389,9 @@ class ClaudeClient extends LLMClient {
       }).toList();
 
       if (toolChoice != null) {
-        if (toolChoice.mode == ToolChoiceMode.auto) {
+        if (toolChoice.mode == ToolChoiceMode.none) {
+          body['tool_choice'] = {'type': 'none'};
+        } else if (toolChoice.mode == ToolChoiceMode.auto) {
           body['tool_choice'] = {'type': 'auto'};
         } else if (toolChoice.mode == ToolChoiceMode.required) {
           if (toolChoice.allowedFunctionNames != null &&

--- a/lib/src/llm/claude_client.dart
+++ b/lib/src/llm/claude_client.dart
@@ -390,6 +390,7 @@ class ClaudeClient extends LLMClient {
 
       if (toolChoice != null) {
         if (toolChoice.mode == ToolChoiceMode.none) {
+          // Omitting tool_choice still lets Claude call tools; send type none.
           body['tool_choice'] = {'type': 'none'};
         } else if (toolChoice.mode == ToolChoiceMode.auto) {
           body['tool_choice'] = {'type': 'auto'};

--- a/test/bedrock_claude_client_test.dart
+++ b/test/bedrock_claude_client_test.dart
@@ -70,6 +70,44 @@ void main() {
         expect(toolResult['is_error'], isTrue);
       },
     );
+
+    test('ToolChoiceMode.none maps to tool_choice type none', () async {
+      final adapter = _CaptureAdapter([
+        (_) => _jsonResponse({
+          'content': [
+            {'type': 'text', 'text': 'ok'},
+          ],
+          'stop_reason': 'end_turn',
+          'usage': {'input_tokens': 1, 'output_tokens': 1},
+        }),
+      ]);
+      final client = BedrockClaudeClient(
+        region: 'us-east-1',
+        accessKeyId: 'AKIATEST',
+        secretAccessKey: 'secret-test',
+        client: Dio()..httpClientAdapter = adapter,
+      );
+
+      await client.generate(
+        [UserMessage.text('do not use tools')],
+        tools: [
+          Tool(
+            name: 'lookup',
+            description: 'Look something up',
+            parameters: const {
+              'type': 'object',
+              'properties': <String, dynamic>{},
+            },
+          ),
+        ],
+        toolChoice: ToolChoice(mode: ToolChoiceMode.none),
+        modelConfig: ModelConfig(model: 'anthropic.claude-test'),
+      );
+
+      final body = adapter.bodies.single as Map<String, dynamic>;
+      expect(body['tools'], isNotEmpty);
+      expect(body['tool_choice'], {'type': 'none'});
+    });
   });
 }
 

--- a/test/claude_client_test.dart
+++ b/test/claude_client_test.dart
@@ -236,6 +236,43 @@ void main() {
         emitsError(predicate((error) => error.toString().contains('过载'))),
       );
     });
+
+    test('ToolChoiceMode.none maps to tool_choice type none', () async {
+      final adapter = _CaptureAdapter([
+        (_) => _jsonResponse({
+          'content': [
+            {'type': 'text', 'text': 'ok'},
+          ],
+          'stop_reason': 'end_turn',
+          'usage': {'input_tokens': 1, 'output_tokens': 1},
+        }),
+      ]);
+      final client = ClaudeClient(
+        apiKey: 'test-key',
+        client: Dio()..httpClientAdapter = adapter,
+      );
+
+      await client.generate(
+        [UserMessage.text('do not use tools')],
+        tools: [
+          Tool(
+            name: 'lookup',
+            description: 'Look something up',
+            parameters: const {
+              'type': 'object',
+              'properties': <String, dynamic>{},
+            },
+          ),
+        ],
+        toolChoice: ToolChoice(mode: ToolChoiceMode.none),
+        modelConfig: ModelConfig(model: 'claude-test'),
+      );
+
+      final body =
+          jsonDecode(adapter.requests.single as String) as Map<String, dynamic>;
+      expect(body['tools'], isNotEmpty);
+      expect(body['tool_choice'], {'type': 'none'});
+    });
   });
 }
 


### PR DESCRIPTION
## Summary
- Map `ToolChoiceMode.none` to Anthropic `tool_choice: {type: none}` in `ClaudeClient` and `BedrockClaudeClient` (previously ignored, so tools could still be called).
- Add request-body capture tests for both clients asserting `tool_choice.type == none` when tools are present.

## Test plan
- [x] `dart test test/claude_client_test.dart -n "ToolChoiceMode.none"` (fail before fix, pass after)
- [x] `dart test test/bedrock_claude_client_test.dart -n "ToolChoiceMode.none"` (fail before fix, pass after)
- [x] `dart test test/claude_client_test.dart test/bedrock_claude_client_test.dart`
- [x] `dart analyze .`