### PR TITLE
Align isSubAgent with sub_agent_mode for nested delegate_task gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,8 @@ Bridge channels can be extended by host apps via:
 
 Register sub-agents for specialized or parallelizable work. Each worker runs in its own isolated `AgentState`.
 
+Set `isSubAgent: true` on every worker factory. That flag (or session metadata `sub_agent_mode`) suppresses nested `delegate_task` so workers cannot re-delegate.
+
 ```dart
 final agent = StatefulAgent(
   ...

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -458,6 +458,8 @@ agent.registerJavaScriptBridgeChannel('local.greeting', (payload, context) {
 
 可注册专长子 Agent 来处理可并行或专业化任务。每个 Worker 都运行在隔离的 `AgentState` 中。
 
+每个 Worker factory 必须设置 `isSubAgent: true`。该标志（或会话元数据 `sub_agent_mode`）会抑制嵌套的 `delegate_task`，避免 Worker 再次委派。
+
 ```dart
 final agent = StatefulAgent(
   ...

--- a/doc/tools_and_planning.md
+++ b/doc/tools_and_planning.md
@@ -250,6 +250,8 @@ class CorePersonalitySkill extends Skill {
 
 Register `SubAgent`s to let the agent delegate tasks to specialized worker agents. Workers run in an isolated context (their own `AgentState`) and return their result as text.
 
+Set `isSubAgent: true` on every worker factory. That flag (or session metadata `sub_agent_mode`) suppresses nested `delegate_task` injection so workers cannot re-delegate.
+
 ```dart
 final researchSubAgent = SubAgent(
   name: 'researcher',

--- a/doc/tools_and_planning.zh-CN.md
+++ b/doc/tools_and_planning.zh-CN.md
@@ -249,6 +249,8 @@ class CorePersonalitySkill extends Skill {
 
 注册 `SubAgent` 后，Agent 可以把任务委派给专长 Worker。Worker 运行在隔离上下文（自己的 `AgentState`）中，并以文本返回结果。
 
+每个 Worker factory 必须设置 `isSubAgent: true`。该标志（或会话元数据 `sub_agent_mode`）会抑制嵌套的 `delegate_task` 注入，避免 Worker 再次委派。
+
 ```dart
 final researchSubAgent = SubAgent(
   name: 'researcher',

--- a/lib/src/agent/stateful_agent.dart
+++ b/lib/src/agent/stateful_agent.dart
@@ -542,7 +542,7 @@ class StatefulAgent {
     }
 
     //2. Sub Agents
-    if (!isSubAgentMode(state)) {
+    if (!isEffectivelySubAgent(this)) {
       if (!disableSubAgents) {
         final subAgentInstruction = buildSubAgentSystemPrompt(state, subAgents);
         if (subAgentInstruction != null) {
@@ -680,7 +680,7 @@ class StatefulAgent {
     }
 
     // 3. Inject sub agent tools
-    if (!isSubAgentMode(state)) {
+    if (!isEffectivelySubAgent(this)) {
       if (!disableSubAgents) {
         toolsCopy.addAll(subAgentTools);
       }

--- a/lib/src/agent/sub_agent.dart
+++ b/lib/src/agent/sub_agent.dart
@@ -88,6 +88,7 @@ Future<AgentToolResult> _delegateTask(
       hooks: parentAgent.hooks,
       controller: parentAgent.controller,
       isSubAgent: true,
+      disableSubAgents: true,
     );
   } else {
     try {
@@ -103,6 +104,12 @@ Future<AgentToolResult> _delegateTask(
           ),
         );
       }
+      // Keep isSubAgentMode(state) in sync with isSubAgent for named factories.
+      workerAgent.state.metadata['sub_agent_mode'] = true;
+      workerAgent.state.metadata.putIfAbsent(
+        'parent_session_id',
+        () => parentState.sessionId,
+      );
     } catch (e) {
       _subAgentLogger.warning(
         "[${parentAgent.name}] Sub-agent ($assignee) not found in registry",

--- a/lib/src/agent/util.dart
+++ b/lib/src/agent/util.dart
@@ -102,6 +102,12 @@ bool isSubAgentMode(AgentState state) {
   return state.metadata['sub_agent_mode'] ?? false;
 }
 
+/// True when this agent is a worker: constructor [StatefulAgent.isSubAgent]
+/// and/or session metadata `sub_agent_mode` (see [isSubAgentMode]).
+bool isEffectivelySubAgent(StatefulAgent agent) {
+  return agent.isSubAgent || isSubAgentMode(agent.state);
+}
+
 String generateEpisodeId(String type) {
   const chars =
       'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';

--- a/lib/src/agent/util.dart
+++ b/lib/src/agent/util.dart
@@ -104,6 +104,7 @@ bool isSubAgentMode(AgentState state) {
 
 /// True when this agent is a worker: constructor [StatefulAgent.isSubAgent]
 /// and/or session metadata `sub_agent_mode` (see [isSubAgentMode]).
+/// Named factories often set only the flag; doc-shaped clones set only metadata.
 bool isEffectivelySubAgent(StatefulAgent agent) {
   return agent.isSubAgent || isSubAgentMode(agent.state);
 }

--- a/test/sub_agent_test.dart
+++ b/test/sub_agent_test.dart
@@ -97,6 +97,75 @@ void main() {
     },
   );
 
+  test('doc-shaped factory with only isSubAgent omits delegate_task', () {
+    final worker = StatefulAgent(
+      name: 'researcher',
+      client: _QueuedLLMClient([]),
+      modelConfig: ModelConfig(model: 'fake-model'),
+      state: AgentState.empty(),
+      withGeneralPrinciples: false,
+      isSubAgent: true,
+    );
+
+    expect(
+      worker.composeTools().map((tool) => tool.name),
+      isNot(contains('delegate_task')),
+    );
+    expect(
+      worker.composeSystemMessage()?.content ?? '',
+      isNot(contains('delegate_task')),
+    );
+  });
+
+  test(
+    'named doc-shaped factory gets sub_agent_mode metadata on delegate',
+    () async {
+      final client = _QueuedLLMClient([
+        _toolCallReply('delegate_task', {
+          'assignee': 'researcher',
+          'task_description': 'Look it up.',
+        }),
+        _textReply('research done'),
+        _textReply('parent done'),
+      ]);
+      final parentState = AgentState.empty();
+      late StatefulAgent worker;
+      final agent = StatefulAgent(
+        name: 'manager',
+        client: client,
+        modelConfig: ModelConfig(model: 'fake-model'),
+        state: parentState,
+        withGeneralPrinciples: false,
+        subAgents: [
+          SubAgent(
+            name: 'researcher',
+            description: 'Researches',
+            agentFactory: (parent) {
+              worker = StatefulAgent(
+                name: 'researcher',
+                client: parent.client,
+                modelConfig: parent.modelConfig,
+                state: AgentState(sessionId: 'worker-doc'),
+                withGeneralPrinciples: false,
+                isSubAgent: true,
+              );
+              return worker;
+            },
+          ),
+        ],
+      );
+
+      await agent.run([UserMessage.text('delegate')], useStream: false);
+
+      expect(worker.state.metadata['sub_agent_mode'], isTrue);
+      expect(worker.state.metadata['parent_session_id'], parentState.sessionId);
+      expect(
+        worker.composeTools().map((tool) => tool.name),
+        isNot(contains('delegate_task')),
+      );
+    },
+  );
+
   test('named factory that forgets isSubAgent is rejected', () async {
     final client = _QueuedLLMClient([
       _toolCallReply('delegate_task', {


### PR DESCRIPTION
## Summary
- Gate `composeTools` / `composeSystemMessage` on `isSubAgent || sub_agent_mode` so doc-shaped worker factories (only `isSubAgent: true`) no longer expose nested `delegate_task`.
- In `delegate_task`, sync `sub_agent_mode` metadata for named workers and set `disableSubAgents` on clones; docs note the required `isSubAgent` contract.

## Test plan
- [x] Repro fail: doc-shaped factory still had `delegate_task` in `composeTools`
- [x] `dart test test/sub_agent_test.dart` (includes new doc-shaped + metadata sync cases)
- [x] `dart analyze .`
- [x] `dart test test/stateful_agent_loop_test.dart`