### PR TITLE
fix: do not retry cancelled Dio LLM requests

### DIFF
--- a/lib/src/agent/stateful_agent.dart
+++ b/lib/src/agent/stateful_agent.dart
@@ -16,6 +16,7 @@ import 'package:logging/logging.dart';
 import '../core/llm_client.dart';
 import '../core/message.dart';
 import '../core/tool.dart';
+import '../llm/llm_request_util.dart';
 import 'context_compressor.dart';
 import 'planner.dart';
 import 'memory.dart';
@@ -1934,10 +1935,7 @@ class StatefulAgent {
   }
 
   bool isCancelled(Object error) {
-    if (error is DioException && CancelToken.isCancel(error)) {
-      return true;
-    }
-    return false;
+    return isLlmRequestCancelled(error);
   }
 
   void _injectSystemReminder(List<LLMMessage> requestMessages) {

--- a/lib/src/llm/bedrock_claude_client.dart
+++ b/lib/src/llm/bedrock_claude_client.dart
@@ -11,6 +11,7 @@ import '../core/http_util.dart';
 import '../core/llm_client.dart';
 import '../core/message.dart';
 import '../core/tool.dart';
+import 'llm_request_util.dart';
 
 class BedrockClaudeClient extends LLMClient {
   final Logger _logger = Logger('BedrockClaudeClient');
@@ -146,6 +147,7 @@ class BedrockClaudeClient extends LLMClient {
           'Bedrock API Error: ${response.statusCode} ${response.data}',
         );
       } on DioException catch (e) {
+        if (isLlmRequestCancelled(e)) rethrow;
         if (retryCount < maxRetries) {
           // Retry on network errors or timeouts
           await _waitForRetry(retryCount, 'DioException: ${e.message}');
@@ -293,6 +295,7 @@ class BedrockClaudeClient extends LLMClient {
         );
       } catch (e) {
         if (e is DioException) {
+          if (isLlmRequestCancelled(e)) rethrow;
           if (retryCount < maxRetries) {
             await _waitForRetry(retryCount, 'DioException: ${e.message}');
             retryCount++;

--- a/lib/src/llm/claude_client.dart
+++ b/lib/src/llm/claude_client.dart
@@ -8,6 +8,7 @@ import '../core/http_util.dart';
 import '../core/llm_client.dart';
 import '../core/message.dart';
 import '../core/tool.dart';
+import 'llm_request_util.dart';
 
 /// Client for the Anthropic Messages API (direct, not via AWS Bedrock).
 ///
@@ -122,6 +123,7 @@ class ClaudeClient extends LLMClient {
           'Claude API Error: ${response.statusCode} ${response.data}',
         );
       } on DioException catch (e) {
+        if (isLlmRequestCancelled(e)) rethrow;
         if (retryCount < maxRetries) {
           await _waitForRetry(retryCount, 'DioException: ${e.message}');
           retryCount++;
@@ -205,6 +207,7 @@ class ClaudeClient extends LLMClient {
         );
       } catch (e) {
         if (e is DioException) {
+          if (isLlmRequestCancelled(e)) rethrow;
           if (retryCount < maxRetries) {
             await _waitForRetry(retryCount, 'DioException: ${e.message}');
             retryCount++;

--- a/lib/src/llm/gemini_client.dart
+++ b/lib/src/llm/gemini_client.dart
@@ -6,6 +6,7 @@ import '../core/http_util.dart';
 import '../core/llm_client.dart';
 import '../core/message.dart';
 import '../core/tool.dart';
+import 'llm_request_util.dart';
 import 'package:logging/logging.dart';
 
 final Logger _geminiLogger = Logger('GeminiClient');
@@ -134,6 +135,7 @@ class GeminiClient extends LLMClient {
           );
         }
       } on DioException catch (e) {
+        if (isLlmRequestCancelled(e)) rethrow;
         if (retryCount < maxRetries) {
           await waitForRetry('DioException: ${e.message}');
           continue;
@@ -287,6 +289,11 @@ class GeminiClient extends LLMClient {
           controller.close();
           break;
         } on DioException catch (e) {
+          if (isLlmRequestCancelled(e)) {
+            controller.addError(e);
+            controller.close();
+            break;
+          }
           if (retryCount < maxRetries) {
             await waitForRetry('DioException: ${e.message}');
             controller.add(

--- a/lib/src/llm/llm_request_util.dart
+++ b/lib/src/llm/llm_request_util.dart
@@ -1,0 +1,9 @@
+import 'package:dio/dio.dart';
+
+/// Whether [error] is a Dio cancellation (user abort / CancelToken).
+///
+/// Cancelled requests must not be retried; Claude/Bedrock must rethrow the
+/// original [DioException] so [StatefulAgent.isCancelled] can recognize it.
+bool isLlmRequestCancelled(Object error) {
+  return error is DioException && CancelToken.isCancel(error);
+}

--- a/lib/src/llm/openai_client.dart
+++ b/lib/src/llm/openai_client.dart
@@ -115,6 +115,7 @@ class OpenAIClient extends LLMClient {
           );
         }
       } on DioException catch (e) {
+        // Cancel is terminal; retrying it just waits out the backoff.
         if (isLlmRequestCancelled(e)) rethrow;
         if (retryCount < maxRetries) {
           await waitForRetry('DioException: ${e.message}');

--- a/lib/src/llm/openai_client.dart
+++ b/lib/src/llm/openai_client.dart
@@ -6,6 +6,7 @@ import '../core/http_util.dart';
 import '../core/llm_client.dart';
 import '../core/message.dart';
 import '../core/tool.dart';
+import 'llm_request_util.dart';
 import 'package:logging/logging.dart';
 
 class OpenAIClient extends LLMClient {
@@ -114,6 +115,7 @@ class OpenAIClient extends LLMClient {
           );
         }
       } on DioException catch (e) {
+        if (isLlmRequestCancelled(e)) rethrow;
         if (retryCount < maxRetries) {
           await waitForRetry('DioException: ${e.message}');
           continue;
@@ -236,6 +238,11 @@ class OpenAIClient extends LLMClient {
           controller.close();
           break;
         } on DioException catch (e) {
+          if (isLlmRequestCancelled(e)) {
+            controller.addError(e);
+            controller.close();
+            break;
+          }
           if (retryCount < maxRetries) {
             await waitForRetry('DioException: ${e.message}');
             controller.add(

--- a/lib/src/llm/responses_client.dart
+++ b/lib/src/llm/responses_client.dart
@@ -6,6 +6,7 @@ import '../core/http_util.dart';
 import '../core/llm_client.dart';
 import '../core/message.dart';
 import '../core/tool.dart';
+import 'llm_request_util.dart';
 import 'package:logging/logging.dart';
 
 class ResponsesClient extends LLMClient {
@@ -132,6 +133,7 @@ class ResponsesClient extends LLMClient {
           );
         }
       } on DioException catch (e) {
+        if (isLlmRequestCancelled(e)) rethrow;
         if (retryCount < maxRetries) {
           await waitForRetry('DioException: ${e.message}');
           continue;
@@ -288,6 +290,11 @@ class ResponsesClient extends LLMClient {
           controller.close();
           break;
         } on DioException catch (e) {
+          if (isLlmRequestCancelled(e)) {
+            controller.addError(e);
+            controller.close();
+            break;
+          }
           if (retryCount < maxRetries) {
             await waitForRetry('DioException: ${e.message}');
             controller.add(

--- a/test/llm_cancel_no_retry_test.dart
+++ b/test/llm_cancel_no_retry_test.dart
@@ -1,0 +1,220 @@
+import 'package:dart_agent_core/dart_agent_core.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final modelConfig = ModelConfig(model: 'test-model');
+
+  final isCancelDioException = isA<DioException>().having(
+    CancelToken.isCancel,
+    'CancelToken.isCancel',
+    isTrue,
+  );
+
+  group('LLM clients do not retry cancelled Dio requests', () {
+    test('OpenAI generate: zero retries, cancel DioException', () async {
+      final adapter = _CancelAdapter();
+      final client = OpenAIClient(
+        apiKey: 'k',
+        client: Dio()..httpClientAdapter = adapter,
+        maxRetries: 3,
+        initialRetryDelayMs: 200,
+      );
+
+      final sw = Stopwatch()..start();
+      await expectLater(
+        client.generate([UserMessage.text('hi')], modelConfig: modelConfig),
+        throwsA(isCancelDioException),
+      );
+      sw.stop();
+
+      expect(adapter.fetches, 1);
+      expect(sw.elapsedMilliseconds, lessThan(150));
+    });
+
+    test('OpenAI stream: zero retries, cancel DioException', () async {
+      final adapter = _CancelAdapter();
+      final client = OpenAIClient(
+        apiKey: 'k',
+        client: Dio()..httpClientAdapter = adapter,
+        maxRetries: 3,
+        initialRetryDelayMs: 200,
+      );
+
+      final stream = await client.stream([
+        UserMessage.text('hi'),
+      ], modelConfig: modelConfig);
+
+      final sw = Stopwatch()..start();
+      await expectLater(stream.first, throwsA(isCancelDioException));
+      sw.stop();
+
+      expect(adapter.fetches, 1);
+      expect(sw.elapsedMilliseconds, lessThan(150));
+    });
+
+    test('Responses generate: zero retries, cancel DioException', () async {
+      final adapter = _CancelAdapter();
+      final client = ResponsesClient(
+        apiKey: 'k',
+        client: Dio()..httpClientAdapter = adapter,
+        maxRetries: 3,
+        initialRetryDelayMs: 200,
+      );
+
+      final sw = Stopwatch()..start();
+      await expectLater(
+        client.generate([UserMessage.text('hi')], modelConfig: modelConfig),
+        throwsA(isCancelDioException),
+      );
+      sw.stop();
+
+      expect(adapter.fetches, 1);
+      expect(sw.elapsedMilliseconds, lessThan(150));
+    });
+
+    test('Gemini generate: zero retries, cancel DioException', () async {
+      final adapter = _CancelAdapter();
+      final client = GeminiClient(
+        apiKey: 'k',
+        client: Dio()..httpClientAdapter = adapter,
+        maxRetries: 3,
+        initialRetryDelayMs: 200,
+      );
+
+      final sw = Stopwatch()..start();
+      await expectLater(
+        client.generate([UserMessage.text('hi')], modelConfig: modelConfig),
+        throwsA(isCancelDioException),
+      );
+      sw.stop();
+
+      expect(adapter.fetches, 1);
+      expect(sw.elapsedMilliseconds, lessThan(150));
+    });
+
+    test(
+      'Claude generate: zero retries and rethrows unwrapped cancel DioException',
+      () async {
+        final adapter = _CancelAdapter();
+        final client = ClaudeClient(
+          apiKey: 'k',
+          client: Dio()..httpClientAdapter = adapter,
+          maxRetries: 3,
+          initialRetryDelayMs: 200,
+        );
+
+        final sw = Stopwatch()..start();
+        await expectLater(
+          client.generate([UserMessage.text('hi')], modelConfig: modelConfig),
+          throwsA(isCancelDioException),
+        );
+        sw.stop();
+
+        expect(adapter.fetches, 1);
+        expect(sw.elapsedMilliseconds, lessThan(150));
+      },
+    );
+
+    test(
+      'Claude stream: zero retries and rethrows unwrapped cancel DioException',
+      () async {
+        final adapter = _CancelAdapter();
+        final client = ClaudeClient(
+          apiKey: 'k',
+          client: Dio()..httpClientAdapter = adapter,
+          maxRetries: 3,
+          initialRetryDelayMs: 200,
+        );
+
+        final sw = Stopwatch()..start();
+        await expectLater(
+          client.stream([UserMessage.text('hi')], modelConfig: modelConfig),
+          throwsA(isCancelDioException),
+        );
+        sw.stop();
+
+        expect(adapter.fetches, 1);
+        expect(sw.elapsedMilliseconds, lessThan(150));
+      },
+    );
+
+    test(
+      'Bedrock generate: zero retries and rethrows unwrapped cancel DioException',
+      () async {
+        final adapter = _CancelAdapter();
+        final client = BedrockClaudeClient(
+          region: 'us-east-1',
+          accessKeyId: 'AKIATEST',
+          secretAccessKey: 'secret-test',
+          client: Dio()..httpClientAdapter = adapter,
+          maxRetries: 3,
+          initialRetryDelayMs: 200,
+        );
+
+        final sw = Stopwatch()..start();
+        await expectLater(
+          client.generate([UserMessage.text('hi')], modelConfig: modelConfig),
+          throwsA(isCancelDioException),
+        );
+        sw.stop();
+
+        expect(adapter.fetches, 1);
+        expect(sw.elapsedMilliseconds, lessThan(150));
+      },
+    );
+  });
+
+  test(
+    'StatefulAgent maps Claude cancel DioException to cancelled, not unknown',
+    () async {
+      final adapter = _CancelAdapter();
+      final client = ClaudeClient(
+        apiKey: 'k',
+        client: Dio()..httpClientAdapter = adapter,
+        maxRetries: 3,
+        initialRetryDelayMs: 50,
+      );
+      final agent = StatefulAgent(
+        name: 'cancel-agent',
+        client: client,
+        modelConfig: modelConfig,
+        state: AgentState.empty(),
+        withGeneralPrinciples: false,
+        disableSubAgents: true,
+      );
+
+      await expectLater(
+        agent.run([UserMessage.text('hi')], useStream: false),
+        throwsA(
+          isA<AgentException>().having(
+            (e) => e.code,
+            'code',
+            AgentExceptionCode.cancelled,
+          ),
+        ),
+      );
+      expect(adapter.fetches, 1);
+    },
+  );
+}
+
+class _CancelAdapter implements HttpClientAdapter {
+  int fetches = 0;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<List<int>>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    fetches++;
+    throw DioException.requestCancelled(
+      requestOptions: options,
+      reason: 'test cancel',
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}


### PR DESCRIPTION
## Summary
- Skip retries when a Dio LLM request is cancelled (`CancelToken.isCancel`)
- Rethrow cancel DioExceptions unwrapped from Claude/Bedrock so StatefulAgent maps them to `cancelled`
- Add shared `isLlmRequestCancelled` helper and regression tests for generate/stream plus agent path

## Test plan
- [x] `dart test test/llm_cancel_no_retry_test.dart` (failed before fix: 4 fetches / wrapped Exception / `unknown`; passed after)
- [x] `dart analyze .`
- [x] `dart test test/llm_cancel_no_retry_test.dart test/claude_client_test.dart test/bedrock_claude_client_test.dart test/gemini_client_test.dart test/responses_client_test.dart test/stateful_agent_loop_test.dart`
- [x] manual if any