### PR TITLE
fix(eval): mark trials failed when no grader decides

### DIFF
--- a/lib/src/eval/core/eval_runner.dart
+++ b/lib/src/eval/core/eval_runner.dart
@@ -317,10 +317,9 @@ extension on EvalRunner {
       }
     }
 
-    // Final trial status reflects graders.
-    final passed = scores
-        .where((s) => s.passed != null)
-        .every((s) => s.passed == true);
+    // Final trial status reflects graders (same rules as
+    // [TrialResult.allGradersPassed]).
+    final passed = TrialResult.scoresIndicatePass(scores);
     if (status == TrialStatus.passed && !passed) status = TrialStatus.failed;
 
     trial = Trial(

--- a/lib/src/eval/core/trial_result.dart
+++ b/lib/src/eval/core/trial_result.dart
@@ -19,10 +19,17 @@ class TrialResult {
 
   /// True if every score (excluding null-valued ones) reports passed=true.
   /// Null-valued scores (e.g. judge returned Unknown) are ignored.
-  bool get allGradersPassed {
-    final passing = scores.where((s) => s.passed != null);
-    if (passing.isEmpty) return false;
-    return passing.every((s) => s.passed == true);
+  /// Returns false when no grader decided (all scores null / empty list).
+  bool get allGradersPassed => scoresIndicatePass(scores);
+
+  /// Whether [scores] indicate a passing trial.
+  ///
+  /// Same rules as [allGradersPassed]: ignore `passed == null`, and treat
+  /// "no grader decided" as not passed.
+  static bool scoresIndicatePass(Iterable<Score> scores) {
+    final decided = scores.where((s) => s.passed != null);
+    if (decided.isEmpty) return false;
+    return decided.every((s) => s.passed == true);
   }
 
   /// Mean of non-null score values. Returns null if all scores are null.

--- a/test/eval/_helpers.dart
+++ b/test/eval/_helpers.dart
@@ -108,9 +108,8 @@ TrialResult makeTrialResult({
   TrialStatus? status,
   DateTime? startedAt,
 }) {
-  final passed = scores
-      .where((s) => s.passed != null)
-      .every((s) => s.passed == true);
+  // Mirror TrialResult.allGradersPassed / EvalRunner status.
+  final passed = TrialResult.scoresIndicatePass(scores);
   return TrialResult(
     trial: makeTrial(
       runName: runName,

--- a/test/eval/runner_e2e_test.dart
+++ b/test/eval/runner_e2e_test.dart
@@ -106,6 +106,28 @@ class _ExpectsValueGrader extends CodeGrader {
   }
 }
 
+/// Grader that never decides (e.g. LLM judge returned Unknown).
+class _NullScoreGrader implements Grader {
+  @override
+  String get name => 'undecided';
+
+  @override
+  GraderKind get kind => GraderKind.model;
+
+  @override
+  double get passThreshold => 1.0;
+
+  @override
+  Future<Score> grade({
+    required Trial trial,
+    required Transcript transcript,
+    required Outcome outcome,
+    required EvalContext context,
+    ReferenceSolution? referenceSolution,
+  }) async =>
+      Score(graderName: name, value: null, passed: null, rationale: 'Unknown');
+}
+
 class _Task implements EvalTask {
   @override
   final String id;
@@ -288,6 +310,39 @@ void main() {
       // recordingStore.flush() was awaited inside runSuite (no exception).
       await recordingStore.flush();
     });
+
+    test(
+      'only passed:null grader scores → trial status is not passed',
+      () async {
+        final suite = EvalSuite(
+          name: 's',
+          agentName: 'agent_x',
+          kind: SuiteKind.mixed,
+          tasks: [
+            _Task(
+              id: 'undecided',
+              input: {'outcome_value': 1},
+              graders: [_NullScoreGrader()],
+            ),
+          ],
+        );
+        final runner = EvalRunner(
+          environment: _StubEnvironment(),
+          harnessFactory: _StubHarnessFactory(),
+        );
+        final report = await runner.runSuite(
+          runName: 'null_scores_run',
+          suite: suite,
+          concurrency: 1,
+        );
+        final tr = report.trials.single;
+        expect(tr.scores, hasLength(1));
+        expect(tr.scores.single.passed, isNull);
+        expect(tr.allGradersPassed, isFalse);
+        expect(tr.trial.status, isNot(TrialStatus.passed));
+        expect(tr.trial.status, TrialStatus.failed);
+      },
+    );
 
     test('per-task timeout marks the trial timedOut', () async {
       final suite = EvalSuite(

--- a/test/eval/trial_test.dart
+++ b/test/eval/trial_test.dart
@@ -1,7 +1,56 @@
 import 'package:dart_agent_core/eval.dart';
 import 'package:test/test.dart';
 
+import '_helpers.dart';
+
 void main() {
+  group('TrialResult.allGradersPassed', () {
+    test('only passed:null scores → false (no grader decided)', () {
+      final result = TrialResult(
+        trial: makeTrial(
+          runName: 'r',
+          suiteName: 's',
+          taskId: 't',
+          status: TrialStatus.passed,
+        ),
+        transcript: emptyTranscript(),
+        outcome: const Outcome(environmentState: {}),
+        scores: [nullScore('judge'), nullScore('human')],
+      );
+      expect(result.allGradersPassed, isFalse);
+    });
+
+    test('empty scores → false', () {
+      final result = TrialResult(
+        trial: makeTrial(
+          runName: 'r',
+          suiteName: 's',
+          taskId: 't',
+          status: TrialStatus.passed,
+        ),
+        transcript: emptyTranscript(),
+        outcome: const Outcome(environmentState: {}),
+        scores: const [],
+      );
+      expect(result.allGradersPassed, isFalse);
+    });
+
+    test('null scores ignored when at least one grader decided pass', () {
+      final result = TrialResult(
+        trial: makeTrial(
+          runName: 'r',
+          suiteName: 's',
+          taskId: 't',
+          status: TrialStatus.passed,
+        ),
+        transcript: emptyTranscript(),
+        outcome: const Outcome(environmentState: {}),
+        scores: [okScore('code'), nullScore('judge')],
+      );
+      expect(result.allGradersPassed, isTrue);
+    });
+  });
+
   group('Trial.cacheSalt', () {
     Trial t({
       String runName = 'r',


### PR DESCRIPTION
## Summary
- Align `EvalRunner` trial status with `TrialResult.allGradersPassed` when every grader returns `passed: null` (or there are no scores).
- Extract shared `TrialResult.scoresIndicatePass` so empty/undecided score lists no longer leave `TrialStatus.passed` via `Iterable.every` on an empty filter.
- Add unit and runner tests covering only-null scores → status not passed.

## Test plan
- [x] `dart test test/eval/runner_e2e_test.dart -n "only passed:null"` (failed before fix; passes after)
- [x] `dart test test/eval/trial_test.dart`
- [x] `dart test test/eval/runner_e2e_test.dart test/eval/suite_and_report_test.dart test/eval/trial_test.dart`
- [x] `dart analyze .`
- [ ] Manual: none