### PR TITLE
fix: do not count errored/timed-out eval trials as metric passes

### DIFF
--- a/lib/src/eval/core/eval_runner.dart
+++ b/lib/src/eval/core/eval_runner.dart
@@ -291,37 +291,42 @@ extension on EvalRunner {
         );
     outcome ??= const Outcome(environmentState: {});
 
-    // Run graders. Each grader returns a Score; runner does not enforce
-    // pass/fail above the grader's own threshold.
+    // Run graders only for completed trials. Timeout/error leave placeholder
+    // outcomes that can spuriously pass weak graders; those must not count as
+    // metric passes (see TrialResult.allGradersPassed).
     final scores = <Score>[];
-    for (final grader in task.graders) {
-      try {
-        final score = await grader.grade(
-          trial: trial,
-          transcript: effectiveTranscript,
-          outcome: outcome,
-          context: context,
-          referenceSolution: task.referenceSolution,
-        );
-        scores.add(score);
-      } catch (e, st) {
-        _logger.warning('grader ${grader.name} threw', e, st);
-        scores.add(
-          Score(
-            graderName: grader.name,
-            value: null,
-            passed: null,
-            rationale: 'grader exception: $e',
-          ),
-        );
+    final shouldGrade =
+        status == TrialStatus.passed || status == TrialStatus.failed;
+    if (shouldGrade) {
+      for (final grader in task.graders) {
+        try {
+          final score = await grader.grade(
+            trial: trial,
+            transcript: effectiveTranscript,
+            outcome: outcome,
+            context: context,
+            referenceSolution: task.referenceSolution,
+          );
+          scores.add(score);
+        } catch (e, st) {
+          _logger.warning('grader ${grader.name} threw', e, st);
+          scores.add(
+            Score(
+              graderName: grader.name,
+              value: null,
+              passed: null,
+              rationale: 'grader exception: $e',
+            ),
+          );
+        }
       }
-    }
 
-    // Final trial status reflects graders.
-    final passed = scores
-        .where((s) => s.passed != null)
-        .every((s) => s.passed == true);
-    if (status == TrialStatus.passed && !passed) status = TrialStatus.failed;
+      // Final trial status reflects graders.
+      final passed = scores
+          .where((s) => s.passed != null)
+          .every((s) => s.passed == true);
+      if (status == TrialStatus.passed && !passed) status = TrialStatus.failed;
+    }
 
     trial = Trial(
       runName: trial.runName,

--- a/lib/src/eval/core/trial_result.dart
+++ b/lib/src/eval/core/trial_result.dart
@@ -17,9 +17,23 @@ class TrialResult {
     required this.scores,
   });
 
-  /// True if every score (excluding null-valued ones) reports passed=true.
+  /// True when this trial counts as a metric pass: execution completed
+  /// ([TrialStatus.passed] or [TrialStatus.failed]) and every non-null score
+  /// reports passed=true.
+  ///
+  /// [TrialStatus.errored], [TrialStatus.timedOut], and [TrialStatus.skipped]
+  /// never count as passes, even if graders would accept a placeholder outcome.
   /// Null-valued scores (e.g. judge returned Unknown) are ignored.
   bool get allGradersPassed {
+    switch (trial.status) {
+      case TrialStatus.errored:
+      case TrialStatus.timedOut:
+      case TrialStatus.skipped:
+        return false;
+      case TrialStatus.passed:
+      case TrialStatus.failed:
+        break;
+    }
     final passing = scores.where((s) => s.passed != null);
     if (passing.isEmpty) return false;
     return passing.every((s) => s.passed == true);

--- a/test/eval/runner_e2e_test.dart
+++ b/test/eval/runner_e2e_test.dart
@@ -245,14 +245,14 @@ void main() {
       // Trials = 2 + 1 + 1 = 4. Two pos pass, one neg fails, one errored.
       expect(report.trials, hasLength(4));
 
-      // pos: 2 pass; neg: 0; errored: 0 (because trial.status=errored has
-      // no scores from harness — but graders still run, and check value==null
-      // which IS true after error → so errored task actually passes its grader.
-      // Verify by direct inspection:
+      // pos: 2 pass; neg: 0; errored must not count as a metric pass even if a
+      // grader would accept the placeholder empty outcome.
       final byTask = report.trialsByTask();
       expect(byTask['pos']!.every((t) => t.allGradersPassed), isTrue);
       expect(byTask['neg']!.every((t) => t.allGradersPassed), isFalse);
       expect(byTask['errored']!.first.trial.status, TrialStatus.errored);
+      expect(byTask['errored']!.first.allGradersPassed, isFalse);
+      expect(report.trialPassRate, 0.5); // 2 of 4
 
       // Composite exporter delivered all phases to the recording exporter.
       expect(
@@ -314,6 +314,10 @@ void main() {
       );
       expect(report.trials.first.trial.status, TrialStatus.timedOut);
       expect(report.trials.first.trial.failureReason, contains('timed out'));
+      // Grader would pass on empty placeholder outcome (expected: null), but a
+      // timeout must not count as a metric pass.
+      expect(report.trials.first.allGradersPassed, isFalse);
+      expect(report.trialPassRate, 0.0);
     });
 
     test(

--- a/test/eval/suite_and_report_test.dart
+++ b/test/eval/suite_and_report_test.dart
@@ -169,6 +169,61 @@ void main() {
     });
 
     test(
+      'errored/timedOut trials with passing graders do not count as metric passes',
+      () {
+        final errored = makeTrialResult(
+          runName: 'r',
+          suiteName: 's',
+          taskId: 'a',
+          trialIndex: 0,
+          scores: [okScore('noop')],
+          status: TrialStatus.errored,
+        );
+        final timedOut = makeTrialResult(
+          runName: 'r',
+          suiteName: 's',
+          taskId: 'a',
+          trialIndex: 1,
+          scores: [okScore('noop')],
+          status: TrialStatus.timedOut,
+        );
+        final skipped = makeTrialResult(
+          runName: 'r',
+          suiteName: 's',
+          taskId: 'b',
+          trialIndex: 0,
+          scores: [okScore('noop')],
+          status: TrialStatus.skipped,
+        );
+        final passed = makeTrialResult(
+          runName: 'r',
+          suiteName: 's',
+          taskId: 'b',
+          trialIndex: 1,
+          scores: [okScore('noop')],
+        );
+
+        expect(errored.allGradersPassed, isFalse);
+        expect(timedOut.allGradersPassed, isFalse);
+        expect(skipped.allGradersPassed, isFalse);
+        expect(passed.allGradersPassed, isTrue);
+
+        final report = EvalRunReport(
+          runName: 'r',
+          suite: suiteOf(SuiteKind.mixed),
+          trials: [errored, timedOut, skipped, passed],
+          startedAt: DateTime(2025),
+          endedAt: DateTime(2025).add(const Duration(seconds: 1)),
+        );
+        expect(report.trialPassRate, 0.25);
+        // Task a: errored + timedOut → no metric passes.
+        expect(report.passAtKByTask(ks: const [1])['a']![1], 0.0);
+        // Task b: skipped + passed → pass@1 = 0.5.
+        expect(report.passAtKByTask(ks: const [1])['b']![1], 0.5);
+      },
+    );
+
+    test(
       'taskPassRate for capability suites: at least one trial passes per task',
       () {
         final report = EvalRunReport(


### PR DESCRIPTION
## Summary
- Gate `TrialResult.allGradersPassed` so `errored` / `timedOut` / `skipped` trials never count as metric passes, even when graders would accept placeholder outcomes.
- Skip graders in `EvalRunner` when a trial times out or errors, so reports, suite health, and diffs stop treating those trials as passes.
- Add regression coverage for timeout/error + would-pass graders.

## Test plan
- [x] `dart test test/eval/suite_and_report_test.dart -n "errored/timedOut"`
- [x] `dart test test/eval/runner_e2e_test.dart -n "per-task timeout|runSuite: trials"`
- [x] `dart test test/eval/`
- [x] `dart analyze` on touched files