### PR TITLE
fix: do not count empty/hook retries against maxTurns

### DIFF
--- a/lib/src/agent/stateful_agent.dart
+++ b/lib/src/agent/stateful_agent.dart
@@ -1001,7 +1001,8 @@ class StatefulAgent {
             error: cancelToken!.cancelError,
           );
         }
-        state.currentLoopCount++;
+        // totalLoopCount counts every LLM attempt; currentLoopCount only after
+        // a reply is committed past empty/hook retries (maxTurns budget).
         state.totalLoopCount++;
 
         final aggregation = _ModelMessageAccumulator();
@@ -1154,6 +1155,7 @@ class StatefulAgent {
         }
         fullMessage = afterModel.response!;
         currentRetryCount = 0;
+        state.currentLoopCount++;
 
         _logModelMessage(fullMessage, false);
         stopReason = fullMessage.stopReason ?? "unknown";

--- a/lib/src/agent/stateful_agent.dart
+++ b/lib/src/agent/stateful_agent.dart
@@ -1155,6 +1155,7 @@ class StatefulAgent {
         }
         fullMessage = afterModel.response!;
         currentRetryCount = 0;
+        // maxTurns uses currentLoopCount; empty/hook retries already returned.
         state.currentLoopCount++;
 
         _logModelMessage(fullMessage, false);

--- a/test/stateful_agent_loop_test.dart
+++ b/test/stateful_agent_loop_test.dart
@@ -92,6 +92,23 @@ void main() {
     },
   );
 
+  test('empty stopReason retry does not consume maxTurns budget', () async {
+    final client = _QueuedLLMClient([
+      ModelMessage(model: 'fake-model', textOutput: 'partial'),
+      _textReply('final'),
+    ]);
+    final agent = _agent(client: client, maxTurns: 2);
+
+    await agent.run([UserMessage.text('hello')], useStream: false);
+
+    expect(client.generateCalls, 2);
+    expect(
+      (agent.state.history.messages.whereType<ModelMessage>().last).textOutput,
+      'final',
+    );
+    expect(agent.state.currentLoopCount, 1);
+  });
+
   test('three empty stopReason retries throw loopDetection', () async {
     final client = _QueuedLLMClient([
       ModelMessage(model: 'fake-model', textOutput: 'a'),


### PR DESCRIPTION
## Summary
- Increment `currentLoopCount` only after a model reply is committed past empty-stopReason, empty-response, and `afterModelCall` retries
- Keep `totalLoopCount` counting every LLM attempt for loop-detection telemetry
- Add a regression test: `maxTurns: 2` + one empty stopReason then success → succeeds with `currentLoopCount == 1`

## Test plan
- [x] `dart test test/stateful_agent_loop_test.dart -n "empty stopReason retry does not consume maxTurns budget"` fails before fix (`currentLoopCount` was 2)
- [x] Same test passes after fix
- [x] `dart test test/stateful_agent_loop_test.dart`
- [x] `dart test test/agent_hooks_test.dart -n "afterModelCall can retry"`
- [x] `dart analyze .`
- [x] `dart test`