### PR TITLE
fix: validate previous_response_id before truncating Responses history

### DIFF
--- a/lib/src/llm/responses_client.dart
+++ b/lib/src/llm/responses_client.dart
@@ -27,6 +27,12 @@ class ResponsesClient extends LLMClient {
   /// prefer to always send full history or manage previous_response_id yourself.
   final bool autoPreviousResponseId;
 
+  /// When true (default), the client calls [checkResponseId] before truncating
+  /// history with [previous_response_id]. If the id is invalid, it is cleared and
+  /// the full message history is sent instead. Set to false to skip the GET check
+  /// (e.g. offline / rate-limited environments).
+  final bool validatePreviousResponseId;
+
   /// Keys from [ModelConfig.extra] allowed to be forwarded to the API request body.
   /// When null (default), uses: { 'reasoning', 'caching', 'expire_at', 'thinking', 'store' }.
   /// Pass a custom set at construction to allow additional or different keys.
@@ -42,6 +48,7 @@ class ResponsesClient extends LLMClient {
     this.initialRetryDelayMs = 1000,
     this.maxRetryDelayMs = 10000,
     this.autoPreviousResponseId = true,
+    this.validatePreviousResponseId = true,
     this.extraAllowedKeys,
     Dio? client,
   }) : _apiKey = apiKey,
@@ -60,15 +67,13 @@ class ResponsesClient extends LLMClient {
     CancelToken? cancelToken,
   }) async {
     final url = '$baseUrl/responses';
-    final body = _createRequestBody(
+    final body = await _buildRequestBody(
       messages,
       tools: tools,
       toolChoice: toolChoice,
       modelConfig: modelConfig,
       stream: false,
       jsonOutput: jsonOutput,
-      autoPreviousResponseId: autoPreviousResponseId,
-      extraAllowedKeys: extraAllowedKeys,
     );
 
     int retryCount = 0;
@@ -175,6 +180,54 @@ class ResponsesClient extends LLMClient {
     }
   }
 
+  /// Resolve [previous_response_id], optionally validate it, then build the body.
+  Future<Map<String, dynamic>> _buildRequestBody(
+    List<LLMMessage> messages, {
+    List<Tool>? tools,
+    ToolChoice? toolChoice,
+    required ModelConfig modelConfig,
+    required bool stream,
+    bool? jsonOutput,
+  }) async {
+    var ignorePreviousResponseId = false;
+
+    if (validatePreviousResponseId) {
+      String? previousResponseId =
+          modelConfig.extra?['previous_response_id'] as String?;
+      if (previousResponseId == null && autoPreviousResponseId) {
+        for (int i = messages.length - 1; i >= 0; i--) {
+          final m = messages[i];
+          if (m is ModelMessage && m.responseId != null) {
+            previousResponseId = m.responseId;
+            break;
+          }
+        }
+      }
+      if (previousResponseId != null) {
+        final valid = await checkResponseId(previousResponseId);
+        if (!valid) {
+          _logger.warning(
+            'previous_response_id $previousResponseId is invalid; '
+            'clearing id and sending full history',
+          );
+          ignorePreviousResponseId = true;
+        }
+      }
+    }
+
+    return _createRequestBody(
+      messages,
+      tools: tools,
+      toolChoice: toolChoice,
+      modelConfig: modelConfig,
+      stream: stream,
+      jsonOutput: jsonOutput,
+      autoPreviousResponseId: autoPreviousResponseId,
+      extraAllowedKeys: extraAllowedKeys,
+      ignorePreviousResponseId: ignorePreviousResponseId,
+    );
+  }
+
   @override
   Future<Stream<StreamingMessage>> stream(
     List<LLMMessage> messages, {
@@ -185,15 +238,13 @@ class ResponsesClient extends LLMClient {
     CancelToken? cancelToken,
   }) async {
     final url = '$baseUrl/responses';
-    final body = _createRequestBody(
+    final body = await _buildRequestBody(
       messages,
       tools: tools,
       toolChoice: toolChoice,
       modelConfig: modelConfig,
       stream: true,
       jsonOutput: jsonOutput,
-      autoPreviousResponseId: autoPreviousResponseId,
-      extraAllowedKeys: extraAllowedKeys,
     );
 
     StreamController<StreamingMessage> controller =
@@ -329,6 +380,7 @@ Map<String, dynamic> _createRequestBody(
   bool? jsonOutput,
   bool autoPreviousResponseId = true,
   Set<String>? extraAllowedKeys,
+  bool ignorePreviousResponseId = false,
 }) {
   const defaultExtraAllowedKeys = {
     'reasoning',
@@ -339,27 +391,30 @@ Map<String, dynamic> _createRequestBody(
   };
   final allowedKeys = extraAllowedKeys ?? defaultExtraAllowedKeys;
   // 1. Determine previous_response_id: explicit extra, or (if autoPreviousResponseId) from last ModelMessage
-  String? previousResponseId =
-      modelConfig.extra?['previous_response_id'] as String?;
+  String? previousResponseId;
   int cutoffIndex = -1;
 
-  if (previousResponseId == null && autoPreviousResponseId) {
-    for (int i = messages.length - 1; i >= 0; i--) {
-      final m = messages[i];
-      if (m is ModelMessage && m.responseId != null) {
-        previousResponseId = m.responseId;
-        cutoffIndex = i;
-        break;
+  if (!ignorePreviousResponseId) {
+    previousResponseId = modelConfig.extra?['previous_response_id'] as String?;
+
+    if (previousResponseId == null && autoPreviousResponseId) {
+      for (int i = messages.length - 1; i >= 0; i--) {
+        final m = messages[i];
+        if (m is ModelMessage && m.responseId != null) {
+          previousResponseId = m.responseId;
+          cutoffIndex = i;
+          break;
+        }
       }
-    }
-  } else if (previousResponseId != null) {
-    // Explicit previous_response_id: still need cutoff so we only send messages after that point
-    // Only when effectiveAuto did not set cutoff, we send all messages (cutoffIndex stays -1)
-    for (int i = messages.length - 1; i >= 0; i--) {
-      final m = messages[i];
-      if (m is ModelMessage && m.responseId == previousResponseId) {
-        cutoffIndex = i;
-        break;
+    } else if (previousResponseId != null) {
+      // Explicit previous_response_id: still need cutoff so we only send messages after that point
+      // Only when effectiveAuto did not set cutoff, we send all messages (cutoffIndex stays -1)
+      for (int i = messages.length - 1; i >= 0; i--) {
+        final m = messages[i];
+        if (m is ModelMessage && m.responseId == previousResponseId) {
+          cutoffIndex = i;
+          break;
+        }
       }
     }
   }

--- a/lib/src/llm/responses_client.dart
+++ b/lib/src/llm/responses_client.dart
@@ -206,6 +206,7 @@ class ResponsesClient extends LLMClient {
       if (previousResponseId != null) {
         final valid = await checkResponseId(previousResponseId);
         if (!valid) {
+          // Truncating to a stale id 400s; send the full thread instead.
           _logger.warning(
             'previous_response_id $previousResponseId is invalid; '
             'clearing id and sending full history',

--- a/test/responses_client_test.dart
+++ b/test/responses_client_test.dart
@@ -10,6 +10,11 @@ void main() {
       'derives previous_response_id and only sends later messages',
       () async {
         final adapter = _CaptureAdapter([
+          (options) {
+            expect(options.method, 'GET');
+            expect(options.uri.path, endsWith('/responses/resp_1'));
+            return _jsonResponse({'id': 'resp_1'});
+          },
           (_) => _jsonResponse({
             'id': 'resp_2',
             'status': 'completed',
@@ -109,12 +114,156 @@ void main() {
       expect(await client.checkResponseId('resp_ok'), isTrue);
       expect(await client.checkResponseId('resp_missing'), isFalse);
     });
+
+    test(
+      'invalid previous_response_id (GET 404) clears id and sends full history',
+      () async {
+        final adapter = _CaptureAdapter([
+          (options) {
+            expect(options.method, 'GET');
+            expect(options.uri.path, endsWith('/responses/resp_stale'));
+            return ResponseBody.fromString(
+              '{"error":"not found"}',
+              404,
+              headers: {
+                Headers.contentTypeHeader: [Headers.jsonContentType],
+              },
+            );
+          },
+          (options) {
+            expect(options.method, 'POST');
+            return _jsonResponse({
+              'id': 'resp_new',
+              'status': 'completed',
+              'output': [
+                {
+                  'type': 'message',
+                  'content': [
+                    {'type': 'output_text', 'text': 'recovered'},
+                  ],
+                },
+              ],
+            });
+          },
+        ]);
+        final client = ResponsesClient(
+          apiKey: 'test-key',
+          client: Dio()..httpClientAdapter = adapter,
+        );
+
+        await client.generate([
+          UserMessage.text('first'),
+          ModelMessage(
+            model: 'gpt-test',
+            textOutput: 'ack',
+            responseId: 'resp_stale',
+            stopReason: 'completed',
+          ),
+          UserMessage.text('second'),
+        ], modelConfig: ModelConfig(model: 'gpt-test'));
+
+        final body = adapter.bodies.single as Map<String, dynamic>;
+        expect(body.containsKey('previous_response_id'), isFalse);
+        expect(body['input'], hasLength(3));
+      },
+    );
+
+    test(
+      'valid previous_response_id (GET 200) keeps truncated previous_response_id path',
+      () async {
+        final adapter = _CaptureAdapter([
+          (options) {
+            expect(options.method, 'GET');
+            expect(options.uri.path, endsWith('/responses/resp_1'));
+            return _jsonResponse({'id': 'resp_1'});
+          },
+          (options) {
+            expect(options.method, 'POST');
+            return _jsonResponse({
+              'id': 'resp_2',
+              'status': 'completed',
+              'output': [
+                {
+                  'type': 'message',
+                  'content': [
+                    {'type': 'output_text', 'text': 'follow-up'},
+                  ],
+                },
+              ],
+            });
+          },
+        ]);
+        final client = ResponsesClient(
+          apiKey: 'test-key',
+          client: Dio()..httpClientAdapter = adapter,
+        );
+
+        await client.generate([
+          UserMessage.text('first'),
+          ModelMessage(
+            model: 'gpt-test',
+            textOutput: 'ack',
+            responseId: 'resp_1',
+            stopReason: 'completed',
+          ),
+          UserMessage.text('second'),
+        ], modelConfig: ModelConfig(model: 'gpt-test'));
+
+        final body = adapter.bodies.single as Map<String, dynamic>;
+        expect(body['previous_response_id'], 'resp_1');
+        final input = body['input'] as List;
+        expect(input, hasLength(1));
+        expect(input.single['content'].single['text'], 'second');
+      },
+    );
+
+    test('validatePreviousResponseId false skips GET and truncates', () async {
+      final adapter = _CaptureAdapter([
+        (options) {
+          expect(options.method, 'POST');
+          return _jsonResponse({
+            'id': 'resp_2',
+            'status': 'completed',
+            'output': [
+              {
+                'type': 'message',
+                'content': [
+                  {'type': 'output_text', 'text': 'ok'},
+                ],
+              },
+            ],
+          });
+        },
+      ]);
+      final client = ResponsesClient(
+        apiKey: 'test-key',
+        validatePreviousResponseId: false,
+        client: Dio()..httpClientAdapter = adapter,
+      );
+
+      await client.generate([
+        UserMessage.text('first'),
+        ModelMessage(
+          model: 'gpt-test',
+          textOutput: 'ack',
+          responseId: 'resp_1',
+          stopReason: 'completed',
+        ),
+        UserMessage.text('second'),
+      ], modelConfig: ModelConfig(model: 'gpt-test'));
+
+      expect(adapter.methods, ['POST']);
+      final body = adapter.bodies.single as Map<String, dynamic>;
+      expect(body['previous_response_id'], 'resp_1');
+      expect(body['input'], hasLength(1));
+    });
   });
 }
 
 class _CaptureAdapter implements HttpClientAdapter {
   final List<ResponseBody Function(RequestOptions)> responses;
   final List<dynamic> bodies = [];
+  final List<String> methods = [];
 
   _CaptureAdapter(this.responses);
 
@@ -124,6 +273,7 @@ class _CaptureAdapter implements HttpClientAdapter {
     Stream<List<int>>? requestStream,
     Future<void>? cancelFuture,
   ) async {
+    methods.add(options.method);
     final bytes = <int>[];
     if (requestStream != null) {
       await for (final chunk in requestStream) {


### PR DESCRIPTION
## Summary
- Validate `previous_response_id` with `checkResponseId` before truncating Responses history; on invalid (e.g. 404), clear the id and send full history (addresses #52).
- Add `validatePreviousResponseId` (default true) so callers can disable the GET check when needed.

## Test plan
- [x] `dart test test/responses_client_test.dart` — GET 404 clears id / full input; GET 200 keeps truncated path; `validatePreviousResponseId: false` skips GET
- [x] `dart analyze .` clean
- [ ] Manual: multi-turn ResponsesClient with a stale `responseId` recovers by sending full history instead of a truncated `previous_response_id` request