### PR TITLE
fix: reschedule FileRecordingStore flush when concurrent puts remain pending

### DIFF
--- a/lib/src/eval/llm/recording_store.dart
+++ b/lib/src/eval/llm/recording_store.dart
@@ -121,6 +121,7 @@ class FileRecordingStore implements RecordingStore {
   }
 
   Future<void> _doFlush() async {
+    // Snapshot then clear so puts during the write land in the next flush.
     final batch = Map<String, ModelMessage>.from(_pendingWrites);
     if (batch.isEmpty) return;
     _pendingWrites.clear();

--- a/lib/src/eval/llm/recording_store.dart
+++ b/lib/src/eval/llm/recording_store.dart
@@ -62,6 +62,10 @@ class FileRecordingStore implements RecordingStore {
   /// the same future to serialize disk writes.
   Future<void>? _inflightFlush;
 
+  /// Invoked before each disk write. Tests set this to pause an in-flight
+  /// flush and interleave concurrent [put]s.
+  Future<void> Function()? beforeWrite;
+
   FileRecordingStore(this.rootDir) {
     if (!rootDir.existsSync()) {
       rootDir.createSync(recursive: true);
@@ -106,6 +110,12 @@ class FileRecordingStore implements RecordingStore {
         await _doFlush();
       } finally {
         _inflightFlush = null;
+        // Puts that arrived while this flush was in flight were added to
+        // _pendingWrites but could not schedule ( _inflightFlush was set ).
+        // Reschedule so they are not stranded after we clear the flag.
+        if (_pendingWrites.isNotEmpty) {
+          _scheduleFlush();
+        }
       }
     });
   }
@@ -115,6 +125,8 @@ class FileRecordingStore implements RecordingStore {
     if (batch.isEmpty) return;
     _pendingWrites.clear();
     for (final entry in batch.entries) {
+      final hook = beforeWrite;
+      if (hook != null) await hook();
       final f = _fileFor(entry.key);
       await f.parent.create(recursive: true);
       await f.writeAsString(jsonEncode(entry.value.toJson()));

--- a/test/eval/llm_record_replay_test.dart
+++ b/test/eval/llm_record_replay_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:dart_agent_core/dart_agent_core.dart';
@@ -233,6 +234,46 @@ void main() {
       await store.flush();
       final f = File('${tmp.path}/ab/cd/abcdef00112233.json');
       expect(await f.exists(), isTrue);
+    });
+
+    test('concurrent puts during a delayed flush all land on disk', () async {
+      final store = FileRecordingStore(tmp);
+      final enteredWrite = Completer<void>();
+      final releaseWrite = Completer<void>();
+      var writeCount = 0;
+      store.beforeWrite = () async {
+        writeCount++;
+        if (writeCount == 1) {
+          enteredWrite.complete();
+          await releaseWrite.future;
+        }
+      };
+
+      const hashA = 'aaaa0000000001';
+      const hashB = 'bbbb0000000002';
+      const hashC = 'cccc0000000003';
+
+      await store.put(hashA, textReply('first'));
+      await enteredWrite.future;
+      // These arrive after the in-flight flush snapped+cleared pending,
+      // so without a post-flush reschedule they are stranded in memory.
+      await store.put(hashB, textReply('second'));
+      await store.put(hashC, textReply('third'));
+      releaseWrite.complete();
+
+      // Do not call flush() — that salvages stranded pending and hides the
+      // race. Wait for background flushes, then reopen from disk.
+      await _waitUntil(() async {
+        final a = File('${tmp.path}/aa/aa/$hashA.json');
+        final b = File('${tmp.path}/bb/bb/$hashB.json');
+        final c = File('${tmp.path}/cc/cc/$hashC.json');
+        return await a.exists() && await b.exists() && await c.exists();
+      });
+
+      final reopened = FileRecordingStore(tmp);
+      expect((await reopened.get(hashA))!.textOutput, 'first');
+      expect((await reopened.get(hashB))!.textOutput, 'second');
+      expect((await reopened.get(hashC))!.textOutput, 'third');
     });
   });
 
@@ -541,6 +582,18 @@ void main() {
       );
     });
   });
+}
+
+Future<void> _waitUntil(
+  Future<bool> Function() predicate, {
+  Duration timeout = const Duration(seconds: 2),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    if (await predicate()) return;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  fail('condition not met within $timeout');
 }
 
 class _CountingRateLimitGate implements RateLimitGate {


### PR DESCRIPTION
## Summary
- `FileRecordingStore` dropped concurrent `put`s that arrived during an in-flight flush: pending entries were left after `_inflightFlush` cleared with no follow-up write.
- Reschedule a flush whenever pending writes remain after the in-flight flush finishes.
- Add a regression test that gates the first disk write, interleaves more puts, and asserts all hashes land on disk without calling `flush()` (which would hide the race).

## Test plan
- [x] `dart test test/eval/llm_record_replay_test.dart -n "concurrent puts during a delayed flush"` fails before the fix, passes after
- [x] `dart test test/eval/llm_record_replay_test.dart`
- [x] `dart analyze .`